### PR TITLE
Np 44995 remove candidate from index

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/DeleteNviCandidateHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/DeleteNviCandidateHandler.java
@@ -1,0 +1,65 @@
+package no.sikt.nva.nvi.index;
+
+import static no.sikt.nva.nvi.index.aws.OpenSearchClient.defaultOpenSearchClient;
+import static nva.commons.core.attempt.Try.attempt;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import java.io.IOException;
+import no.sikt.nva.nvi.index.aws.SearchClient;
+import no.sikt.nva.nvi.index.model.DeleteNviCandidateMessageBody;
+import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
+import no.unit.nva.commons.json.JsonUtils;
+import nva.commons.core.JacocoGenerated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DeleteNviCandidateHandler implements RequestHandler<SQSEvent, Void> {
+
+    public static final String SUCCESSFULLY_REMOVED_MESSAGE = "Document with id has been removed from index: {}";
+    public static final String FAILED_TO_REMOVE_MESSAGE = "Failed to remove document from index: {}";
+    private static final Logger LOGGER = LoggerFactory.getLogger(DeleteNviCandidateHandler.class);
+    public final SearchClient<NviCandidateIndexDocument> openSearchClient;
+
+    @JacocoGenerated
+    public DeleteNviCandidateHandler() {
+        this(defaultOpenSearchClient());
+    }
+
+    public DeleteNviCandidateHandler(SearchClient<NviCandidateIndexDocument> indexingClient) {
+        this.openSearchClient = indexingClient;
+    }
+
+    @Override
+    public Void handleRequest(SQSEvent input, Context context) {
+        input.getRecords()
+            .stream()
+            .map(SQSMessage::getBody)
+            .map(DeleteNviCandidateHandler::parseBody)
+            .map(this::toIndexDocument)
+            .forEach(this::removeFromIndex);
+        return null;
+    }
+
+    private static DeleteNviCandidateMessageBody parseBody(String body) {
+        return attempt(() -> JsonUtils.dtoObjectMapper.readValue(body, DeleteNviCandidateMessageBody.class))
+                   .orElseThrow();
+    }
+
+    private void removeFromIndex(NviCandidateIndexDocument document) {
+        try {
+            openSearchClient.removeDocumentFromIndex(document);
+            LOGGER.info(SUCCESSFULLY_REMOVED_MESSAGE, document.identifier());
+        } catch (IOException e) {
+            LOGGER.info(FAILED_TO_REMOVE_MESSAGE, document.identifier());
+            throw new RuntimeException(e);
+        }
+    }
+
+    private NviCandidateIndexDocument toIndexDocument(DeleteNviCandidateMessageBody message) {
+        return new NviCandidateIndexDocument.Builder()
+                   .withIdentifier(message.publicationIdentifier())
+                   .build();
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandler.java
@@ -37,7 +37,7 @@ public class SearchNviCandidatesHandler extends ApiGatewayHandler<Void, SearchRe
         try {
             var openSearchResponse = openSearchSearchSearchClient.search(query);
             return SearchResponseDto.fromSearchResponse(openSearchResponse);
-        } catch (IOException e) {
+        } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -21,6 +21,7 @@ import org.opensearch.client.RestClient;
 import org.opensearch.client.json.jackson.JacksonJsonpMapper;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.DeleteRequest;
 import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
@@ -70,6 +71,12 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
         attempt(() -> client.index(constructIndexRequest(indexDocument))).orElseThrow();
     }
 
+    @Override
+    public void removeDocumentFromIndex(NviCandidateIndexDocument indexDocument) throws IOException {
+        client.delete(contructDeleteRequest(indexDocument));
+    }
+
+    @Override
     public SearchResponse<NviCandidateIndexDocument> search(Query query) throws IOException {
         return client.search(constructSearchRequest(query), NviCandidateIndexDocument.class);
     }
@@ -77,6 +84,13 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
     @Override
     public void deleteIndex() throws IOException {
         client.indices().delete(new DeleteIndexRequest.Builder().index(NVI_CANDIDATES_INDEX).build());
+    }
+
+    private static DeleteRequest contructDeleteRequest(NviCandidateIndexDocument indexDocument) {
+        return new DeleteRequest.Builder()
+                   .index(NVI_CANDIDATES_INDEX)
+                   .id(indexDocument.identifier())
+                   .build();
     }
 
     private static IndexRequest<NviCandidateIndexDocument> constructIndexRequest(
@@ -87,7 +101,6 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
                    .build();
     }
 
-    @JacocoGenerated
     private static CognitoCredentials createCognitoCredentials(SecretsReader secretsReader) {
         var credentials = secretsReader.fetchClassSecret(SEARCH_INFRASTRUCTURE_CREDENTIALS,
                                                          UsernamePasswordWrapper.class);

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/SearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/SearchClient.java
@@ -1,15 +1,16 @@
 package no.sikt.nva.nvi.index.aws;
 
 import java.io.IOException;
-import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch.core.SearchResponse;
 
 public interface SearchClient<T> {
 
-
     void addDocumentToIndex(T indexDocument);
-    SearchResponse<T> search(Query query) throws IOException;
-    void deleteIndex() throws IOException;
 
+    void removeDocumentFromIndex(T indexDocument) throws IOException;
+
+    SearchResponse<T> search(Query query) throws IOException;
+
+    void deleteIndex() throws IOException;
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/DeleteNviCandidateMessageBody.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/DeleteNviCandidateMessageBody.java
@@ -1,0 +1,11 @@
+package no.sikt.nva.nvi.index.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
+@JsonSerialize
+public record DeleteNviCandidateMessageBody(String publicationIdentifier) {
+
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URI;
 import java.util.List;
+import nva.commons.core.JacocoGenerated;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
@@ -16,4 +17,50 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         List<Affiliation> affiliations) {
 
     private static final String CONTEXT = "@context";
+
+
+    @JacocoGenerated
+    public static class Builder {
+
+        private URI context;
+        private String identifier;
+        private String year;
+        private String type;
+        private PublicationDetails publicationDetails;
+        private List<Affiliation> affiliations;
+
+        public Builder withContext(URI context) {
+            this.context = context;
+            return this;
+        }
+
+        public Builder withIdentifier(String identifier) {
+            this.identifier = identifier;
+            return this;
+        }
+
+        public Builder withYear(String year) {
+            this.year = year;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withPublicationDetails(PublicationDetails publicationDetails) {
+            this.publicationDetails = publicationDetails;
+            return this;
+        }
+
+        public Builder withAffiliations(List<Affiliation> affiliations) {
+            this.affiliations = affiliations;
+            return this;
+        }
+
+        public NviCandidateIndexDocument build() {
+            return new NviCandidateIndexDocument(context, identifier, year, type, publicationDetails, affiliations);
+        }
+    }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/DeleteNviCandidateHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/DeleteNviCandidateHandlerTest.java
@@ -1,0 +1,62 @@
+package no.sikt.nva.nvi.index;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.util.List;
+import no.sikt.nva.nvi.index.aws.OpenSearchClient;
+import no.sikt.nva.nvi.index.model.DeleteNviCandidateMessageBody;
+import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
+import no.unit.nva.commons.json.JsonUtils;
+import nva.commons.logutils.LogUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class DeleteNviCandidateHandlerTest {
+
+    public static final String REMOVED_MESSAGE = "Document with id has been removed from index:";
+
+    @Test
+    void shouldDeleteDocumentFromIndex() throws JsonProcessingException {
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+        var handler = new DeleteNviCandidateHandler(new FakeSearchClient());
+        var document = randomDocument();
+        handler.handleRequest(createEvent(document), mock(Context.class));
+        assertThat(appender.getMessages(), containsString(REMOVED_MESSAGE));
+    }
+
+    @Test
+    void shouldThrowExceptionAndLogWhenDocumentDeletionFails() throws IOException {
+        var openSearchClient = mock(OpenSearchClient.class);
+        var document = randomDocument();
+        Mockito.doThrow(new IOException()).when(openSearchClient).removeDocumentFromIndex(document);
+        var handler = new DeleteNviCandidateHandler(openSearchClient);
+        assertThrows(RuntimeException.class, () -> handler.handleRequest(createEvent(document), mock(Context.class)));
+    }
+
+    private static SQSEvent createEvent(NviCandidateIndexDocument document) throws JsonProcessingException {
+        var sqsEvent = new SQSEvent();
+        var message = new SQSMessage();
+        var body = constructBody(document);
+        message.setBody(body);
+        sqsEvent.setRecords(List.of(message));
+        return sqsEvent;
+    }
+
+    private static String constructBody(NviCandidateIndexDocument document) throws JsonProcessingException {
+        return JsonUtils.dtoObjectMapper.writeValueAsString(new DeleteNviCandidateMessageBody(document.identifier()));
+    }
+
+    private NviCandidateIndexDocument randomDocument() {
+        return new NviCandidateIndexDocument.Builder()
+                   .withIdentifier(randomString())
+                   .build();
+    }
+}

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/FakeSearchClient.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/FakeSearchClient.java
@@ -24,6 +24,11 @@ public class FakeSearchClient implements SearchClient<NviCandidateIndexDocument>
     }
 
     @Override
+    public void removeDocumentFromIndex(NviCandidateIndexDocument indexDocument) throws IOException {
+
+    }
+
+    @Override
     public SearchResponse<NviCandidateIndexDocument> search(Query query) throws IOException {
         return null;
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -50,31 +50,44 @@ public class OpenSearchClientTest {
 
     @Test
     void shouldCreateIndexAndAddDocumentToIndexWhenIndexDoesNotExist() throws IOException, InterruptedException {
-        var indexDocument = singleNviCandidateIndexDocument();
-        openSearchClient.addDocumentToIndex(indexDocument);
+        var document = singleNviCandidateIndexDocument();
+        openSearchClient.addDocumentToIndex(document);
         Thread.sleep(2000);
-        var searchResponse = openSearchClient.search(searchTermToQuery(indexDocument.identifier()));
+        var searchResponse =
+            openSearchClient.search(searchTermToQuery(document.identifier()));
         var nviCandidateIndexDocument = searchResponseToIndexDocumentList(searchResponse);
-        assertThat(nviCandidateIndexDocument, containsInAnyOrder(indexDocument));
+        assertThat(nviCandidateIndexDocument, containsInAnyOrder(document));
     }
 
     @Test
     void shouldReturnUniqueDocumentFromIndexWhenSearchingByDocumentIdentifier()
         throws InterruptedException, IOException {
-        var indexDocument = singleNviCandidateIndexDocument();
-        addDocumentsToIndex(singleNviCandidateIndexDocument(), singleNviCandidateIndexDocument(), indexDocument);
-        var searchResponse = openSearchClient.search(searchTermToQuery(indexDocument.identifier()));
+        var document = singleNviCandidateIndexDocument();
+        addDocumentsToIndex(singleNviCandidateIndexDocument(), singleNviCandidateIndexDocument(), document);
+        var searchResponse =
+            openSearchClient.search(searchTermToQuery(document.identifier()));
         var nviCandidateIndexDocument = searchResponseToIndexDocumentList(searchResponse);
         assertThat(nviCandidateIndexDocument, hasSize(1));
     }
 
     @Test
     void shouldDeleteIndexAndThrowExceptionWhenSearchingInNonExistentIndex() throws IOException, InterruptedException {
-        var indexDocument = singleNviCandidateIndexDocument();
-        addDocumentsToIndex(indexDocument);
+        var document = singleNviCandidateIndexDocument();
+        addDocumentsToIndex(document);
         openSearchClient.deleteIndex();
         assertThrows(OpenSearchException.class,
-                     () -> openSearchClient.search(searchTermToQuery(indexDocument.identifier())));
+                     () -> openSearchClient.search(searchTermToQuery(document.identifier())));
+    }
+
+    @Test
+    void shouldRemoveDocumentFromIndex() throws InterruptedException, IOException {
+        var document = singleNviCandidateIndexDocument();
+        addDocumentsToIndex(document);
+        openSearchClient.removeDocumentFromIndex(document);
+        Thread.sleep(2000);
+        var searchResponse = openSearchClient.search(searchTermToQuery(document.identifier()));
+        var nviCandidateIndexDocument = searchResponseToIndexDocumentList(searchResponse);
+        assertThat(nviCandidateIndexDocument, hasSize(0));
     }
 
     @NotNull

--- a/template.yaml
+++ b/template.yaml
@@ -21,10 +21,6 @@ Globals:
       AllowOrigin: "'*'"
 
 Parameters:
-  CognitoAuthorizerArn:
-    Type: 'AWS::SSM::Parameter::Value<String>'
-    Description: Reference to Cognito UserPool for the stage
-    Default: CognitoAuthorizerArn
   CognitoAuthorizationUri:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Default: '/NVA/CognitoUri'
@@ -227,11 +223,26 @@ Resources:
       Environment:
         Variables:
           EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
+          SEARCH_INFRASTRUCTURE_API_HOST: !Ref SearchInfrastructureApiHost
+          SEARCH_INFRASTRUCTURE_AUTH_URI: !Ref SearchInfrastructureAuthUri
       Events:
         SqsEvent:
           Type: SQS
           Properties:
             Queue: !GetAtt NewCandidateQueue.Arn
+
+  DeleteNviCandidateHandler:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: index-handlers
+      Handler: no.sikt.nva.nvi.index.DeleteNviCandidateHandler::handleRequest
+      Timeout: 30
+      MemorySize: 1536
+      Role: !GetAtt NvaNviRole.Arn
+      Environment:
+        Variables:
+          SEARCH_INFRASTRUCTURE_API_HOST: !Ref SearchInfrastructureApiHost
+          SEARCH_INFRASTRUCTURE_AUTH_URI: !Ref SearchInfrastructureAuthUri
 
   SearchNviCandidatesHandler:
     Type: AWS::Serverless::Function
@@ -256,7 +267,7 @@ Resources:
             Method: get
             RestApiId: !Ref ScientificIndexApi
 
-  DeleteImportCandidateIndexHandler:
+  DeleteNviCandidateIndexHandler:
     Type: AWS::Serverless::Function
     Properties:
       Description: Lambda that deletes scientific index. Needs to be run manually from Test
@@ -267,5 +278,3 @@ Resources:
         Variables:
           SEARCH_INFRASTRUCTURE_API_HOST: !Ref SearchInfrastructureApiHost
           SEARCH_INFRASTRUCTURE_AUTH_URI: !Ref SearchInfrastructureAuthUri
-          ALLOWED_ORIGIN: '*'
-          API_HOST: !Ref ApiDomain

--- a/template.yaml
+++ b/template.yaml
@@ -227,8 +227,6 @@ Resources:
       Environment:
         Variables:
           EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
-          SEARCH_INFRASTRUCTURE_API_HOST: !Ref SearchInfrastructureApiHost
-          SEARCH_INFRASTRUCTURE_AUTH_URI: !Ref SearchInfrastructureAuthUri
       Events:
         SqsEvent:
           Type: SQS
@@ -243,10 +241,6 @@ Resources:
       Timeout: 30
       MemorySize: 1536
       Role: !GetAtt NvaNviRole.Arn
-      Environment:
-        Variables:
-          SEARCH_INFRASTRUCTURE_API_HOST: !Ref SearchInfrastructureApiHost
-          SEARCH_INFRASTRUCTURE_AUTH_URI: !Ref SearchInfrastructureAuthUri
 
   SearchNviCandidatesHandler:
     Type: AWS::Serverless::Function
@@ -259,8 +253,6 @@ Resources:
       AutoPublishAlias: live
       Environment:
         Variables:
-          SEARCH_INFRASTRUCTURE_API_HOST: !Ref SearchInfrastructureApiHost
-          SEARCH_INFRASTRUCTURE_AUTH_URI: !Ref SearchInfrastructureAuthUri
           ALLOWED_ORIGIN: '*'
           API_HOST: !Ref ApiDomain
       Events:
@@ -278,7 +270,3 @@ Resources:
       CodeUri: index-handlers
       Handler: no.sikt.nva.nvi.index.DeleteNviIndexHandler::handleRequest
       Role: !GetAtt NvaNviRole.Arn
-      Environment:
-        Variables:
-          SEARCH_INFRASTRUCTURE_API_HOST: !Ref SearchInfrastructureApiHost
-          SEARCH_INFRASTRUCTURE_AUTH_URI: !Ref SearchInfrastructureAuthUri

--- a/template.yaml
+++ b/template.yaml
@@ -21,6 +21,10 @@ Globals:
       AllowOrigin: "'*'"
 
 Parameters:
+  CognitoAuthorizerArn:
+    Type: 'AWS::SSM::Parameter::Value<String>'
+    Description: Reference to Cognito UserPool for the stage
+    Default: CognitoAuthorizerArn
   CognitoAuthorizationUri:
     Type: 'AWS::SSM::Parameter::Value<String>'
     Default: '/NVA/CognitoUri'


### PR DESCRIPTION
Could be great to remove @JacocGenerated from OpenSearchClient, but for now it is not possible to test indexExists() method when throwing exception. 

I have also removed unused environment variables in template.

One more thing, it seems like OpenSearch is smart enough and does not create new document when document with matching id already exists. Which means we do not need to update(or delete and put new one) nvi candidate in index when update event from expansion comes.