### PR TITLE
Np 45666 Secondary index: SearchByYear

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/DatabaseConstants.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/DatabaseConstants.java
@@ -1,20 +1,17 @@
 package no.sikt.nva.nvi.common;
 
-import nva.commons.core.JacocoGenerated;
-
-@JacocoGenerated
 public final class DatabaseConstants {
-
-
     public static final String HASH_KEY = "PrimaryKeyHashKey";
     public static final String SORT_KEY = "PrimaryKeyRangeKey";
     public static final String SECONDARY_INDEX_1_HASH_KEY = "SecondaryIndex1HashKey";
     public static final String SECONDARY_INDEX_1_RANGE_KEY = "SecondaryIndex1RangeKey";
     public static final String SECONDARY_INDEX_PUBLICATION_ID = "SearchByPublicationId";
+    public static final String SECONDARY_INDEX_YEAR = "SearchByYear";
+    public static final String SECONDARY_INDEX_YEAR_HASH_KEY = "SearchByYearHashKey";
+    public static final String SECONDARY_INDEX_YEAR_RANGE_KEY = "SearchByYearRangeKey";
     public static final String DATA_FIELD = "data";
 
     private DatabaseConstants() {
 
     }
-
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -91,7 +91,7 @@ public record CandidateDao(
     @DynamoDbSecondarySortKey(indexNames = {SECONDARY_INDEX_YEAR})
     @DynamoDbAttribute(SECONDARY_INDEX_YEAR_RANGE_KEY)
     public String searchByYearSortKey() {
-        return nonNull(candidate.publicationDate()) ? candidate.publicationDate().year() : null;
+        return nonNull(identifier) ? identifier.toString() : null;
     }
 
     @DynamoDbIgnore

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -6,6 +6,9 @@ import static no.sikt.nva.nvi.common.DatabaseConstants.HASH_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_1_HASH_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_1_RANGE_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_PUBLICATION_ID;
+import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR;
+import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_HASH_KEY;
+import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_RANGE_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SORT_KEY;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -77,6 +80,20 @@ public record CandidateDao(
         return nonNull(candidate.publicationId()) ? candidate.publicationId().toString() : null;
     }
 
+    @JacocoGenerated
+    @DynamoDbSecondaryPartitionKey(indexNames = {SECONDARY_INDEX_YEAR})
+    @DynamoDbAttribute(SECONDARY_INDEX_YEAR_HASH_KEY)
+    public String searchByYearHashKey() {
+        return nonNull(candidate.publicationDate()) ? candidate.publicationDate().year() : null;
+    }
+
+    @JacocoGenerated
+    @DynamoDbSecondarySortKey(indexNames = {SECONDARY_INDEX_YEAR})
+    @DynamoDbAttribute(SECONDARY_INDEX_YEAR_RANGE_KEY)
+    public String searchByYearSortKey() {
+        return nonNull(candidate.publicationDate()) ? candidate.publicationDate().year() : null;
+    }
+
     @DynamoDbIgnore
     public CandidateDao.Builder copy() {
         return builder()
@@ -143,6 +160,16 @@ public record CandidateDao(
         }
 
         public Builder searchByPublicationIdSortKey(String noop) {
+            // Used by @DynamoDbImmutable for building the object
+            return this;
+        }
+
+        public Builder searchByYearHashKey(String noop) {
+            // Used by @DynamoDbImmutable for building the object
+            return this;
+        }
+
+        public Builder searchByYearSortKey(String noop) {
             // Used by @DynamoDbImmutable for building the object
             return this;
         }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -4,8 +4,10 @@ import static java.util.Objects.nonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toMap;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_PUBLICATION_ID;
+import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR;
 import static no.sikt.nva.nvi.common.utils.ApplicationConstants.NVI_TABLE_NAME;
 import static software.amazon.awssdk.enhanced.dynamodb.TableSchema.fromImmutableClass;
+import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo;
 import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.sortBeginsWith;
 import java.net.URI;
 import java.time.Instant;
@@ -30,6 +32,7 @@ import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
 import software.amazon.awssdk.enhanced.dynamodb.Key;
 import software.amazon.awssdk.enhanced.dynamodb.model.Page;
 import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactPutItemEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest;
 import software.amazon.awssdk.enhanced.dynamodb.model.TransactWriteItemsEnhancedRequest.Builder;
@@ -49,10 +52,12 @@ public class CandidateRepository extends DynamoRepository {
     private static final String CANDIDATE_UNIQUENESS_ENTRY = "CandidateUniquenessEntry";
     protected final DynamoDbTable<CandidateDao> candidateTable;
     protected final DynamoDbTable<CandidateUniquenessEntryDao> uniquenessTable;
-    private final DynamoDbIndex<CandidateDao> publicationIdIndex;
     protected final DynamoDbTable<ApprovalStatusDao> approvalStatusTable;
     protected final DynamoDbTable<NoteDao> noteTable;
     protected final DynamoDbTable<NviPeriodDao> periodTable;
+    private final DynamoDbIndex<CandidateDao> publicationIdIndex;
+
+    private final DynamoDbIndex<CandidateDao> yearIndex;
     private final DynamoDbRetryWrapper dynamoDbRetryClient;
 
     public CandidateRepository(DynamoDbClient client) {
@@ -60,6 +65,7 @@ public class CandidateRepository extends DynamoRepository {
         this.candidateTable = this.client.table(NVI_TABLE_NAME, fromImmutableClass(CandidateDao.class));
         this.uniquenessTable = this.client.table(NVI_TABLE_NAME, fromImmutableClass(CandidateUniquenessEntryDao.class));
         this.publicationIdIndex = this.candidateTable.index(SECONDARY_INDEX_PUBLICATION_ID);
+        this.yearIndex = this.candidateTable.index(SECONDARY_INDEX_YEAR);
         this.approvalStatusTable = this.client.table(NVI_TABLE_NAME, fromImmutableClass(ApprovalStatusDao.class));
         this.noteTable = this.client.table(NVI_TABLE_NAME, fromImmutableClass(NoteDao.class));
         this.periodTable = this.client.table(NVI_TABLE_NAME, fromImmutableClass(NviPeriodDao.class));
@@ -76,69 +82,19 @@ public class CandidateRepository extends DynamoRepository {
         var items = scan.items().stream().map(this::mutateVersion).toList();
 
         var count = getBatches(items).map(this::toBatchRequest)
-                .map(dynamoDbRetryClient::batchWriteItem)
-                .mapToInt(Integer::intValue)
-                .sum();
+                        .map(dynamoDbRetryClient::batchWriteItem)
+                        .mapToInt(Integer::intValue)
+                        .sum();
 
         return new ListingResult(thereAreMorePagesToScan(scan), toStringMap(scan.lastEvaluatedKey()), count);
     }
 
-
-    private Map<String, AttributeValue> mutateVersion(Map<String, AttributeValue> item) {
-        var mutableMap = new HashMap<>(item);
-        mutableMap.put(DynamoEntryWithRangeKey.VERSION_FIELD_NAME,
-                       AttributeValue.builder().s(randomUUID().toString()).build());
-        return mutableMap;
-    }
-
-    private boolean thereAreMorePagesToScan(ScanResponse scanResult) {
-        return nonNull(scanResult.lastEvaluatedKey()) && !scanResult.lastEvaluatedKey().isEmpty();
-    }
-
-    private static <T> Stream<List<T>> getBatches(List<T> scanResult) {
-        var count = scanResult.size();
-        return IntStream.range(0, (count + BATCH_SIZE - 1) / BATCH_SIZE)
-                   .mapToObj(i -> scanResult.subList(i * BATCH_SIZE, Math.min((i + 1) * BATCH_SIZE, count)));
-    }
-
-    private BatchWriteItemRequest toBatchRequest(List<Map<String, AttributeValue>> results) {
-        return BatchWriteItemRequest.builder().requestItems(Map.of(NVI_TABLE_NAME, toWriteBatches(results))).build();
-    }
-
-    private Collection<WriteRequest> toWriteBatches(List<Map<String, AttributeValue>> results) {
-        return results.stream().map(this::toWriteRequest).toList();
-    }
-
-    private WriteRequest toWriteRequest(Map<String, AttributeValue> dao) {
-        return WriteRequest.builder().putRequest(toPutRequest(dao)).build();
-    }
-
-    private PutRequest toPutRequest(Map<String, AttributeValue> dao) {
-        return PutRequest.builder().item(dao).build();
-    }
-
-    private ScanRequest createScanRequest(int pageSize, Map<String, String> startMarker) {
-        var start = nonNull(startMarker) ? toAttributeMap(startMarker) : null;
-        return ScanRequest.builder()
-                   .tableName(NVI_TABLE_NAME)
-                   .filterExpression("not contains (#PK, :TYPE) ")
-                   .expressionAttributeNames(Map.of("#PK", PRIMARY_KEY_HASH_KEY))
-                   .expressionAttributeValues(Map.of(":TYPE", AttributeValue.fromS(CANDIDATE_UNIQUENESS_ENTRY)))
-                   .exclusiveStartKey(start)
-                   .limit(pageSize)
-                   .build();
-    }
-
-    private static Map<String, AttributeValue> toAttributeMap(Map<String, String> startMarker) {
-        return startMarker.entrySet()
+    public List<CandidateDao> fetchCandidatesByYear(int year, int pageSize, Map<String, String> startMarker) {
+        return this.yearIndex.query(createQuery(year, pageSize, startMarker))
                    .stream()
-                   .collect(toMap(Map.Entry::getKey, e -> AttributeValue.builder().s(e.getValue()).build()));
-    }
-
-    private static Map<String, String> toStringMap(Map<String, AttributeValue> startMarker) {
-        return startMarker.entrySet()
-                   .stream()
-                   .collect(toMap(Map.Entry::getKey, e -> e.getValue().s()));
+                   .map(Page::items)
+                   .flatMap(Collection::stream)
+                   .toList();
     }
 
     public Candidate create(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses) {
@@ -277,6 +233,36 @@ public class CandidateRepository extends DynamoRepository {
         }
     }
 
+    protected static Key noteKey(UUID candidateIdentifier, UUID noteIdentifier) {
+        return Key.builder()
+                   .partitionValue(CandidateDao.createPartitionKey(candidateIdentifier.toString()))
+                   .sortValue(NoteDao.createSortKey(noteIdentifier.toString()))
+                   .build();
+    }
+
+    protected static QueryConditional queryCandidateParts(UUID id, String type) {
+        return sortBeginsWith(
+            Key.builder().partitionValue(CandidateDao.createPartitionKey(id.toString())).sortValue(type).build());
+    }
+
+    private static <T> Stream<List<T>> getBatches(List<T> scanResult) {
+        var count = scanResult.size();
+        return IntStream.range(0, (count + BATCH_SIZE - 1) / BATCH_SIZE)
+                   .mapToObj(i -> scanResult.subList(i * BATCH_SIZE, Math.min((i + 1) * BATCH_SIZE, count)));
+    }
+
+    private static Map<String, AttributeValue> toAttributeMap(Map<String, String> startMarker) {
+        return startMarker.entrySet()
+                   .stream()
+                   .collect(toMap(Map.Entry::getKey, e -> AttributeValue.builder().s(e.getValue()).build()));
+    }
+
+    private static Map<String, String> toStringMap(Map<String, AttributeValue> startMarker) {
+        return startMarker.entrySet()
+                   .stream()
+                   .collect(toMap(Map.Entry::getKey, e -> e.getValue().s()));
+    }
+
     private static ApprovalStatusDao mapToApprovalStatusDao(UUID identifier, DbApprovalStatus approval) {
         return ApprovalStatusDao.builder().identifier(identifier).approvalStatus(approval).build();
     }
@@ -314,29 +300,68 @@ public class CandidateRepository extends DynamoRepository {
     }
 
     private static QueryConditional findCandidateByPublicationIdQuery(URI publicationId) {
-        return QueryConditional.keyEqualTo(candidateByPublicationIdKey(publicationId));
+        return keyEqualTo(candidateByPublicationIdKey(publicationId));
     }
 
     private static Key candidateByPublicationIdKey(URI publicationId) {
         return Key.builder().partitionValue(publicationId.toString()).sortValue(publicationId.toString()).build();
     }
 
-    protected static Key noteKey(UUID candidateIdentifier, UUID noteIdentifier) {
-        return Key.builder()
-                   .partitionValue(CandidateDao.createPartitionKey(candidateIdentifier.toString()))
-                   .sortValue(NoteDao.createSortKey(noteIdentifier.toString()))
-                   .build();
-    }
-
-    protected static QueryConditional queryCandidateParts(UUID id, String type) {
-        return sortBeginsWith(
-            Key.builder().partitionValue(CandidateDao.createPartitionKey(id.toString())).sortValue(type).build());
-    }
-
     private static <T> TransactPutItemEnhancedRequest<T> insertTransaction(T insert, Class<T> clazz) {
         return TransactPutItemEnhancedRequest.builder(clazz)
                    .item(insert)
                    .conditionExpression(uniquePrimaryKeysExpression())
+                   .build();
+    }
+
+    private QueryEnhancedRequest createQuery(int year, int pageSize, Map<String, String> startMarker) {
+        var start = nonNull(startMarker) ? toAttributeMap(startMarker) : null;
+        return QueryEnhancedRequest.builder()
+                   .queryConditional(keyEqualTo(Key.builder()
+                                                    .partitionValue(String.valueOf(year))
+                                                    .sortValue(String.valueOf(year))
+                                                    .build()))
+                   .limit(pageSize)
+                   .exclusiveStartKey(start)
+                   .build();
+    }
+
+    private Map<String, AttributeValue> mutateVersion(Map<String, AttributeValue> item) {
+        var mutableMap = new HashMap<>(item);
+        mutableMap.put(DynamoEntryWithRangeKey.VERSION_FIELD_NAME,
+                       AttributeValue.builder().s(randomUUID().toString()).build());
+        return mutableMap;
+    }
+
+    private boolean thereAreMorePagesToScan(ScanResponse scanResult) {
+        return nonNull(scanResult.lastEvaluatedKey()) && !scanResult.lastEvaluatedKey().isEmpty();
+    }
+
+    private BatchWriteItemRequest toBatchRequest(List<Map<String, AttributeValue>> results) {
+        return BatchWriteItemRequest.builder().requestItems(Map.of(NVI_TABLE_NAME, toWriteBatches(results))).build();
+    }
+
+    private Collection<WriteRequest> toWriteBatches(List<Map<String, AttributeValue>> results) {
+        return results.stream().map(this::toWriteRequest).toList();
+    }
+
+    private WriteRequest toWriteRequest(Map<String, AttributeValue> dao) {
+        return WriteRequest.builder().putRequest(toPutRequest(dao)).build();
+    }
+
+    private PutRequest toPutRequest(Map<String, AttributeValue> dao) {
+        return PutRequest.builder().item(dao).build();
+    }
+
+    private ScanRequest createScanRequest(int pageSize, Map<String, String> startMarker) {
+        var start = nonNull(startMarker) ? toAttributeMap(startMarker) : null;
+        return ScanRequest.builder()
+                   .tableName(NVI_TABLE_NAME)
+                   .filterExpression("not contains (#PK, :TYPE) ")
+                   .expressionAttributeNames(Map.of("#PK", PRIMARY_KEY_HASH_KEY))
+                   .expressionAttributeValues(Map.of(":TYPE", AttributeValue.fromS(CANDIDATE_UNIQUENESS_ENTRY)))
+                   .exclusiveStartKey(start)
+                   .limit(pageSize)
                    .build();
     }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -1,15 +1,21 @@
 package no.sikt.nva.nvi.common.db;
 
-import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
+import static no.sikt.nva.nvi.test.TestUtils.randomIntBetween;
+import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
+import java.util.stream.IntStream;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.sikt.nva.nvi.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,7 +41,7 @@ class CandidateRepositoryTest extends LocalDynamoTest {
 
     @Test
     public void shouldOverwriteExistingCandidateWhenUpdating() {
-        var originalCandidate = randomCandidate();
+        var originalCandidate = TestUtils.randomCandidate();
         var created = candidateRepository.create(originalCandidate, List.of());
         var newCandidate = originalCandidate.copy().publicationBucketUri(randomUri()).build();
         candidateRepository.update(created.identifier(), newCandidate, List.of());
@@ -46,5 +52,28 @@ class CandidateRepositoryTest extends LocalDynamoTest {
         assertThat(fetched, is(equalTo(newCandidate)));
     }
 
+    @Test
+    void shouldFetchCandidatesByGivenYearAndPageSizeAndStartMarker() {
+        int year = Integer.parseInt(randomYear());
+        int numberOfCandidates = randomIntBetween(1, 10);
+        var candidates = createNumberOfCandidatesForYear(year, numberOfCandidates);
+        var results = candidateRepository.fetchCandidatesByYear(year, 5, null);
+        assertThat(results.size(), is(equalTo(numberOfCandidates)));
+        assertThat(results, containsInAnyOrder(candidates.toArray()));
+    }
 
+    private static DbCandidate randomCandidate(int year) {
+        return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
+    }
+
+    private static DbPublicationDate publicationDate(int year) {
+        return new DbPublicationDate(String.valueOf(year), null, null);
+    }
+
+    private List<CandidateDao> createNumberOfCandidatesForYear(int year, int number) {
+        return IntStream.range(0, number)
+                   .mapToObj(i -> randomCandidate(year))
+                   .map(candidate -> candidateRepository.createDao(candidate, List.of()))
+                   .toList();
+    }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -60,11 +60,12 @@ class CandidateRepositoryTest extends LocalDynamoTest {
 
     @Test
     void shouldFetchCandidatesByGivenYearAndPageSize() {
-        int year = Integer.parseInt(randomYear());
-        var candidates = createNumberOfCandidatesForYear(year, 10);
+        int searchYear = Integer.parseInt(randomYear());
+        var candidates = createNumberOfCandidatesForYear(searchYear, 10);
+        createNumberOfCandidatesForYear(Integer.parseInt(randomYear()), 10);
         int pageSize = 5;
         var expectedCandidates = sortByIdentifier(candidates, pageSize);
-        var results = candidateRepository.fetchCandidatesByYear(year, pageSize, null);
+        var results = candidateRepository.fetchCandidatesByYear(searchYear, pageSize, null);
         assertThat(results.size(), is(equalTo(pageSize)));
         assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -9,6 +9,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.Comparator;
 import java.util.List;
@@ -73,10 +74,12 @@ class CandidateRepositoryTest extends LocalDynamoTest {
         int year = Integer.parseInt(randomYear());
         var candidates = createNumberOfCandidatesForYear(year, 2);
         var expectedCandidates = sortByIdentifier(candidates, DEFAULT_PAGE_SIZE);
-        var startMarker = getStartMarker(expectedCandidates.get(0));
+        var firstCandidateInIndex = expectedCandidates.get(0);
+        var secondCandidateInIndex = expectedCandidates.get(1);
+        var startMarker = getStartMarker(firstCandidateInIndex);
         var results = candidateRepository.fetchCandidatesByYear(year, null, startMarker);
         assertThat(results.size(), is(equalTo(1)));
-        assertThat(expectedCandidates.subList(1, 2), containsInAnyOrder(results.toArray()));
+        assertEquals(secondCandidateInIndex, results.get(0));
     }
 
     @Test

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/LocalDynamoTest.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/LocalDynamoTest.java
@@ -4,6 +4,9 @@ import static no.sikt.nva.nvi.common.DatabaseConstants.HASH_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_1_HASH_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_1_RANGE_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_PUBLICATION_ID;
+import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR;
+import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_HASH_KEY;
+import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_RANGE_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SORT_KEY;
 import static no.sikt.nva.nvi.common.utils.ApplicationConstants.NVI_TABLE_NAME;
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
@@ -29,14 +32,13 @@ import software.amazon.awssdk.services.dynamodb.model.TableStatus;
 
 public class LocalDynamoTest {
 
-    protected DynamoDbClient localDynamo;
-    private static final Long CAPACITY_DOES_NOT_MATTER = 1000L;
     public static final int SINGLE_TABLE_EXPECTED = 1;
+    private static final Long CAPACITY_DOES_NOT_MATTER = 1000L;
+    protected DynamoDbClient localDynamo;
 
     public DynamoDbClient initializeTestDatabase() {
 
         var localDynamo = DynamoDBEmbedded.create().dynamoDbClient();
-
 
         var tableName = NVI_TABLE_NAME;
         var createTableResult = createTable(localDynamo, tableName);
@@ -49,6 +51,10 @@ public class LocalDynamoTest {
         var tables = localDynamo.listTables();
         Assertions.assertEquals(SINGLE_TABLE_EXPECTED, tables.tableNames().size());
         return localDynamo;
+    }
+
+    protected ScanResponse scanDB() {
+        return localDynamo.scan(ScanRequest.builder().tableName(NVI_TABLE_NAME).build());
     }
 
     private static CreateTableResponse createTable(DynamoDbClient client, String tableName) {
@@ -65,7 +71,10 @@ public class LocalDynamoTest {
                 .globalSecondaryIndexes(
                     newGsi(SECONDARY_INDEX_PUBLICATION_ID,
                            SECONDARY_INDEX_1_HASH_KEY,
-                           SECONDARY_INDEX_1_RANGE_KEY)
+                           SECONDARY_INDEX_1_RANGE_KEY),
+                    newGsi(SECONDARY_INDEX_YEAR,
+                           SECONDARY_INDEX_YEAR_HASH_KEY,
+                           SECONDARY_INDEX_YEAR_RANGE_KEY)
                 )
                 .build();
 
@@ -87,6 +96,8 @@ public class LocalDynamoTest {
         attributeDefinitions.add(createAttributeDefinition(SORT_KEY));
         attributeDefinitions.add(createAttributeDefinition(SECONDARY_INDEX_1_HASH_KEY));
         attributeDefinitions.add(createAttributeDefinition(SECONDARY_INDEX_1_RANGE_KEY));
+        attributeDefinitions.add(createAttributeDefinition(SECONDARY_INDEX_YEAR_HASH_KEY));
+        attributeDefinitions.add(createAttributeDefinition(SECONDARY_INDEX_YEAR_RANGE_KEY));
         return attributeDefinitions;
     }
 
@@ -103,18 +114,16 @@ public class LocalDynamoTest {
                    .build();
     }
 
-    private static GlobalSecondaryIndex newGsi(String searchUsersByInstitutionIndexName,
-                                               String secondaryIndex1HashKey,
-                                               String secondaryIndex1RangeKey) {
-        ProvisionedThroughput provisionedthroughput = provisionedThroughputForLocalDatabase();
+    private static GlobalSecondaryIndex newGsi(String indexName,
+                                               String hashKey,
+                                               String rangeKey) {
+        var provisionedthroughput = provisionedThroughputForLocalDatabase();
 
         return GlobalSecondaryIndex
                    .builder()
-                   .indexName(searchUsersByInstitutionIndexName)
-                   .keySchema(
-                       KeySchemaElement.builder().attributeName(secondaryIndex1HashKey).keyType(KeyType.HASH).build(),
-                       KeySchemaElement.builder().attributeName(secondaryIndex1RangeKey).keyType(KeyType.RANGE).build()
-                   )
+                   .indexName(indexName)
+                   .keySchema(KeySchemaElement.builder().attributeName(hashKey).keyType(KeyType.HASH).build(),
+                              KeySchemaElement.builder().attributeName(rangeKey).keyType(KeyType.RANGE).build())
                    .projection(Projection.builder().projectionType(ProjectionType.ALL).build())
                    .provisionedThroughput(provisionedthroughput)
                    .build();
@@ -124,10 +133,4 @@ public class LocalDynamoTest {
         MatcherAssert.assertThat(tableKeySchema.toString(), StringContains.containsString(HASH_KEY));
         MatcherAssert.assertThat(tableKeySchema.toString(), StringContains.containsString(SORT_KEY));
     }
-
-    protected ScanResponse scanDB() {
-        return localDynamo.scan(ScanRequest.builder().tableName(NVI_TABLE_NAME).build());
-    }
-
-
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -120,7 +120,7 @@ public final class TestUtils {
     }
 
     public static String randomYear() {
-        return String.valueOf(randomInteger(3000));
+        return String.valueOf(randomIntBetween(START_DATE.getYear(), LocalDate.now().getYear()));
     }
 
     public static DbCandidate randomCandidate() {

--- a/template.yaml
+++ b/template.yaml
@@ -646,6 +646,10 @@ Resources:
           AttributeType: S
         - AttributeName: SecondaryIndex1RangeKey
           AttributeType: S
+        - AttributeName: SearchByYearHashKey
+          AttributeType: S
+        - AttributeName: SearchByYearRangeKey
+          AttributeType: S
       KeySchema:
         - AttributeName: PrimaryKeyHashKey
           KeyType: HASH
@@ -657,6 +661,14 @@ Resources:
             - AttributeName: SecondaryIndex1HashKey
               KeyType: HASH
             - AttributeName: SecondaryIndex1RangeKey
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+        - IndexName: SearchByYear
+          KeySchema:
+            - AttributeName: SearchByYearHashKey
+              KeyType: HASH
+            - AttributeName: SearchByYearRangeKey
               KeyType: RANGE
           Projection:
             ProjectionType: ALL


### PR DESCRIPTION
Jira task: [Tool for re-evaluating nvi candidates](https://unit.atlassian.net/browse/NP-45666)

New access pattern needed in DB: _Get all candidates published in given year_

- Added a new secondary index: SearchByYear
- Added method in CandidateRepository to fetch candidates for a given year with `startMarker` and `pageSize` (for pagination)