### PR TITLE
Np 45529 Handle publication channel v2 level values 

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/UpsertNviCandidateHandlerTest.java
@@ -8,6 +8,7 @@ import static no.sikt.nva.nvi.test.TestUtils.generatePublicationId;
 import static no.sikt.nva.nvi.test.TestUtils.generateS3BucketUri;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomInstanceTypeExcluding;
+import static no.sikt.nva.nvi.test.TestUtils.randomLevelExcluding;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
@@ -176,7 +177,9 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
         var publicationId = generatePublicationId(identifier);
         var dto = CandidateBO.fromRequest(
             createUpsertCandidateRequest(publicationId, randomUri(), true, InstanceType.ACADEMIC_ARTICLE, 1,
-                                         randomBigDecimal(), delete, keep),
+                                         randomBigDecimal(),
+                                         randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
+                                         delete, keep),
             candidateRepository, periodRepository).orElseThrow();
         var sqsEvent = createEvent(keep, publicationId, generateS3BucketUri(identifier));
         handler.handleRequest(sqsEvent, CONTEXT);
@@ -210,7 +213,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                                           .withPublicationId(generatePublicationId(identifier))
                                           .withPublicationBucketUri(generateS3BucketUri(identifier))
                                           .withInstanceType(randomInstanceTypeExcluding(NON_CANDIDATE).getValue())
-                                          .withLevel(randomElement(DbLevel.values()).getValue())
+                                          .withLevel(randomElement(DbLevel.values()).getVersionOneValue())
                                           .withTotalPoints(randomBigDecimal())
                                           .withBasePoints(randomBigDecimal())
                                           .withCreatorShareCount(randomInteger())
@@ -238,7 +241,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                                                     .withPublicationId(null)
                                                     .withInstanceType(randomString())
                                                     .withLevel(randomElement(
-                                                        DbLevel.values()).getValue())
+                                                        DbLevel.values()).getVersionOneValue())
                                                     .withDate(randomPublicationDate())
                                                     .withVerifiedCreators(List.of(randomCreator()))
                                                     .build())
@@ -277,7 +280,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                                           .withInstanceType(instanceType.getValue())
                                           .withChannelType(randomElement(ChannelType.values()).getValue())
                                           .withPublicationChannelId(randomUri())
