### PR TITLE
Np 45326 remove approval status if not applicable

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
@@ -227,10 +227,11 @@ public class NviService {
         return nviCandidateRepository.update(identifier, candidate, approvalStatuses);
     }
 
-    private Optional<Candidate> updateCandidateToNotApplicable(DbCandidate dbCandidate) {
-        var existingCandidate = findByPublicationId(dbCandidate.publicationId()).orElseThrow();
-        return Optional.of(updateCandidateRemovingApprovals(existingCandidate.identifier(), dbCandidate,
-                                                            generatePendingApprovalStatuses(dbCandidate.points())));
+    private Optional<Candidate> updateCandidateToNotApplicable(DbCandidate candidate) {
+        var existingCandidate = findByPublicationId(candidate.publicationId()).orElseThrow();
+        return Optional.of(updateCandidateRemovingApprovals(existingCandidate.identifier(),
+                                                            candidate,
+                                                            existingCandidate.approvalStatuses()));
     }
 
     private Candidate updateCandidateRemovingApprovals(UUID identifier, DbCandidate candidate,


### PR DESCRIPTION
Fix for bug: Should remove existing approvals when candidate exists and is no longer applicable