### PR TITLE
Np 45535 point calculation unverified affiliations

### DIFF
--- a/buildSrc/src/main/groovy/nva.nvi.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.nvi.java-conventions.gradle
@@ -28,7 +28,7 @@ repositories {
 
 tasks.named('test') {
     useJUnitPlatform()
-    failFast = true
+    failFast = false
     testLogging {
         events 'skipped', 'passed', 'failed'
     }

--- a/nvi-evaluator/src/test/java/no/sikt/nva/nvi/evaluator/calculator/PointCalculatorTest.java
+++ b/nvi-evaluator/src/test/java/no/sikt/nva/nvi/evaluator/calculator/PointCalculatorTest.java
@@ -163,9 +163,9 @@ class PointCalculatorTest {
     void shouldCountOneCreatorShareForCreatorsWithOnlyAffiliationsWithoutId() {
         var nviCreatorId = randomUri();
         var nviInstitutionId = randomUri();
-        int numberOfEmptyAffiliationsWithoutId = randomIntBetween(2, 10);
+        int numberOfAffiliationsWithoutId = randomIntBetween(2, 10);
         var expandedResource = setUpResourceWithOneCreatorWithUnverifiedAffiliations(nviCreatorId, nviInstitutionId,
-                                                                                     numberOfEmptyAffiliationsWithoutId);
+                                                                                     numberOfAffiliationsWithoutId);
 
         var institutionPoints = calculatePoints(expandedResource,
                                                 Map.of(nviCreatorId, List.of(nviInstitutionId))).institutionPoints();
@@ -175,7 +175,7 @@ class PointCalculatorTest {
 
     private static JsonNode setUpResourceWithOneCreatorWithUnverifiedAffiliations(URI nviCreatorId,
                                                                                   URI nviInstitutionId,
-                                                                                  int numberOfEmptyAffiliationsWithoutId) {
+                                                                                  int numberOfAffiliationsWithoutId) {
         return createExpandedResourceWithTwoVerifiedContributors(nviCreatorId,
                                                                  ROLE_CREATOR,
                                                                  Map.of(nviInstitutionId,
@@ -184,18 +184,18 @@ class PointCalculatorTest {
                                                                  ROLE_CREATOR,
                                                                  emptyMap(),
                                                                  HARDCODED_JOURNAL_REFERENCE,
-                                                                 numberOfEmptyAffiliationsWithoutId);
+                                                                 numberOfAffiliationsWithoutId);
     }
 
     private static JsonNode setUpResourceWithCreatorWithUnverifiedAffiliations(URI nviCreatorId, URI nviInstitutionId,
-                                                                               int numberOfEmptyAffiliationsWithoutId) {
+                                                                               int numberOfAffiliationsWithoutId) {
         return createExpandedResource(randomUri(),
                                       createContributorNodes(
                                           createContributorNode(nviCreatorId, true,
                                                                 Map.of(nviInstitutionId,
                                                                        COUNTRY_CODE_NO),
                                                                 ROLE_CREATOR,
-                                                                numberOfEmptyAffiliationsWithoutId)),
+                                                                numberOfAffiliationsWithoutId)),
                                       HARDCODED_JOURNAL_REFERENCE);
     }
 
@@ -275,21 +275,23 @@ class PointCalculatorTest {
         return createExpandedResource(randomUri(), contributorNodes, getInstanceTypeReference(parameters));
     }
 
-    private static JsonNode createExpandedResourceWithTwoVerifiedContributors(URI creator1,
-                                                                              String contributor1Role,
-                                                                              Map<URI, String> creator1Institution,
-                                                                              URI creator2,
-                                                                              String contributor2Role,
-                                                                              Map<URI, String> creator2Institution,
-                                                                              JsonNode reference,
-                                                                              int creator2numberOfEmptyAffiliations) {
+    private static JsonNode createExpandedResourceWithTwoVerifiedContributors(
+        URI creator1,
+        String contributor1Role,
+        Map<URI, String> creator1Institution,
+        URI creator2,
+        String contributor2Role,
+        Map<URI, String> creator2Institution,
+        JsonNode reference,
+        int creator2numberOfAffiliationsWithoutId) {
         return createExpandedResource(randomUri(),
                                       createContributorNodes(
                                           createContributorNode(creator1, true,
                                                                 creator1Institution,
                                                                 contributor1Role, 0),
                                           createContributorNode(creator2, true, creator2Institution,
-                                                                contributor2Role, creator2numberOfEmptyAffiliations)),
+                                                                contributor2Role,
+                                                                creator2numberOfAffiliationsWithoutId)),
                                       reference);
     }
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -56,12 +56,17 @@ public final class TestUtils {
     public static final int POINTS_SCALE = 4;
     public static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
     public static final int CURRENT_YEAR = Year.now().getValue();
+    public static final Random RANDOM = new Random();
     private static final String BUCKET_HOST = "example.org";
     private static final LocalDate START_DATE = LocalDate.of(1970, 1, 1);
     private static final String PUBLICATION_API_PATH = "publication";
     private static final String API_HOST = "example.com";
 
     private TestUtils() {
+    }
+
+    public static int randomIntBetween(int min, int max) {
+        return RANDOM.nextInt(min, max);
     }
 
     public static DbPublicationDate randomPublicationDate() {
@@ -80,7 +85,7 @@ public final class TestUtils {
 
     public static LocalDate randomLocalDate() {
         var daysBetween = ChronoUnit.DAYS.between(START_DATE, LocalDate.now());
-        var randomDays = new Random().nextInt((int) daysBetween);
+        var randomDays = RANDOM.nextInt((int) daysBetween);
 
         return START_DATE.plusDays(randomDays);
     }
@@ -101,17 +106,17 @@ public final class TestUtils {
 
     public static InstanceType randomInstanceType() {
         var instanceTypes = Arrays.stream(InstanceType.values()).toList();
-        return instanceTypes.get(new Random().nextInt(instanceTypes.size()));
+        return instanceTypes.get(RANDOM.nextInt(instanceTypes.size()));
     }
 
     public static InstanceType randomInstanceTypeExcluding(InstanceType instanceType) {
         var instanceTypes = Arrays.stream(InstanceType.values()).filter(type -> !type.equals(instanceType)).toList();
-        return instanceTypes.get(new Random().nextInt(instanceTypes.size()));
+        return instanceTypes.get(RANDOM.nextInt(instanceTypes.size()));
     }
 
     public static DbLevel randomLevelExcluding(DbLevel level) {
         var levels = Arrays.stream(DbLevel.values()).filter(type -> !type.equals(level)).toList();
-        return levels.get(new Random().nextInt(levels.size()));
+        return levels.get(RANDOM.nextInt(levels.size()));
     }
 
     public static String randomYear() {


### PR DESCRIPTION
Jira task: [Creator shares (forfatterandeler) should not be counted for unverified affiliations](https://unit.atlassian.net/browse/NP-45535)

Creator share count changed from:
`(Number of combinations of author and affiliations) + (number of authors with without affiliations)`
to:
`(Number of combinations of author and verified affiliations) + (number of authors (with only unverified affiliations OR without affiliations))`

(Also changed failFast = false in java conventions)