### PR TITLE
Np 45083 upsert nvi candidate handler validation

### DIFF
--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -4,16 +4,27 @@ plugins {
 
 dependencies {
     implementation project(':nvi-commons')
-    implementation libs.nva.commons.apigateway
-    implementation libs.nva.commons.core
     implementation libs.nva.json
-    testImplementation libs.nva.testutils
+    implementation libs.nva.core
+    implementation libs.nva.commons.secrets
+    implementation libs.nva.commons.auth
+    implementation libs.nva.commons.apigateway
+    implementation libs.nva.s3
 
     implementation libs.aws.lambda.java.core
-    implementation libs.aws.java.sdk.core
     implementation libs.aws.lambda.events
+    implementation libs.aws.java.sdk.core
     implementation libs.aws.sdk2.s3
     implementation libs.aws.sdk2.sqs
+    implementation libs.aws.sdk2.apache.client
+    implementation libs.aws.sdk2.regions
+
+    implementation libs.jackson.core
+    implementation libs.jackson.databind
+
+    testImplementation "org.testcontainers:testcontainers:1.18.3"
+    testImplementation 'org.testcontainers:junit-jupiter:1.18.3'
+
 
     implementation libs.bundles.logging
 }

--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -6,25 +6,13 @@ dependencies {
     implementation project(':nvi-commons')
     implementation libs.nva.json
     implementation libs.nva.core
-    implementation libs.nva.commons.secrets
-    implementation libs.nva.commons.auth
-    implementation libs.nva.commons.apigateway
-    implementation libs.nva.s3
 
     implementation libs.aws.lambda.java.core
     implementation libs.aws.lambda.events
-    implementation libs.aws.java.sdk.core
-    implementation libs.aws.sdk2.s3
     implementation libs.aws.sdk2.sqs
-    implementation libs.aws.sdk2.apache.client
-    implementation libs.aws.sdk2.regions
 
     implementation libs.jackson.core
     implementation libs.jackson.databind
-
-    testImplementation "org.testcontainers:testcontainers:1.18.3"
-    testImplementation 'org.testcontainers:junit-jupiter:1.18.3'
-
 
     implementation libs.bundles.logging
 }

--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id 'nva.nvi.java-conventions'
+}
+
+dependencies {
+    implementation project(':nvi-commons')
+    implementation libs.nva.commons.apigateway
+    implementation libs.nva.commons.core
+    implementation libs.nva.json
+    testImplementation libs.nva.testutils
+
+    implementation libs.aws.lambda.java.core
+    implementation libs.aws.java.sdk.core
+    implementation libs.aws.lambda.events
+    implementation libs.aws.sdk2.s3
+    implementation libs.aws.sdk2.sqs
+
+    implementation libs.bundles.logging
+}

--- a/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
+++ b/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
@@ -16,8 +16,6 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UpsertNviCandidateHandler.class);
 
-    private static final String ERROR_MESSAGE_BODY_INVALID = "Message body invalid";
-
     @Override
     public Void handleRequest(SQSEvent input, Context context) {
         input.getRecords()
@@ -54,6 +52,6 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
     }
 
     private void logInvalidMessageBody(String body) {
-        LOGGER.error(ERROR_MESSAGE_BODY_INVALID, body);
+        LOGGER.error("Message body invalid: {}", body);
     }
 }

--- a/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
+++ b/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
@@ -24,6 +24,7 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
             .map(this::parseBody)
             .filter(Objects::nonNull)
             .map(this::validate)
+            .filter(Objects::nonNull)
             .forEach(this::upsertNviCandidate);
 
         return null;
@@ -31,6 +32,7 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
 
     private void upsertNviCandidate(UpsertRequest request) {
         //TODO: implement
+        LOGGER.info(request.publicationBucketUri());
     }
 
     private UpsertRequest parseBody(String body) {

--- a/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
+++ b/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
@@ -8,6 +8,7 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,6 +32,7 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
     }
 
     private void upsertNviCandidate(UpsertRequest request) {
+        //TODO: implement
     }
 
     private UpsertRequest parseBody(String body) {
@@ -41,6 +43,8 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
                    });
     }
 
