### PR TITLE
shouldDoNothingIfCreateRequestIsForNonCandidateThatDoesNotExist

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/UpsertNviCandidateHandlerTest.java
@@ -120,7 +120,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
     @Test
     void shouldUpdateExistingNviCandidateToNonCandidateWhenIncomingEventIsNonCandidate() {
         var dto = CandidateBO.fromRequest(
-            createUpsertCandidateRequest(randomUri()), candidateRepository, periodRepository).toDto();
+            createUpsertCandidateRequest(randomUri()), candidateRepository, periodRepository).orElseThrow().toDto();
         var eventMessage = nonCandidateMessageForExistingCandidate(dto);
         handler.handleRequest(createEvent(eventMessage), CONTEXT);
         var updatedCandidate =
@@ -137,7 +137,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
         var publicationId = generatePublicationId(identifier);
         var dto = CandidateBO.fromRequest(createUpsertCandidateRequest(publicationId, true, 1,
                                                                        InstanceType.ACADEMIC_ARTICLE, delete, keep),
-                                          candidateRepository, periodRepository);
+                                          candidateRepository, periodRepository).orElseThrow();
         var sqsEvent = createEvent(keep, publicationId, generateS3BucketUri(identifier));
         handler.handleRequest(sqsEvent, CONTEXT);
         Map<URI, DbApprovalStatus> approvals = getAprovalMaps(dto);

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/exception/IllegalOperationException.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/exception/IllegalOperationException.java
@@ -1,5 +1,0 @@
-package no.sikt.nva.nvi.common.service.exception;
-
-public class IllegalOperationException extends RuntimeException {
-
-}

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateBONotesTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateBONotesTest.java
@@ -90,6 +90,6 @@ public class CandidateBONotesTest extends LocalDynamoTest {
 
     private CandidateBO createCandidate() {
         return CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()), candidateRepository,
-                                       periodRepository);
+                                       periodRepository).orElseThrow();
     }
 }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -74,7 +74,7 @@ public class CreateNoteHandlerTest extends LocalDynamoTest {
     @Test
     void shouldAddNoteToCandidateWhenNoteIsValid() throws IOException {
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()), candidateRepository,
-                                                periodRepository);
+                                                periodRepository).orElseThrow();
         var theNote = "The note";
         var userName = randomString();
 
@@ -90,7 +90,7 @@ public class CreateNoteHandlerTest extends LocalDynamoTest {
     @Test
     void shouldReturnConflictWhenCreatingNoteAndReportingPeriodIsClosed() throws IOException {
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()), candidateRepository,
-                                                periodRepository);
+                                                periodRepository).orElseThrow();
         var request = createRequest(candidate.identifier(), new NviNoteRequest(randomString()), randomString());
         var handler = new CreateNoteHandler(candidateRepository, periodRepositoryReturningClosedPeriod(YEAR));
         handler.handleRequest(request, output, context);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandlerTest.java
@@ -68,7 +68,8 @@ class FetchNviCandidateHandlerTest extends LocalDynamoTest {
     @Test
     void shouldReturnValidCandidateWhenCandidateExists() throws IOException {
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()), candidateRepository, periodRepository)
+                .orElseThrow();
         var request = createRequest(candidate.identifier());
 
         handler.handleRequest(request, output, CONTEXT);
@@ -89,12 +90,13 @@ class FetchNviCandidateHandlerTest extends LocalDynamoTest {
     private CandidateBO setUpNonApplicableCandidate() {
         URI institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         return CandidateBO.fromRequest(createUpsertCandidateRequest(candidate.publicationId(),
                                                                     false, 0,
                                                                     InstanceType.NON_CANDIDATE,
                                                                     institutionId),
-                                       candidateRepository, periodRepository);
+                                       candidateRepository, periodRepository).orElseThrow();
     }
 
     private GatewayResponse<CandidateDto> getGatewayResponse()

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -130,7 +130,7 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
 
     private CandidateBO createCandidate() {
         return CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()), candidateRepository,