-                                          .withLevel(level.getValue())
+                                          .withLevel(level.getVersionOneValue())
                                           .withDate(publicationDate)
                                           .withVerifiedCreators(verifiedCreators)
                                           .withIsInternationalCollaboration(randomBoolean())

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -260,38 +260,38 @@ public class SearchNviCandidatesHandlerTest {
 
     private static SearchResponse<NviCandidateIndexDocument> createSearchResponse(NviCandidateIndexDocument document) {
         return new Builder<NviCandidateIndexDocument>().hits(constructHitsMetadata(List.of(document)))
-            .took(10)
-            .timedOut(false)
-            .shards(new ShardStatistics.Builder().failed(0).successful(1).total(1).build())
-            .build();
+                   .took(10)
+                   .timedOut(false)
+                   .shards(new ShardStatistics.Builder().failed(0).successful(1).total(1).build())
+                   .build();
     }
 
     private static SearchResponse<NviCandidateIndexDocument> createSearchResponse(
         List<NviCandidateIndexDocument> documents, int total, String aggregateName, int docCount) {
         return new Builder<NviCandidateIndexDocument>()
-            .hits(constructHitsMetadata(documents))
-            .took(10)
-            .timedOut(false)
-            .shards(new ShardStatistics.Builder().failed(0).successful(1).total(total).build())
-            .aggregations(aggregateName, new Aggregate(new FilterAggregate.Builder().docCount(docCount).build()))
-            .build();
+                   .hits(constructHitsMetadata(documents))
+                   .took(10)
+                   .timedOut(false)
+                   .shards(new ShardStatistics.Builder().failed(0).successful(1).total(total).build())
+                   .aggregations(aggregateName, new Aggregate(new FilterAggregate.Builder().docCount(docCount).build()))
+                   .build();
     }
 
     private static HitsMetadata<NviCandidateIndexDocument> constructHitsMetadata(
         List<NviCandidateIndexDocument> document) {
         return new HitsMetadata.Builder<NviCandidateIndexDocument>()
-            .total(new TotalHits.Builder().value(10).relation(TotalHitsRelation.Eq).build())
-            .hits(document.stream().map(SearchNviCandidatesHandlerTest::toHit).collect(Collectors.toList()))
-            .total(new TotalHits.Builder().relation(TotalHitsRelation.Eq).value(1).build())
-            .build();
+                   .total(new TotalHits.Builder().value(10).relation(TotalHitsRelation.Eq).build())
+                   .hits(document.stream().map(SearchNviCandidatesHandlerTest::toHit).collect(Collectors.toList()))
+                   .total(new TotalHits.Builder().relation(TotalHitsRelation.Eq).value(1).build())
+                   .build();
     }
 
     private static Hit<NviCandidateIndexDocument> toHit(NviCandidateIndexDocument document) {
         return new Hit.Builder<NviCandidateIndexDocument>()
-            .id(randomString())
-            .index(NVI_CANDIDATES_INDEX)
-            .source(document)
-            .build();
+                   .id(randomString())
+                   .index(NVI_CANDIDATES_INDEX)
+                   .source(document)
+                   .build();
     }
 
     private static NviCandidateIndexDocument singleNviCandidateIndexDocument() {
@@ -312,7 +312,6 @@ public class SearchNviCandidatesHandlerTest {
         return IntStream.range(0, number).boxed().map(i -> singleNviCandidateIndexDocument()).toList();
     }
 
-
     private URI randomSiktSubUnit() {
         return randomElement(
             List.of(
@@ -328,44 +327,46 @@ public class SearchNviCandidatesHandlerTest {
 
     private InputStream emptyRequest() throws JsonProcessingException {
         return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
-            .withTopLevelCristinOrgId(randomUri())
-            .withUserName(randomString())
-            .build();
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withUserName(randomString())
+                   .build();
     }
 
     private InputStream requestWithInstitutionsAndFilter(List<URI> institutions, String filter, String category,
                                                          String title)
         throws JsonProcessingException {
         return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
-            .withTopLevelCristinOrgId(randomUri())
-            .withUserName(randomString())
-            .withQueryParameters(Map.of(QUERY_PARAM_AFFILIATIONS, String.join(COMMA,
-                                        institutions.stream().map(URI::toString).toList()),
-                                        QUERY_PARAM_EXCLUDE_SUB_UNITS, "true",
-                                        QUERY_PARAM_FILTER, filter,
-                                        QUERY_PARAM_CATEGORY, category,
-                                        QUERY_PARAM_TITLE, title))
-            .build();
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withUserName(randomString())
+                   .withQueryParameters(Map.of(QUERY_PARAM_AFFILIATIONS, String.join(COMMA,
+                                                                                     institutions.stream()
+                                                                                         .map(URI::toString)
+                                                                                         .toList()),
+                                               QUERY_PARAM_EXCLUDE_SUB_UNITS, "true",
+                                               QUERY_PARAM_FILTER, filter,
+                                               QUERY_PARAM_CATEGORY, category,
+                                               QUERY_PARAM_TITLE, title))
+                   .build();
     }
 
     private InputStream requestWithInstitutionsAndTopLevelCristinOrgId(List<URI> institutions, URI cristinId)
         throws JsonProcessingException {
         return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
-            .withTopLevelCristinOrgId(cristinId)
-            .withUserName(randomString())
-            .withQueryParameters(Map.of(QUERY_PARAM_AFFILIATIONS,
-                                        String.join(",",
-                                        institutions.stream().map(URI::toString).toList()),
-                                        QUERY_PARAM_EXCLUDE_SUB_UNITS,
-                                        "true"))
-            .build();
+                   .withTopLevelCristinOrgId(cristinId)
+                   .withUserName(randomString())
+                   .withQueryParameters(Map.of(QUERY_PARAM_AFFILIATIONS,
+                                               String.join(",",
+                                                           institutions.stream().map(URI::toString).toList()),
+                                               QUERY_PARAM_EXCLUDE_SUB_UNITS,
+                                               "true"))
+                   .build();
     }
 
     private InputStream requestWithoutQueryParameters() throws JsonProcessingException {
         return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
-            .withTopLevelCristinOrgId(randomUri())
-            .withUserName(randomString())
-            .build();
+                   .withTopLevelCristinOrgId(randomUri())
+                   .withUserName(randomString())
+                   .build();
     }
 
     public class CandidateSearchParamsAffiliationMatcher implements ArgumentMatcher<CandidateSearchParameters> {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -7,8 +7,6 @@ import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_1_HASH_KE
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_1_RANGE_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_PUBLICATION_ID;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SORT_KEY;
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.ArrayList;
@@ -87,27 +85,30 @@ public record CandidateDao(
     }
 
     public enum DbLevel {
-        UNASSIGNED("Unassigned"), LEVEL_ONE("1"), LEVEL_TWO("2"), NON_CANDIDATE("NonCandidateLevel");
+        LEVEL_ONE(List.of("1", "LevelOne")), LEVEL_TWO(List.of("2", "LevelTwo")), NON_CANDIDATE(
+            List.of("NonCandidateLevel"));
 
-        @JsonValue
-        private final String value;
+        private final List<String> values;
 
-        DbLevel(String value) {
+        DbLevel(List<String> values) {
 
-            this.value = value;
+            this.values = values;
         }
 
-        @JsonCreator
-        public static DbLevel parse(String value) {
-            return Arrays
-                       .stream(DbLevel.values())
-                       .filter(level -> level.getValue().equalsIgnoreCase(value))
+        public static DbLevel parse(String string) {
+            return Arrays.stream(DbLevel.values())
+                       .filter(level -> level.getValues().contains(string))
                        .findFirst()
                        .orElse(NON_CANDIDATE);
         }
 
-        public String getValue() {
-            return value;
+        @Deprecated
+        public String getVersionOneValue() {
+            return values.get(0);
+        }
+
+        public List<String> getValues() {
+            return values;
         }
     }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateBO.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateBO.java
@@ -287,7 +287,7 @@ public final class CandidateBO {
     }
 
     private static boolean levelIsUpdated(UpsertCandidateRequest request, CandidateDao existingCandidateDao) {
-        return !Objects.equals(request.level(), existingCandidateDao.candidate().level().getValue());
+        return !Objects.equals(DbLevel.parse(request.level()), existingCandidateDao.candidate().level());
     }
 
     private static CandidateBO createCandidate(UpsertCandidateRequest request, CandidateRepository repository,

--- a/nvi-commons/src/main/resources/sparql/nvi.sparql
+++ b/nvi-commons/src/main/resources/sparql/nvi.sparql
@@ -15,7 +15,7 @@ ASK WHERE {
   {
       SELECT ?level WHERE {
         VALUES ?channelType { nva:Publisher  nva:Series   nva:Journal }
-        VALUES ?rawLevel {"0" "1" "2"}
+        VALUES ?rawLevel {"0" "1" "2" "Unassigned" "LevelZero" "LevelOne" "LevelTwo"}
         ?a a ?channelType ;
            nva:level ?rawLevel .
         OPTIONAL { ?b a nva:Series ;
@@ -23,7 +23,7 @@ ASK WHERE {
         BIND(IF(BOUND(?seriesLevel), ?seriesLevel, ?rawLevel) AS ?level)
       }
     }
-  VALUES ?validLevel {"1" "2"}
+  VALUES ?validLevel {"1" "2" "LevelOne" "LevelTwo"}
   FILTER(?level = ?validLevel)
   FILTER(xsd:integer(?year) > 2021)
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateBOApprovalStatusTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateBOApprovalStatusTest.java
@@ -7,6 +7,7 @@ import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeri
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningNotOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
+import static no.sikt.nva.nvi.test.TestUtils.randomLevelExcluding;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -21,6 +22,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.model.InstanceType;
@@ -99,6 +101,8 @@ public class CandidateBOApprovalStatusTest extends LocalDynamoTest {
         var upsertCandidateRequest = createUpsertCandidateRequest(randomUri(), randomUri(), true,
                                                                   InstanceType.ACADEMIC_MONOGRAPH, 1,
                                                                   randomBigDecimal(),
+                                                                  randomLevelExcluding(
+                                                                      DbLevel.NON_CANDIDATE).getVersionOneValue(),
                                                                   institutionId);
         var candidateBO = CandidateBO.fromRequest(upsertCandidateRequest, candidateRepository, periodRepository)
                               .orElseThrow();
@@ -138,6 +142,8 @@ public class CandidateBOApprovalStatusTest extends LocalDynamoTest {
         var updateRequest = createUpsertCandidateRequest(candidate.toDto().publicationId(),
                                                          randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH, 2,
                                                          randomBigDecimal(),
+                                                         randomLevelExcluding(DbLevel.NON_CANDIDATE)
+                                                             .getVersionOneValue(),
                                                          randomUri(),
                                                          randomUri(), randomUri());
         var updatedCandidate = CandidateBO.fromRequest(updateRequest, candidateRepository, periodRepository)
@@ -154,7 +160,7 @@ public class CandidateBOApprovalStatusTest extends LocalDynamoTest {
         CandidateBO.fromRequest(createCandidateRequest, candidateRepository, periodRepository);
         var updateRequest = createUpsertCandidateRequest(
             createCandidateRequest.publicationId(), randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH, 2,
-            randomBigDecimal(),
+            randomBigDecimal(), randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
             keepInstitutionId,
             randomUri());
         var updatedCandidate = CandidateBO.fromRequest(updateRequest, candidateRepository, periodRepository)
@@ -188,7 +194,9 @@ public class CandidateBOApprovalStatusTest extends LocalDynamoTest {
                               .orElseThrow();
         var updateRequest = createUpsertCandidateRequest(candidateBO.toDto().publicationId(),
                                                          randomUri(), true, InstanceType.NON_CANDIDATE, 2,
-                                                         randomBigDecimal(), randomUri());
+                                                         randomBigDecimal(),
+                                                         randomLevelExcluding(DbLevel.NON_CANDIDATE)
+                                                             .getVersionOneValue(), randomUri());
         assertThrows(InvalidNviCandidateException.class,
                      () -> CandidateBO.fromRequest(updateRequest, candidateRepository, periodRepository));
     }

--- a/nvi-evaluator/src/main/java/no/sikt/nva/nvi/evaluator/calculator/PointCalculator.java
+++ b/nvi-evaluator/src/main/java/no/sikt/nva/nvi/evaluator/calculator/PointCalculator.java
@@ -19,7 +19,9 @@ import static no.sikt.nva.nvi.evaluator.model.InstanceType.ACADEMIC_CHAPTER;
 import static no.sikt.nva.nvi.evaluator.model.InstanceType.ACADEMIC_LITERATURE_REVIEW;
 import static no.sikt.nva.nvi.evaluator.model.InstanceType.ACADEMIC_MONOGRAPH;
 import static no.sikt.nva.nvi.evaluator.model.Level.LEVEL_ONE;
+import static no.sikt.nva.nvi.evaluator.model.Level.LEVEL_ONE_V2;
 import static no.sikt.nva.nvi.evaluator.model.Level.LEVEL_TWO;
+import static no.sikt.nva.nvi.evaluator.model.Level.LEVEL_TWO_V2;
 import static no.sikt.nva.nvi.evaluator.model.PublicationChannel.JOURNAL;
 import static no.sikt.nva.nvi.evaluator.model.PublicationChannel.PUBLISHER;
 import static no.sikt.nva.nvi.evaluator.model.PublicationChannel.SERIES;
@@ -60,25 +62,37 @@ public final class PointCalculator {
         ACADEMIC_MONOGRAPH, Map.of(
             PUBLISHER, Map.of(
                 LEVEL_ONE, BigDecimal.valueOf(5),
-                LEVEL_TWO, BigDecimal.valueOf(8)),
+                LEVEL_ONE_V2, BigDecimal.valueOf(5),
+                LEVEL_TWO, BigDecimal.valueOf(8),
+                LEVEL_TWO_V2, BigDecimal.valueOf(8)),
             SERIES, Map.of(
                 LEVEL_ONE, BigDecimal.valueOf(5),
-                LEVEL_TWO, BigDecimal.valueOf(8))),
+                LEVEL_ONE_V2, BigDecimal.valueOf(5),
+                LEVEL_TWO, BigDecimal.valueOf(8),
+                LEVEL_TWO_V2, BigDecimal.valueOf(8))),
         ACADEMIC_CHAPTER, Map.of(
             PUBLISHER, Map.of(
                 LEVEL_ONE, BigDecimal.valueOf(0.7),
-                LEVEL_TWO, BigDecimal.valueOf(1)),
+                LEVEL_ONE_V2, BigDecimal.valueOf(0.7),
+                LEVEL_TWO, BigDecimal.valueOf(1),
+                LEVEL_TWO_V2, BigDecimal.valueOf(1)),
             SERIES, Map.of(
                 LEVEL_ONE, BigDecimal.valueOf(1),
-                LEVEL_TWO, BigDecimal.valueOf(3))),
+                LEVEL_ONE_V2, BigDecimal.valueOf(1),
+                LEVEL_TWO, BigDecimal.valueOf(3),
+                LEVEL_TWO_V2, BigDecimal.valueOf(3))),
         ACADEMIC_ARTICLE, Map.of(
             JOURNAL, Map.of(
                 LEVEL_ONE, BigDecimal.valueOf(1),
-                LEVEL_TWO, BigDecimal.valueOf(3))),
+                LEVEL_ONE_V2, BigDecimal.valueOf(1),
+                LEVEL_TWO, BigDecimal.valueOf(3),
+                LEVEL_TWO_V2, BigDecimal.valueOf(3))),
         ACADEMIC_LITERATURE_REVIEW, Map.of(
             JOURNAL, Map.of(
                 LEVEL_ONE, BigDecimal.valueOf(1),
-                LEVEL_TWO, BigDecimal.valueOf(3))));
+                LEVEL_ONE_V2, BigDecimal.valueOf(1),
+                LEVEL_TWO, BigDecimal.valueOf(3),
+                LEVEL_TWO_V2, BigDecimal.valueOf(3))));
 
     private PointCalculator() {
     }

--- a/nvi-evaluator/src/main/java/no/sikt/nva/nvi/evaluator/model/Level.java
+++ b/nvi-evaluator/src/main/java/no/sikt/nva/nvi/evaluator/model/Level.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum Level {
     LEVEL_ONE("1"),
-    LEVEL_TWO("2");
+    LEVEL_ONE_V2("LevelOne"),
+    LEVEL_TWO("2"),
+    LEVEL_TWO_V2("LevelTwo");
 
     @JsonValue
     private final String value;

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.test;
 
+import static no.sikt.nva.nvi.common.db.model.InstanceType.NON_CANDIDATE;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
@@ -89,7 +90,7 @@ public final class TestUtils {
                    .publicationId(randomUri())
                    .publicationBucketUri(randomUri())
                    .applicable(applicable)
-                   .instanceType(randomInstanceTypeExcluding(InstanceType.NON_CANDIDATE))
+                   .instanceType(randomInstanceTypeExcluding(NON_CANDIDATE))
                    .points(List.of(new DbInstitutionPoints(randomUri(), randomBigDecimal())))
                    .level(randomElement(DbLevel.values()))
                    .publicationDate(new DbPublicationDate(randomString(), randomString(), randomString()))
@@ -106,6 +107,11 @@ public final class TestUtils {
     public static InstanceType randomInstanceTypeExcluding(InstanceType instanceType) {
         var instanceTypes = Arrays.stream(InstanceType.values()).filter(type -> !type.equals(instanceType)).toList();
         return instanceTypes.get(new Random().nextInt(instanceTypes.size()));
+    }
+
+    public static DbLevel randomLevelExcluding(DbLevel level) {
+        var levels = Arrays.stream(DbLevel.values()).filter(type -> !type.equals(level)).toList();
+        return levels.get(new Random().nextInt(levels.size()));
     }
 
     public static String randomYear() {
@@ -214,16 +220,25 @@ public final class TestUtils {
                    .build();
     }
 
+    public static UpsertCandidateRequest createUpsertCandidateRequestWithLevel(String level, URI... institutions) {
+        return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceTypeExcluding(NON_CANDIDATE),
+                                            1, randomBigDecimal(), level, institutions);
+    }
+
     public static UpsertCandidateRequest createUpsertCandidateRequest(URI... institutions) {
-        return createUpsertCandidateRequest(randomUri(), randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH, 1,
-                                            randomBigDecimal(),
+        return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceTypeExcluding(NON_CANDIDATE),
+                                            1, randomBigDecimal(),
+                                            randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
                                             institutions);
     }
 
     public static UpsertCandidateRequest createUpsertCandidateRequest(URI publicationId,
-                                                                      URI publicationBucketUri, boolean isApplicable,
-                                                                      final InstanceType instanceType, int creatorCount,
+                                                                      URI publicationBucketUri,
+                                                                      boolean isApplicable,
+                                                                      InstanceType instanceType,
+                                                                      int creatorCount,
                                                                       BigDecimal totalPoints,
+                                                                      String level,
                                                                       URI... institutions) {
         var creators = IntStream.of(creatorCount)
                            .mapToObj(i -> randomUri())
@@ -236,7 +251,7 @@ public final class TestUtils {
                                             new PublicationDate(String.valueOf(CURRENT_YEAR), null, null), creators,
                                             instanceType,
                                             randomElement(ChannelType.values()).getValue(), randomUri(),
-                                            DbLevel.LEVEL_TWO, points,
+                                            level, points,
                                             randomInteger(), randomBoolean(),
                                             randomBigDecimal(), randomBigDecimal(), totalPoints);
     }
@@ -248,7 +263,7 @@ public final class TestUtils {
                                                                       Map<URI, List<URI>> creators,
                                                                       InstanceType instanceType,
                                                                       String channelType, URI channelId,
-                                                                      DbLevel level,
+                                                                      String level,
                                                                       Map<URI, BigDecimal> points,
                                                                       final Integer creatorShareCount,
                                                                       final boolean isInternationalCollaboration,
@@ -295,7 +310,7 @@ public final class TestUtils {
 
             @Override
             public String level() {
-                return level.getValue();
+                return level;
             }
 
             @Override


### PR DESCRIPTION
Changes in evaluater (EvaluateNviCandidateHandler):
- Should create candidate when level value in expanded resource has "version two" values (“Unassigned”, “LevelZero”, “LevelOne", “LevelTwo")

Changes during persistence of candidate:
- Enum DbLevel handles both version 1 and version 2 values when parsing a string to a DbLevel object.