### PR TITLE
Remove lambda onSuccess destinations

### DIFF
--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -54,7 +54,7 @@ test {
     environment("NVI_TABLE_NAME", "some-table")
     environment("CUSTOM_DOMAIN_BASE_PATH", "scientific-index")
     environment("UPSERT_CANDIDATE_DLQ_QUEUE_URL", "UpsertCandidateDLQ")
-    environment("QUEUE_PERSISTED_RESOURCE_QUEUE_URL", "PersistedResourceQueue")
+    environment("PERSISTED_RESOURCE_QUEUE_URL", "PersistedResourceQueue")
     environment "EXPANDED_RESOURCES_BUCKET", "ignoredBucket"
     environment "BACKEND_CLIENT_AUTH_URL", "My url"
     environment "BACKEND_CLIENT_SECRET_NAME", "My secret name"

--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -54,6 +54,7 @@ test {
     environment("NVI_TABLE_NAME", "some-table")
     environment("CUSTOM_DOMAIN_BASE_PATH", "scientific-index")
     environment("UPSERT_CANDIDATE_DLQ_QUEUE_URL", "UpsertCandidateDLQ")
+    environment("QUEUE_PERSISTED_RESOURCE_QUEUE_URL", "PersistedResourceQueue")
     environment "EXPANDED_RESOURCES_BUCKET", "ignoredBucket"
     environment "BACKEND_CLIENT_AUTH_URL", "My url"
     environment "BACKEND_CLIENT_SECRET_NAME", "My secret name"

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandler.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 
 public class QueuePersistedResourceHandler extends DestinationsEventBridgeEventHandler<EventReference, Void> {
 
-    public static final String QUEUE_PERSISTED_RESOURCE_QUEUE_URL = "QUEUE_PERSISTED_RESOURCE_QUEUE_URL";
+    public static final String QUEUE_PERSISTED_RESOURCE_QUEUE_URL = "PERSISTED_RESOURCE_QUEUE_URL";
     private static final Logger LOGGER = LoggerFactory.getLogger(QueuePersistedResourceHandler.class);
     private static final String ERROR_MSG = "Invalid EventReference, missing uri: %s";
     private final QueueClient<NviSendMessageResponse> queueClient;

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandler.java
@@ -24,8 +24,8 @@ import org.slf4j.LoggerFactory;
 
 public class EvaluateNviCandidateHandler implements RequestHandler<SQSEvent, Void> {
 
-    public static final String EVALUATED_CANDIDATE_QUEUE_URL = "EVALUATED_CANDIDATE_QUEUE_URL";
     private static final Logger LOGGER = LoggerFactory.getLogger(EvaluateNviCandidateHandler.class);
+    private static final String EVALUATED_CANDIDATE_QUEUE_URL = "CANDIDATE_QUEUE_URL";
     private static final String BACKEND_CLIENT_AUTH_URL = "BACKEND_CLIENT_AUTH_URL";
     private static final String BACKEND_CLIENT_SECRET_NAME = "BACKEND_CLIENT_SECRET_NAME";
     private static final String EVALUATION_MESSAGE = "Nvi candidacy has been evaluated for publication: {}. Type: {}";

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandler.java
@@ -6,8 +6,10 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
-import java.util.List;
 import no.sikt.nva.nvi.common.S3StorageReader;
+import no.sikt.nva.nvi.common.queue.NviQueueClient;
+import no.sikt.nva.nvi.common.queue.NviSendMessageResponse;
+import no.sikt.nva.nvi.common.queue.QueueClient;
 import no.sikt.nva.nvi.events.evaluator.calculator.CandidateCalculator;
 import no.sikt.nva.nvi.events.evaluator.calculator.OrganizationRetriever;
 import no.sikt.nva.nvi.events.evaluator.calculator.PointCalculator;
@@ -20,34 +22,43 @@ import nva.commons.core.attempt.Failure;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class EvaluateNviCandidateHandler implements RequestHandler<SQSEvent, SQSEvent> {
+public class EvaluateNviCandidateHandler implements RequestHandler<SQSEvent, Void> {
 
+    public static final String EVALUATED_CANDIDATE_QUEUE_URL = "EVALUATED_CANDIDATE_QUEUE_URL";
     private static final Logger LOGGER = LoggerFactory.getLogger(EvaluateNviCandidateHandler.class);
     private static final String BACKEND_CLIENT_AUTH_URL = "BACKEND_CLIENT_AUTH_URL";
     private static final String BACKEND_CLIENT_SECRET_NAME = "BACKEND_CLIENT_SECRET_NAME";
     private static final String EVALUATION_MESSAGE = "Nvi candidacy has been evaluated for publication: {}. Type: {}";
     private static final String FAILURE_MESSAGE = "Failure while calculating NVI Candidate: %s, ex: %s, msg: %s";
     private final EvaluatorService evaluatorService;
+    private final QueueClient<NviSendMessageResponse> queueClient;
+    private final String queueUrl;
 
     @JacocoGenerated
     public EvaluateNviCandidateHandler() {
         this(new EvaluatorService(new S3StorageReader(new Environment().readEnv("EXPANDED_RESOURCES_BUCKET")),
                                   new CandidateCalculator(defaultUriRetriever(new Environment())),
                                   new PointCalculator(
-                                      new OrganizationRetriever(defaultUriRetriever(new Environment())))));
+                                      new OrganizationRetriever(defaultUriRetriever(new Environment())))),
+             new NviQueueClient(), new Environment());
     }
 
-    public EvaluateNviCandidateHandler(EvaluatorService evaluatorService) {
+    public EvaluateNviCandidateHandler(EvaluatorService evaluatorService,
+                                       QueueClient<NviSendMessageResponse> queueClient,
+                                       Environment environment) {
         this.evaluatorService = evaluatorService;
+        this.queueClient = queueClient;
+        this.queueUrl = environment.readEnv(EVALUATED_CANDIDATE_QUEUE_URL);
     }
 
     @Override
-    public SQSEvent handleRequest(SQSEvent input, Context context) {
-        return attempt(() -> createEvent(evaluateCandidacy(extractPersistedResourceMessage(input)))).orElseThrow(
+    public Void handleRequest(SQSEvent input, Context context) {
+        attempt(() -> sendEvent(evaluateCandidacy(extractPersistedResourceMessage(input)))).orElseThrow(
             failure -> handleFailure(input, failure));
+        return null;
     }
 
-    private static RuntimeException handleFailure(SQSEvent input, Failure<SQSEvent> failure) {
+    private static RuntimeException handleFailure(SQSEvent input, Failure<NviSendMessageResponse> failure) {
         LOGGER.error(String.format(FAILURE_MESSAGE, input.toString(), failure.getException(),
                                    failure.getException().getMessage()));
         return new RuntimeException(failure.getException());
@@ -59,21 +70,13 @@ public class EvaluateNviCandidateHandler implements RequestHandler<SQSEvent, SQS
                                                  env.readEnv(BACKEND_CLIENT_SECRET_NAME));
     }
 
-    private static SQSEvent createEvent(CandidateEvaluatedMessage messageBody) {
-        var event = new SQSEvent();
-        event.setRecords(
-            List.of(createMessage(attempt(() -> dtoObjectMapper.writeValueAsString(messageBody)).orElseThrow())));
-        return event;
-    }
-
-    private static SQSMessage createMessage(String messageBody) {
-        var message = new SQSMessage();
-        message.setBody(messageBody);
-        return message;
-    }
-
     private static PersistedResourceMessage parseBody(String body) {
         return attempt(() -> dtoObjectMapper.readValue(body, PersistedResourceMessage.class)).orElseThrow();
+    }
+
+    private NviSendMessageResponse sendEvent(CandidateEvaluatedMessage candidateEvaluatedMessage) {
+        var messageBody = attempt(() -> dtoObjectMapper.writeValueAsString(candidateEvaluatedMessage)).orElseThrow();
+        return queueClient.sendMessage(messageBody, queueUrl);
     }
 
     private PersistedResourceMessage extractPersistedResourceMessage(SQSEvent input) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 public class QueuePersistedResourceHandlerTest {
 
     private static final Environment environment = new Environment();
-    private static final String queueUrl = environment.readEnv("QUEUE_PERSISTED_RESOURCE_QUEUE_URL");
+    private static final String queueUrl = environment.readEnv("PERSISTED_RESOURCE_QUEUE_URL");
     private final Context context = mock(Context.class);
     private QueuePersistedResourceHandler handler;
     private ByteArrayOutputStream output;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
@@ -9,23 +9,28 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import no.sikt.nva.nvi.events.evaluator.FakeSqsClient;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
+import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class QueuePersistedResourceHandlerTest {
 
+    private static final Environment environment = new Environment();
+    private static final String queueUrl = environment.readEnv("QUEUE_PERSISTED_RESOURCE_QUEUE_URL");
     private final Context context = mock(Context.class);
     private QueuePersistedResourceHandler handler;
     private ByteArrayOutputStream output;
+    private FakeSqsClient sqsClient;
 
     @BeforeEach
     void setUp() {
-        handler = new QueuePersistedResourceHandler();
+        sqsClient = new FakeSqsClient();
+        handler = new QueuePersistedResourceHandler(sqsClient, environment);
         output = new ByteArrayOutputStream();
     }
 
@@ -42,8 +47,11 @@ public class QueuePersistedResourceHandlerTest {
         var fileUri = randomUri();
         var event = createS3Event(fileUri);
         handler.handleRequest(event, output, context);
-        var response = objectMapper.readValue(output.toString(), SQSEvent.class);
-        var body = objectMapper.readValue(response.getRecords().get(0).getBody(), PersistedResourceMessage.class);
+        var sentMessages = sqsClient.getSentMessages();
+        assertEquals(1, sentMessages.size());
+        var sentMessage = sentMessages.get(0);
+        var body = objectMapper.readValue(sentMessage.messageBody(), PersistedResourceMessage.class);
+        assertEquals(queueUrl, sentMessage.queueUrl());
         assertEquals(fileUri, body.resourceFileUri());
     }
 }

--- a/template.yaml
+++ b/template.yaml
@@ -334,6 +334,7 @@ Resources:
           BACKEND_CLIENT_AUTH_URL: !Ref CognitoAuthorizationUri
           BACKEND_CLIENT_SECRET_NAME: 'BackendCognitoClientCredentials'
           EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
+          CANDIDATE_QUEUE_URL: !Ref NewCandidateQueue
       AutoPublishAlias: live
       Events:
         SqsEvent:
@@ -345,9 +346,6 @@ Resources:
             #Don't change the batch size value, unless you change the implementation.
       EventInvokeConfig:
         DestinationConfig:
-          OnSuccess:
-            Type: SQS
-            Destination: !GetAtt NewCandidateQueue.Arn
           OnFailure:
             Type: SQS
             Destination: !GetAtt NewCandidateDLQ.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -300,6 +300,9 @@ Resources:
       Timeout: 30
       MemorySize: 1536
       AutoPublishAlias: live
+      Environment:
+        Variables:
+          PERSISTED_RESOURCE_QUEUE_URL: !Ref PersistedResourceQueue
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule
@@ -313,9 +316,6 @@ Resources:
                   topic: [ "PublicationService.ExpandedEntry.Persisted" ]
       EventInvokeConfig:
         DestinationConfig:
-          OnSuccess:
-            Type: SQS
-            Destination: !GetAtt PersistedResourceQueue.Arn
           OnFailure:
             Type: SQS
             Destination: !GetAtt PersistedResourceDLQ.Arn

--- a/template.yaml
+++ b/template.yaml
@@ -110,7 +110,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Ref NewCandidateDLQName
-      MessageRetentionPeriod: 43200
+      MessageRetentionPeriod: 1209600 #14 days
   BatchScanDLQ:
     Type: AWS::SQS::Queue
     Properties:
@@ -119,17 +119,16 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Ref UpdateIndexDLQName
-      MessageRetentionPeriod: 43200
+      MessageRetentionPeriod: 1209600 #14 days
   UpsertCandidateDLQ:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Ref UpsertCandidateDLQName
-      MessageRetentionPeriod: 43200
+      MessageRetentionPeriod: 1209600 #14 days
   PersistedResourceQueue:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Ref PersistedResourceQueueName
-      MessageRetentionPeriod: 43200
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt PersistedResourceDLQ.Arn
         maxReceiveCount: 5
@@ -137,7 +136,7 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Ref PersistedResourceDLQName
-      MessageRetentionPeriod: 43200
+      MessageRetentionPeriod: 1209600 #14 days
 
   #============================= Permissions =======================================================
   NvaNviRole:

--- a/template.yaml
+++ b/template.yaml
@@ -103,6 +103,9 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Ref NewCandidateQueueName
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt NewCandidateDLQ.Arn
+        maxReceiveCount: 5
   NewCandidateDLQ:
     Type: AWS::SQS::Queue
     Properties:
@@ -127,6 +130,9 @@ Resources:
     Properties:
       QueueName: !Ref PersistedResourceQueueName
       MessageRetentionPeriod: 43200
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt PersistedResourceDLQ.Arn
+        maxReceiveCount: 5
   PersistedResourceDLQ:
     Type: AWS::SQS::Queue
     Properties:


### PR DESCRIPTION
Removing onSuccess destinations for EvaluateNVICandidateHandler and QueuePersistedResourceHandler, and replacing with queue client initiated in handler.

Also added redrive policies (DLQ-config) to NewCandidateQueue and PersistedResourceQueue