### PR TITLE
Np 45443 fix reset for non candidates

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateBO.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateBO.java
@@ -231,11 +231,15 @@ public final class CandidateBO {
         validateCandidate(request);
         var existingCandidateDao = repository.findByPublicationIdDao(request.publicationId())
                                        .orElseThrow(CandidateNotFoundException::new);
-        if (shouldResetCandidate(request, existingCandidateDao)) {
+        if (shouldResetCandidate(request, existingCandidateDao) || isNotApplicable(existingCandidateDao)) {
             return resetCandidate(request, repository, periodRepository, existingCandidateDao);
         } else {
             return updateCandidateKeepingApprovalsAndNotes(request, repository, periodRepository, existingCandidateDao);
         }
+    }
+
+    private static boolean isNotApplicable(CandidateDao existingCandidateDao) {
+        return !existingCandidateDao.candidate().applicable();
     }
 
     private static CandidateBO resetCandidate(UpsertCandidateRequest request, CandidateRepository repository,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateBOTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateBOTest.java
@@ -276,7 +276,7 @@ class CandidateBOTest extends LocalDynamoTest {
     }
 
     @Test
-    void shouldResetApprovalsWhenUpdatingNonCandidate() {
+    void shouldResetApprovalsWhenNonCandidateBecomesCandidate() {
         var institutionId = randomUri();
         var upsertCandidateRequest = createUpsertCandidateRequest(institutionId);
         var candidate = CandidateBO.fromRequest(upsertCandidateRequest, candidateRepository, periodRepository)


### PR DESCRIPTION
Jira issue: [Bug: Candidate not showing after being nonCandidate when no relevant fields are updated](https://unit.atlassian.net/browse/NP-45443)

If a candidate goes from candidate -> non candidate -> candidate, we need to generate new approvals, even if candidate data hasen't changed.