### PR TITLE
Fix FetchReportHandler path parameter

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -525,12 +525,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Problem"
-  /report/{institutionId+}:
+  /report/{institutionId}:
     get:
       description: 'Get NVI report for a given institution'
       parameters:
         - in: path
-          name: institutionId+
+          name: institutionId
           description: The identifier of a top level organization in Cristin proxy. This must be a UTF-8 encoded URI
           required: true
           schema:

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchReportHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchReportHandler.java
@@ -30,7 +30,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 public class FetchReportHandler extends ApiGatewayHandler<Void, String> {
 
     public static final Encoder ENCODER = Base64.getEncoder();
-    private static final String INSTITUTION_IDENTIFIER = "institutionIdentifier";
+    private static final String INSTITUTION_ID = "institutionId";
     private final CandidateRepository candidateRepository;
     private final PeriodRepository periodRepository;
 
@@ -71,7 +71,7 @@ public class FetchReportHandler extends ApiGatewayHandler<Void, String> {
     }
 
     private static URI decodeInstitutionIdentifierPath(RequestInfo requestInfo) {
-        return URI.create(URLDecoder.decode(requestInfo.getPathParameter(INSTITUTION_IDENTIFIER), UTF_8));
+        return URI.create(URLDecoder.decode(requestInfo.getPathParameter(INSTITUTION_ID), UTF_8));
     }
 
     private static void validateRequest(URI requestedInstitution, RequestInfo requestInfo)

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/model/Excel.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/model/Excel.java
@@ -44,16 +44,6 @@ public final class Excel implements AutoCloseable {
         return new Excel(workbook);
     }
 
-    private static <T> void addSheetComponent(RecordComponent[] recordComponents, T record, XSSFRow row, int columnIndex) {
-        var recordComponent = recordComponents[columnIndex];
-        var cell = row.createCell(columnIndex);
-        addValueToCell(recordComponent, record, cell);
-    }
-
-    private static void addHeaderRow(RecordComponent[] recordComponents, XSSFRow headerRow, int colIndex) {
-        headerRow.createCell(colIndex).setCellValue(getHeaderValue(recordComponents[colIndex]));
-    }
-
     public void write(OutputStream outputStream) throws IOException {
         workbook.write(outputStream);
         workbook.close();
@@ -62,6 +52,17 @@ public final class Excel implements AutoCloseable {
     @Override
     public void close() throws Exception {
         workbook.close();
+    }
+
+    private static <T> void addSheetComponent(RecordComponent[] recordComponents, T record, XSSFRow row,
+                                              int columnIndex) {
+        var recordComponent = recordComponents[columnIndex];
+        var cell = row.createCell(columnIndex);
+        addValueToCell(recordComponent, record, cell);
+    }
+
+    private static void addHeaderRow(RecordComponent[] recordComponents, XSSFRow headerRow, int colIndex) {
+        headerRow.createCell(colIndex).setCellValue(getHeaderValue(recordComponents[colIndex]));
     }
 
     private static String getHeaderValue(RecordComponent recordComponent) {

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportHandlerTest.java
@@ -53,7 +53,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 class FetchReportHandlerTest extends LocalDynamoTest {
 
-    private static final String INSTITUTION_IDENTIFIER = "institutionIdentifier";
+    private static final String INSTITUTION_ID = "institutionId";
     private static final String YEAR = "year";
     private static final int CURRENT_YEAR = Year.now().getValue();
     private static final Context CONTEXT = mock(Context.class);
@@ -153,7 +153,7 @@ class FetchReportHandlerTest extends LocalDynamoTest {
                    .withAccessRights(customerId, accessRight)
                    .withUserName(randomString())
                    .withPathParameters(Map.of(CANDIDATE_IDENTIFIER, candidateIdentifier.toString(),
-                                              INSTITUTION_IDENTIFIER,
+                                              INSTITUTION_ID,
                                               URLEncoder.encode(institutionId.toString(), StandardCharsets.UTF_8),
                                               YEAR, String.valueOf(year)));
     }

--- a/template.yaml
+++ b/template.yaml
@@ -623,7 +623,7 @@ Resources:
         GetEvent:
           Type: Api
           Properties:
-            Path: /report/{institutionId+}
+            Path: /report/{institutionId}
             Method: get
             RestApiId: !Ref ScientificIndexApi
 


### PR DESCRIPTION
Rename path parameter institutionIdentifier to institutionId in FetchReportHandler. Remove plus sign from open api spec and handler, not necessary