+    //TODO: Remove jacocoGenerated when "happy cases" are implemented
+    @JacocoGenerated
     private UpsertRequest validate(UpsertRequest request) {
         if (isNull(request.publicationBucketUri())) {
             logInvalidMessageBody(request.toString());

--- a/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
+++ b/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
@@ -1,0 +1,55 @@
+package handlers;
+
+import static java.util.Objects.isNull;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(UpsertNviCandidateHandler.class);
+
+    private static final String ERROR_MESSAGE_BODY_INVALID = "Message body invalid";
+
+    @Override
+    public Void handleRequest(SQSEvent input, Context context) {
+        input.getRecords()
+            .stream()
+            .map(SQSMessage::getBody)
+            .map(this::parseBody)
+            .filter(Objects::nonNull)
+            .map(this::validate)
+            .forEach(this::upsertNviCandidate);
+
+        return null;
+    }
+
+    private void upsertNviCandidate(UpsertRequest request) {
+    }
+
+    private UpsertRequest parseBody(String body) {
+        return attempt(() -> dtoObjectMapper.readValue(body, UpsertRequest.class))
+                   .orElse(failure -> {
+                       logInvalidMessageBody(body);
+                       return null;
+                   });
+    }
+
+    private UpsertRequest validate(UpsertRequest request) {
+        if (isNull(request.publicationBucketUri())) {
+            logInvalidMessageBody(request.toString());
+            return null;
+        }
+        return request;
+    }
+
+    private void logInvalidMessageBody(String body) {
+        LOGGER.error(ERROR_MESSAGE_BODY_INVALID, body);
+    }
+}

--- a/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
+++ b/event-handlers/src/main/java/handlers/UpsertNviCandidateHandler.java
@@ -30,6 +30,8 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
         return null;
     }
 