-                                       periodRepository);
+                                       periodRepository).orElseThrow();
     }
 
     private HandlerRequestBuilder<NviNoteRequest> createRequest(UUID candidateIdentifier, UUID noteIdentifier,

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -90,7 +90,7 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
     void shouldBeForbiddenToChangeStatusOfOtherInstitution() throws IOException {
         var institutionId = randomUri();
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository,
-                                                periodRepository);
+                                                periodRepository).orElseThrow();
         var request = createUnauthorizedRequest(candidate.identifier(), institutionId);
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -105,7 +105,8 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
         handler = new UpdateNviCandidateStatusHandler(candidateRepository, periodRepository);
         var institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         var request = createRequest(candidate.identifier(), institutionId, APPROVED);
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -120,7 +121,8 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
         handler = new UpdateNviCandidateStatusHandler(candidateRepository, periodRepository);
         var institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         var request = createRequest(candidate.identifier(), institutionId, APPROVED);
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -132,7 +134,8 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
     void shouldReturnBadRequestIfRejectionDoesNotContainReason() throws IOException {
         var institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         var request = createRequestWithoutReason(candidate.identifier(), institutionId, REJECTED);
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -146,7 +149,8 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
     void shouldUpdateApprovalStatus(DbStatus oldStatus, DbStatus newStatus) throws IOException {
         var institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         candidate.updateApproval(createStatusRequest(oldStatus));
         var request = createRequest(candidate.identifier(), institutionId,
                                     NviApprovalStatus.parse(newStatus.getValue()));
@@ -162,7 +166,8 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
     void shouldResetFinalizedValuesWhenUpdatingStatusToPending(DbStatus oldStatus) throws IOException {
         var institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         candidate.updateApproval(createStatusRequest(oldStatus));
         var newStatus = PENDING;
         var request = createRequest(candidate.identifier(), institutionId, newStatus);
@@ -180,7 +185,8 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
     void shouldUpdateApprovalStatusToRejectedWithReason(DbStatus oldStatus) throws IOException {
         var institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         candidate.updateApproval(createStatusRequest(oldStatus));
         var rejectionReason = randomString();
         var newStatus = REJECTED;
@@ -200,7 +206,8 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
     void shouldRemoveReasonWhenUpdatingStatusFromRejected(DbStatus newStatus) throws IOException {
         var institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         candidate.updateApproval(createStatusRequest(DbStatus.REJECTED));
         var request = createRequest(candidate.identifier(), institutionId,
                                     NviApprovalStatus.parse(newStatus.getValue()));
@@ -217,7 +224,8 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
     void shouldUpdateAssigneeWhenFinalizingApprovalWithoutAssignee() throws IOException {
         var institutionId = randomUri();
         var candidate =
-            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository);
+            CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
+                .orElseThrow();
         var assignee = randomString();
         var requestBody = new NviStatusRequest(candidate.identifier(), institutionId, APPROVED, null);
         var request = createRequest(candidate.identifier(), institutionId, requestBody, assignee);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -2,10 +2,10 @@ package no.sikt.nva.nvi.rest.upsert;
 
 import static java.util.UUID.randomUUID;
 import static no.sikt.nva.nvi.rest.upsert.UpsertAssigneeHandler.CANDIDATE_IDENTIFIER;
+import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningNotOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -85,7 +85,7 @@ public class UpsertAssigneeHandlerTest extends LocalDynamoTest {
         mockUserApiResponse("userResponseBodyWithoutAccessRight.json");
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()),
                                                 candidateRepository,
-                                                periodRepository);
+                                                periodRepository).orElseThrow();
         var assignee = randomString();
         handler.handleRequest(createRequest(candidate, assignee), output, context);
         var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
@@ -107,7 +107,7 @@ public class UpsertAssigneeHandlerTest extends LocalDynamoTest {
         mockUserApiResponse("userResponseBodyWithAccessRight.json");
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()),
                                                 candidateRepository,
-                                                periodRepository);
+                                                periodRepository).orElseThrow();
         var assignee = randomString();
         var periodRepository = periodRepositoryReturningClosedPeriod(YEAR);
         var handler = new UpsertAssigneeHandler(candidateRepository, periodRepository, uriRetriever);
@@ -122,7 +122,7 @@ public class UpsertAssigneeHandlerTest extends LocalDynamoTest {
         mockUserApiResponse("userResponseBodyWithAccessRight.json");
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()),
                                                 candidateRepository,
-                                                periodRepository);
+                                                periodRepository).orElseThrow();
         var assignee = randomString();
         var periodRepository = periodRepositoryReturningNotOpenedPeriod(YEAR);
         var handler = new UpsertAssigneeHandler(candidateRepository, periodRepository, uriRetriever);
@@ -137,7 +137,7 @@ public class UpsertAssigneeHandlerTest extends LocalDynamoTest {
         mockUserApiResponse("userResponseBodyWithAccessRight.json");
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()),
                                                 candidateRepository,
-                                                periodRepository);
+                                                periodRepository).orElseThrow();
         var assignee = randomString();
         handler.handleRequest(createRequest(candidate, assignee), output, context);
         var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
@@ -152,7 +152,7 @@ public class UpsertAssigneeHandlerTest extends LocalDynamoTest {
         mockUserApiResponse("userResponseBodyWithAccessRight.json");
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()),
                                                 candidateRepository,
-                                                periodRepository);
+                                                periodRepository).orElseThrow();
         handler.handleRequest(createRequest(candidate, null), output, context);
         var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
 
@@ -177,8 +177,8 @@ public class UpsertAssigneeHandlerTest extends LocalDynamoTest {
     private CandidateBO candidateWithFinalizedApproval(String newAssignee) {
         var institutionId = randomUri();
         var candidate = CandidateBO.fromRequest(createUpsertCandidateRequest(institutionId),
-                                candidateRepository,
-                                periodRepository);
+                                                candidateRepository,
+                                                periodRepository).orElseThrow();
         candidate.updateApproval(new UpdateAssigneeRequest(institutionId, newAssignee));
         candidate.updateApproval(new UpdateStatusRequest(institutionId,
                                                          DbStatus.APPROVED, randomString(), randomString()));
@@ -207,7 +207,7 @@ public class UpsertAssigneeHandlerTest extends LocalDynamoTest {
     private InputStream createRequestWithNonExistingCandidate() throws JsonProcessingException {
         var approvalToUpdate =
             CandidateBO.fromRequest(createUpsertCandidateRequest(randomUri()), candidateRepository, periodRepository)
-                .toDto().approvalStatuses().get(0);
+                .orElseThrow().toDto().approvalStatuses().get(0);
         var requestBody = new ApprovalDto(randomString(), approvalToUpdate.institutionId());
         var customerId = randomUri();
         return new HandlerRequestBuilder<ApprovalDto>(JsonUtils.dtoObjectMapper).withBody(randomAssigneeRequest())


### PR DESCRIPTION
UpsertNviCandidateHandler is logging lots of error for the following case: Evaluated candidate is not candidate and does not exist. This is wrong, UpsertNviCandidateHandler should do nothing in this case. Changes:

- CandidateBO.fromRequest(UpsertRequest ...) returns Optional.empty() in this case instead of throwing IllegalOperationException().