### PR TITLE
shouldCreateNonCandidateEventOnAcademicArticleWithoutRoleCreator

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/events/Publication.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/events/Publication.java
@@ -24,10 +24,16 @@ public record Publication(URI id,
 
         public record Contributor(Identity identity,
 
+                                  Role role,
+
                                   List<Affiliation> affiliations) {
 
             public record Identity(URI id,
                                    String verificationStatus) {
+
+            }
+
+            public record Role(String type){
 
             }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/EventModelTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/EventModelTest.java
@@ -93,6 +93,7 @@ public class EventModelTest {
 
     private Creator toCreator(Contributor contributor) {
         contributor.identity().verificationStatus();
+        contributor.role().type();
         return new Creator(contributor.identity().id(), contributor.affiliations()
                                                             .stream()
                                                             .map(Affiliation::id)

--- a/nvi-evaluator/src/main/java/no/sikt/nva/nvi/evaluator/calculator/CandidateCalculator.java
+++ b/nvi-evaluator/src/main/java/no/sikt/nva/nvi/evaluator/calculator/CandidateCalculator.java
@@ -43,15 +43,15 @@ import org.slf4j.LoggerFactory;
 
 public class CandidateCalculator {
 
+    public static final String ROLE_CREATOR = "Creator";
     private static final String CONTENT_TYPE = "application/json";
     private static final String COULD_NOT_FETCH_CUSTOMER_MESSAGE = "Could not fetch customer for: ";
     private static final String CUSTOMER = "customer";
     private static final String CRISTIN_ID = "cristinId";
     private static final String VERIFIED = "Verified";
-
     private static final String COULD_NOT_FETCH_CRISTIN_ORG_MESSAGE = "Could not fetch Cristin organization for: ";
     private static final String ERROR_COULD_NOT_FETCH_CRISTIN_ORG = COULD_NOT_FETCH_CRISTIN_ORG_MESSAGE + "{}. "
-                                                                   + "Response code: {}";
+                                                                    + "Response code: {}";
     private static final Logger LOGGER = LoggerFactory.getLogger(CandidateCalculator.class);
     //TODO to be configured somehow
     private static final String NVI_YEAR = "2023";
@@ -167,10 +167,15 @@ public class CandidateCalculator {
         return new PublicationDate(publicationDate.day(), publicationDate.month(), publicationDate.year());
     }
 
+    private static boolean isCreator(Contributor contributor) {
+        return ROLE_CREATOR.equals(contributor.role().type());
+    }
+
     private List<Creator> extractVerifiedCreator(Publication publication) {
         return publication.entityDescription()
                    .contributors()
                    .stream()
+                   .filter(CandidateCalculator::isCreator)
                    .filter(CandidateCalculator::isVerified)
                    .map(this::filterInstitutionsToKeepNvaCustomers)
                    .map(CandidateCalculator::toCreator)
@@ -188,7 +193,7 @@ public class CandidateCalculator {
     }
 
     private Contributor filterInstitutionsToKeepNvaCustomers(Contributor contributor) {
-        return new Contributor(contributor.identity(), getTopLevelOrgNviInstitutions(contributor));
+        return new Contributor(contributor.identity(), contributor.role(), getTopLevelOrgNviInstitutions(contributor));
     }
 
     private List<Affiliation> getTopLevelOrgNviInstitutions(Contributor contributor) {

--- a/nvi-evaluator/src/test/java/no/sikt/nva/nvi/evaluator/EvaluateNviNviCandidateHandlerTest.java
+++ b/nvi-evaluator/src/test/java/no/sikt/nva/nvi/evaluator/EvaluateNviNviCandidateHandlerTest.java
@@ -227,6 +227,18 @@ class EvaluateNviNviCandidateHandlerTest {
     }
 
     @Test
+    void shouldCreateNonCandidateEventOnAcademicArticleWithoutRoleCreator() throws IOException {
+        var path = "nonCandidate_nonCreatorRole";
+        var content = IoUtils.inputStreamFromResources(path);
+        var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
+        var event = createS3Event(fileUri);
+        handler.handleRequest(event, output, context);
+        var sentMessages = sqsClient.getSentMessages();
+        var candidate = getSingleCandidateResponse(sentMessages);
+        assertThat(candidate.status(), is(equalTo(CandidateStatus.NON_CANDIDATE)));
+    }
+
+    @Test
     void shouldCreateNonCandidateEventWhenIdentityIsNotVerified() throws IOException {
         var path = "nonCandidate_nonVerified.json";
         var content = IoUtils.inputStreamFromResources(path);

--- a/nvi-evaluator/src/test/resources/nonCandidate_nonCreatorRole
+++ b/nvi-evaluator/src/test/resources/nonCandidate_nonCreatorRole
@@ -1,0 +1,230 @@
+{
+  "body" : {
+    "type" : "Publication",
+    "publicationContextUris" : [ "https://api.dev.nva.aws.unit.no/publication-channels/journal/490845/2023" ],
+    "@context" : {
+      "@vocab" : "https://nva.sikt.no/ontology/publication#",
+      "hasPart" : "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+      "xsd" : "http://www.w3.org/2001/XMLSchema#",
+      "DIRHEALTH" : "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+      "NMA" : "https://nva.sikt.no/ontology/approvals-body#NMA",
+      "NARA" : "https://nva.sikt.no/ontology/approvals-body#NARA",
+      "REK" : "https://nva.sikt.no/ontology/approvals-body#REK",
+      "ShortFilm" : "https://nva.sikt.no/ontology/publication#ShortFilm",
+      "SerialFilmProduction" : "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+      "Film" : "https://nva.sikt.no/ontology/publication#Film",
+      "InteractiveFilm" : "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+      "AugmentedVirtualRealityFilm" : "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+      "approvedBy" : {
+        "@context" : {
+          "@vocab" : "https://nva.sikt.no/ontology/approvals-body#"
+        },
+        "@type" : "@vocab"
+      },
+      "activeFrom" : {
+        "@type" : "xsd:dateTime"
+      },
+      "activeTo" : {
+        "@type" : "xsd:dateTime"
+      },
+      "additionalIdentifiers" : {
+        "@container" : "@set",
+        "@id" : "additionalIdentifier"
+      },
+      "affiliations" : {
+        "@container" : "@set",
+        "@id" : "affiliation"
+      },
+      "alternativeTitles" : {
+        "@container" : "@language",
+        "@id" : "alternativeTitle"
+      },
+      "approvals" : {
+        "@container" : "@set",
+        "@id" : "approval"
+      },
+      "approvalStatus" : {
+        "@context" : {
+          "@vocab" : "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type" : "@vocab"
+      },
+      "architectureOutput" : {
+        "@container" : "@set",
+        "@id" : "architectureOutput"
+      },
+      "associatedArtifacts" : {
+        "@container" : "@set",
+        "@id" : "associatedArtifact"
+      },
+      "compliesWith" : {
+        "@container" : "@set",
+        "@id" : "compliesWith"
+      },
+      "concertProgramme" : {
+        "@container" : "@set",
+        "@id" : "concertProgramme"
+      },
+      "contributors" : {
+        "@container" : "@set",
+        "@id" : "contributor"
+      },
+      "createdDate" : {
+        "@type" : "xsd:dateTime"
+      },
+      "doi" : {
+        "@type" : "@id"
+      },
+      "embargoDate" : {
+        "@type" : "xsd:dateTime"
+      },
+      "from" : {
+        "@type" : "xsd:dateTime"
+      },
+      "fundings" : {
+        "@container" : "@set",
+        "@id" : "funding"
+      },
+      "handle" : {
+        "@type" : "@id"
+      },
+      "id" : "@id",
+      "indexedDate" : {
+        "@type" : "xsd:dateTime"
+      },
+      "isbnList" : {
+        "@container" : "@set",
+        "@id" : "isbn"
+      },
+      "labels" : {
+        "@container" : "@language",
+        "@id" : "label"
+      },
+      "language" : {
+        "@type" : "@id"
+      },
+      "link" : {
+        "@type" : "@id"
+      },
+      "manifestations" : {
+        "@container" : "@set",
+        "@id" : "manifestation"
+      },
+      "metadataSource" : {
+        "@type" : "@id"
+      },
+      "modifiedDate" : {
+        "@type" : "xsd:dateTime"
+      },
+      "musicalWorks" : {
+        "@container" : "@set",
+        "@id" : "musicalWork"
+      },
+      "nameType" : {
+        "@context" : {
+          "@vocab" : "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type" : "@vocab"
+      },
+      "outputs" : {
+        "@container" : "@set",
+        "@id" : "output"
+      },
+      "ownerAffiliation" : {
+        "@type" : "@id"
+      },
+      "projects" : {
+        "@container" : "@set",
+        "@id" : "project"
+      },
+      "publishedDate" : {
+        "@type" : "xsd:dateTime"
+      },
+      "referencedBy" : {
+        "@container" : "@set",
+        "@id" : "referencedBy"
+      },
+      "related" : {
+        "@container" : "@set",
+        "@id" : "related"
+      },
+      "status" : {
+        "@context" : {
+          "@vocab" : "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type" : "@vocab"
+      },
+      "subjects" : {
+        "@container" : "@set",
+        "@id" : "subject",
+        "@type" : "@id"
+      },
+      "tags" : {
+        "@container" : "@set",
+        "@id" : "tag"
+      },
+      "to" : {
+        "@type" : "xsd:dateTime"
+      },
+      "trackList" : {
+        "@container" : "@set",
+        "@id" : "trackList"
+      },
+      "type" : "@type",
+      "venues" : {
+        "@container" : "@set",
+        "@id" : "venue"
+      },
+      "nviType" : {
+        "@type" : "@vocab",
+        "@context" : {
+          "@vocab" : "https://nva.sikt.no/ontology/publication#"
+        }
+      },
+      "NviCandidate" : "https://nva.sikt.no/ontology/publication#NviCandidate",
+      "NonNviCandidate" : "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+      "publicationContextUris" : {
+        "@container" : "@set"
+      }
+    },
+    "id" : "https://api.dev.nva.aws.unit.no/publication/01888b283f29-cae193c7-80fa-4f92-a164-c73b02c19f2d",
+    "entityDescription" : {
+      "type" : "EntityDescription",
+      "contributors" : [ {
+        "type" : "Contributor",
+        "affiliations" : [ {
+          "id" : "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.20.0",
+          "type" : "Organization"
+        } ],
+        "identity" : {
+          "id" : "https://api.dev.nva.aws.unit.no/cristin/person/997998",
+          "type" : "Identity",
+          "verificationStatus": "Verified"
+        },
+        "role" : {
+          "type" : "Other"
+        }
+      } ],
+      "publicationDate" : {
+        "type" : "PublicationDate",
+        "year" : "2023"
+      },
+      "reference" : {
+        "type" : "Reference",
+        "publicationContext" : {
+          "id" : "https://api.dev.nva.aws.unit.no/publication-channels/journal/490845/2023",
+          "type" : "Journal",
+          "level" : "1"
+        },
+        "publicationInstance" : {
+          "type" : "AcademicArticle"
+        }
+      }
+    },
+    "status" : "PUBLISHED"
+  },
+  "consumptionAttributes" : {
+    "index" : "resources",
+    "documentIdentifier" : "01888b283f29-cae193c7-80fa-4f92-a164-c73b02c19f2d"
+  }
+}


### PR DESCRIPTION
Found another bug while working on [Bug: Only AcademicArticles showing as nvi candidates](https://unit.atlassian.net/browse/NP-45196). We have to filter out only contributors with role `Creator` when evaluating nvi candidates