+    //TODO: Remove jacocoGenerated when implemented
+    @JacocoGenerated
     private void upsertNviCandidate(UpsertRequest request) {
         //TODO: implement
         LOGGER.info(request.publicationBucketUri());

--- a/event-handlers/src/main/java/handlers/UpsertRequest.java
+++ b/event-handlers/src/main/java/handlers/UpsertRequest.java
@@ -1,0 +1,13 @@
+package handlers;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+
+@JsonSerialize
+public record UpsertRequest(@JsonProperty(PUBLICATION_BUCKET_URI) String publicationBucketUri,
+                            @JsonProperty(APPROVAL_AFFILIATIONS) List<String> affiliationApprovals) {
+
+    private static final String PUBLICATION_BUCKET_URI = "publicationBucketUri";
+    private static final String APPROVAL_AFFILIATIONS = "approvalAffiliations";
+}

--- a/event-handlers/src/main/java/handlers/UpsertRequest.java
+++ b/event-handlers/src/main/java/handlers/UpsertRequest.java
@@ -3,8 +3,11 @@ package handlers;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import nva.commons.core.JacocoGenerated;
 
+//TODO: Remove jacocoGenerated when rest of the tests cases are implemented
 @JsonSerialize
+@JacocoGenerated
 public record UpsertRequest(@JsonProperty(PUBLICATION_BUCKET_URI) String publicationBucketUri,
                             @JsonProperty(APPROVAL_AFFILIATIONS) List<String> affiliationApprovals) {
 

--- a/event-handlers/src/test/java/handlers/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/handlers/UpsertNviCandidateHandlerTest.java
@@ -11,13 +11,11 @@ import static org.mockito.Mockito.mock;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
-import java.io.ByteArrayOutputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import nva.commons.logutils.LogUtils;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class UpsertNviCandidateHandlerTest {
@@ -26,14 +24,7 @@ public class UpsertNviCandidateHandlerTest {
     public static final String ERROR_MESSAGE_BODY_INVALID = "Message body invalid";
     public static final String PUBLICATION_ID_FIELD = "publicationBucketUri";
     public static final String AFFILIATION_APPROVALS_FIELD = "approvalAffiliations";
-    private ByteArrayOutputStream outputStream;
-    private UpsertNviCandidateHandler handler;
-
-    @BeforeEach
-    void setUp() {
-        outputStream = new ByteArrayOutputStream();
-        handler = new UpsertNviCandidateHandler();
-    }
+    private final UpsertNviCandidateHandler handler = new UpsertNviCandidateHandler();
 
     @Test
     void shouldLogErrorWhenMessageBodyInvalid() {

--- a/event-handlers/src/test/java/handlers/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/handlers/UpsertNviCandidateHandlerTest.java
@@ -1,0 +1,95 @@
+package handlers;
+
+import static java.util.Map.entry;
+import static java.util.Objects.nonNull;
+import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.mockito.Mockito.mock;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import java.io.ByteArrayOutputStream;
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import nva.commons.logutils.LogUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class UpsertNviCandidateHandlerTest {
+
+    public static final Context CONTEXT = mock(Context.class);
+    public static final String ERROR_MESSAGE_BODY_INVALID = "Message body invalid";
+    public static final String PUBLICATION_ID_FIELD = "publicationBucketUri";
+    public static final String AFFILIATION_APPROVALS_FIELD = "approvalAffiliations";
+    private ByteArrayOutputStream outputStream;
+    private UpsertNviCandidateHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        outputStream = new ByteArrayOutputStream();
+        handler = new UpsertNviCandidateHandler();
+    }
+
+    @Test
+    void shouldLogErrorWhenMessageBodyInvalid() {
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+        var sqsEvent = createEventWithInvalidBody();
+
+        handler.handleRequest(sqsEvent, CONTEXT);
+        assertThat(appender.getMessages(), containsString(ERROR_MESSAGE_BODY_INVALID));
+    }
+
+    @Test
+    void shouldLogErrorWhenMessageBodypublicationBucketUriNull() {
+        var appender = LogUtils.getTestingAppenderForRootLogger();
+        var sqsEvent = createEventWithMessageBody(null, Collections.emptyList());
+
+        handler.handleRequest(sqsEvent, CONTEXT);
+
+        assertThat(appender.getMessages(), containsString(ERROR_MESSAGE_BODY_INVALID));
+    }
+
+    private static String constructBody(List<String> affiliationApprovals) {
+        return attempt(
+            () -> objectMapper.writeValueAsString(
+                Map.ofEntries(
+                    entry(AFFILIATION_APPROVALS_FIELD,
+                          affiliationApprovals
+                    )))).orElseThrow();
+    }
+
+    private static SQSEvent createEventWithMessageBody(URI publicationBucketUri, List<String> affiliationApprovals) {
+        var sqsEvent = new SQSEvent();
+        var message = new SQSMessage();
+        var body = nonNull(publicationBucketUri)
+                       ? constructBody(publicationBucketUri.toString(), affiliationApprovals)
+                       : constructBody(affiliationApprovals);
+        message.setBody(body);
+        sqsEvent.setRecords(List.of(message));
+        return sqsEvent;
+    }
+
+    private static String constructBody(String publicationId,
+                                        List<String> affiliationApprovals) {
+        return attempt(
+            () -> objectMapper.writeValueAsString(
+                Map.ofEntries(
+                    entry(PUBLICATION_ID_FIELD, publicationId),
+                    entry(AFFILIATION_APPROVALS_FIELD,
+                          affiliationApprovals
+                    )))).orElseThrow();
+    }
+
+    private static SQSEvent createEventWithInvalidBody() {
+        var sqsEvent = new SQSEvent();
+        var invalidSqsMessage = new SQSMessage();
+        invalidSqsMessage.setBody(randomString());
+        sqsEvent.setRecords(List.of(invalidSqsMessage));
+        return sqsEvent;
+    }
+}

--- a/event-handlers/src/test/java/handlers/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/handlers/UpsertNviCandidateHandlerTest.java
@@ -54,15 +54,6 @@ public class UpsertNviCandidateHandlerTest {
         assertThat(appender.getMessages(), containsString(ERROR_MESSAGE_BODY_INVALID));
     }
 
-    private static String constructBody(List<String> affiliationApprovals) {
-        return attempt(
-            () -> objectMapper.writeValueAsString(
-                Map.ofEntries(
-                    entry(AFFILIATION_APPROVALS_FIELD,
-                          affiliationApprovals
-                    )))).orElseThrow();
-    }
-
     private static SQSEvent createEventWithMessageBody(URI publicationBucketUri, List<String> affiliationApprovals) {
         var sqsEvent = new SQSEvent();
         var message = new SQSMessage();
@@ -74,8 +65,16 @@ public class UpsertNviCandidateHandlerTest {
         return sqsEvent;
     }
 
-    private static String constructBody(String publicationId,
-                                        List<String> affiliationApprovals) {
+    private static String constructBody(List<String> affiliationApprovals) {
+        return attempt(
+            () -> objectMapper.writeValueAsString(
+                Map.ofEntries(
+                    entry(AFFILIATION_APPROVALS_FIELD,
+                          affiliationApprovals
+                    )))).orElseThrow();
+    }
+
+    private static String constructBody(String publicationId, List<String> affiliationApprovals) {
         return attempt(
             () -> objectMapper.writeValueAsString(
                 Map.ofEntries(

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,5 @@ include 'nvi-rest'
 include 'nvi-commons'
 include 'nvi-evaluator'
 include 'index-handlers'
+include 'event-handlers'
 

--- a/template.yaml
+++ b/template.yaml
@@ -233,6 +233,20 @@ Resources:
           Properties:
             Queue: !GetAtt NewCandidateQueue.Arn
 
+  UpsertNviCandidateHandler:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: index-handlers
+      Handler: no.sikt.nva.nvi.handlers.IndexNviCandidateHandler::handleRequest
+      Timeout: 30
+      MemorySize: 1536
+      Role: !GetAtt NvaNviRole.Arn
+      Events:
+        SqsEvent:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt NewCandidateQueue.Arn
+
   DeleteNviCandidateHandler:
     Type: AWS::Serverless::Function
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -227,11 +227,6 @@ Resources:
       Environment:
         Variables:
           EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
-      Events:
-        SqsEvent:
-          Type: SQS
-          Properties:
-            Queue: !GetAtt NewCandidateQueue.Arn
 
   UpsertNviCandidateHandler:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Splitting Jira task (https://unit.atlassian.net/browse/NP-45083) into several PRs to keep them small. This is nr 1
- UpsertNviCandidateHandler consumes messages on sqs queue "NewCandidateQueue"
- Logs error if message body is invalid
- Logs error if publicationBucketUri is null