### PR TITLE
Np 45666- ReEvaluateNviCandidatesHandler

### DIFF
--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 test {
     useJUnitPlatform()
     environment("OUTPUT_EVENT_TOPIC", "someTopic")
+    environment("TOPIC_REEVALUATE_CANDIDATES", "someTopic")
     environment("EVENT_BUS_NAME", "someEvent")
     environment "API_HOST", "api.dev.nva.aws.unit.no"
     environment("SEARCH_INFRASTRUCTURE_API_HOST", "localhost")

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandler.java
@@ -55,7 +55,7 @@ public class EventBasedBatchScanHandler extends EventHandler<ScanDatabaseRequest
 
     private void sendEventToInvokeNewRefreshRowVersionExecution(ScanDatabaseRequest input, Context context,
                                                                 ListingResult result) {
-        var newEvent = input.newScanDatabaseRequest(result.startMarker())
+        var newEvent = input.newScanDatabaseRequest(result.getStartMarker())
                            .createNewEventEntry(EVENT_BUS_NAME, DETAIL_TYPE, context.getInvokedFunctionArn());
         sendEvent(newEvent);
     }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -38,11 +38,11 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
     private static final String PERSISTED_RESOURCE_QUEUE_URL = "PERSISTED_RESOURCE_QUEUE_URL";
     private static final String EVENT_BUS_NAME = "EVENT_BUS_NAME";
     private static final String INVALID_INPUT_MSG = "Invalid request. Field year is required";
-    private static final String TOPIC = new Environment().readEnv(OUTPUT_EVENT_TOPIC);
     private final QueueClient<NviSendMessageResponse> queueClient;
     private final NviService nviService;
     private final String queueUrl;
     private final String eventBusName;
+    private final String topic;
     private final EventBridgeClient eventBridgeClient;
 
     @JacocoGenerated
@@ -57,6 +57,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
         this.queueClient = queueClient;
         this.queueUrl = environment.readEnv(PERSISTED_RESOURCE_QUEUE_URL);
         this.eventBusName = environment.readEnv(EVENT_BUS_NAME);
+        this.topic = environment.readEnv(OUTPUT_EVENT_TOPIC);
         this.eventBridgeClient = eventBridgeClient;
     }
 
@@ -92,7 +93,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
 
     private void sendEventToInvokeNewReEvaluateExecution(ReEvaluateRequest request, Context context,
                                                          ListingResultWithCandidates result) {
-        var newEvent = request.newReEvaluateRequest(result.getStartMarker(), TOPIC)
+        var newEvent = request.newReEvaluateRequest(result.getStartMarker(), topic)
                            .createNewEventEntry(eventBusName, context.getInvokedFunctionArn());
         sendEvent(newEvent);
     }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -81,7 +81,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
 
     private void sendEventToInvokeNewReEvaluateExecution(ReEvaluateRequest request, Context context,
                                                          ListingResultWithCandidates result) {
-        var newEvent = request.newReEvaluateRequest(result.startMarker(), TOPIC)
+        var newEvent = request.newReEvaluateRequest(result.getStartMarker(), TOPIC)
                            .createNewEventEntry(eventBusName, context.getInvokedFunctionArn());
         sendEvent(newEvent);
     }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -1,0 +1,29 @@
+package no.sikt.nva.nvi.events.batch;
+
+import static java.util.Objects.isNull;
+import com.amazonaws.services.lambda.runtime.Context;
+import no.sikt.nva.nvi.events.model.ReEvaluateRequest;
+import no.unit.nva.events.handlers.EventHandler;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+
+public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateRequest, Void> {
+
+    public static final String INVALID_INPUT_MSG = "Invalid request. Field year is required";
+
+    public ReEvaluateNviCandidatesHandler() {
+        super(ReEvaluateRequest.class);
+    }
+
+    @Override
+    protected Void processInput(ReEvaluateRequest input, AwsEventBridgeEvent<ReEvaluateRequest> event,
+                                Context context) {
+        validateInput(input);
+        return null;
+    }
+
+    private void validateInput(ReEvaluateRequest input) {
+        if (isNull(input) || isNull(input.year())) {
+            throw new IllegalArgumentException(INVALID_INPUT_MSG);
+        }
+    }
+}

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -32,6 +32,8 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
     private static final String PERSISTED_RESOURCE_QUEUE_URL = "PERSISTED_RESOURCE_QUEUE_URL";
     private static final String EVENT_BUS_NAME = "EVENT_BUS_NAME";
     private static final String INVALID_INPUT_MSG = "Invalid request. Field year is required";
+    public static final String OUTPUT_EVENT_TOPIC = "TOPIC_REEVALUATE_CANDIDATES";
+    private static final String TOPIC = new Environment().readEnv(OUTPUT_EVENT_TOPIC);
     private final QueueClient<NviSendMessageResponse> queueClient;
     private final NviService nviService;
     private final String queueUrl;
@@ -79,7 +81,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
 
     private void sendEventToInvokeNewReEvaluateExecution(ReEvaluateRequest request, Context context,
                                                          ListingResultWithCandidates result) {
-        var newEvent = request.newReEvaluateRequest(result.startMarker())
+        var newEvent = request.newReEvaluateRequest(result.startMarker(), TOPIC)
                            .createNewEventEntry(eventBusName, context.getInvokedFunctionArn());
         sendEvent(newEvent);
     }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -58,7 +58,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
                                 Context context) {
         validateInput(input);
         var result = getListingResultWithCandidates(input);
-        splitIntoBatches(mapToFileUris(result)).forEach(uris -> sendBatch(createMessages(uris)));
+        splitIntoBatches(mapToFileUris(result)).forEach(fileUriList -> sendBatch(createMessages(fileUriList)));
         if (result.shouldContinueScan()) {
             sendEventToInvokeNewReEvaluateExecution(input, context, result);
         }
@@ -80,7 +80,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
     private void sendEventToInvokeNewReEvaluateExecution(ReEvaluateRequest request, Context context,
                                                          ListingResultWithCandidates result) {
         var newEvent = request.newReEvaluateRequest(result.startMarker())
-                           .createNewEventEntry(EVENT_BUS_NAME, context.getInvokedFunctionArn());
+                           .createNewEventEntry(eventBusName, context.getInvokedFunctionArn());
         sendEvent(newEvent);
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -31,13 +31,14 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateRequest, Void> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ReEvaluateNviCandidatesHandler.class);
-    private static final String QUERY_STARTING_POINT_MSG = "Query starting point: {}";
-    private static final String RESULT_MSG = "Batch result startMarker: {}, totalItemCount: {}, shouldContinueScan: {}";
+    private static final String INVALID_INPUT_MESSAGE = "Invalid request. Field year is required";
+    private static final String QUERY_STARTING_POINT_MESSAGE = "Query starting point: {}";
+    private static final String RESULT_MESSAGE = "Batch result startMarker: {}, totalItemCount: {}, "
+                                                 + "shouldContinueScan: {}";
     private static final String OUTPUT_EVENT_TOPIC = "TOPIC_REEVALUATE_CANDIDATES";
     private static final int BATCH_SIZE = 10;
     private static final String PERSISTED_RESOURCE_QUEUE_URL = "PERSISTED_RESOURCE_QUEUE_URL";
     private static final String EVENT_BUS_NAME = "EVENT_BUS_NAME";
-    private static final String INVALID_INPUT_MSG = "Invalid request. Field year is required";
     private final QueueClient<NviSendMessageResponse> queueClient;
     private final NviService nviService;
     private final String queueUrl;
@@ -65,7 +66,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
     protected Void processInput(ReEvaluateRequest input, AwsEventBridgeEvent<ReEvaluateRequest> event,
                                 Context context) {
         validateInput(input);
-        LOGGER.info(QUERY_STARTING_POINT_MSG, input.startMarker());
+        LOGGER.info(QUERY_STARTING_POINT_MESSAGE, input.startMarker());
         var result = getListingResultWithCandidates(input);
         logResult(result);
         splitIntoBatches(mapToFileUris(result)).forEach(fileUriList -> sendBatch(createMessages(fileUriList)));
@@ -76,7 +77,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
     }
 
     private static void logResult(ListingResultWithCandidates result) {
-        LOGGER.info(RESULT_MSG, result.getStartMarker(), result.getTotalItemCount(), result.shouldContinueScan());
+        LOGGER.info(RESULT_MESSAGE, result.getStartMarker(), result.getTotalItemCount(), result.shouldContinueScan());
     }
 
     @JacocoGenerated
@@ -129,7 +130,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
 
     private void validateInput(ReEvaluateRequest input) {
         if (isNull(input) || isNull(input.year())) {
-            throw new IllegalArgumentException(INVALID_INPUT_MSG);
+            throw new IllegalArgumentException(INVALID_INPUT_MESSAGE);
         }
     }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -90,9 +90,9 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
     }
 
     private ListingResultWithCandidates getListingResultWithCandidates(ReEvaluateRequest input) {
-        return nviService.fetchCandidatePublicationFileUrisByYear(input.year(),
-                                                                  input.pageSize(),
-                                                                  input.startMarker());
+        return nviService.fetchCandidatesByYear(input.year(),
+                                                input.pageSize(),
+                                                input.startMarker());
     }
 
     private Stream<List<URI>> splitIntoBatches(List<URI> fileUris) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.nvi.events.batch;
 
 import static java.util.Objects.isNull;
-import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.URI;
@@ -9,7 +8,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import no.sikt.nva.nvi.common.model.ListingResult;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
+import no.sikt.nva.nvi.common.model.ListingResultWithCandidates;
 import no.sikt.nva.nvi.common.queue.NviQueueClient;
 import no.sikt.nva.nvi.common.queue.NviSendMessageResponse;
 import no.sikt.nva.nvi.common.queue.QueueClient;
@@ -20,39 +21,78 @@ import no.unit.nva.events.handlers.EventHandler;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.services.eventbridge.EventBridgeClient;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequest;
+import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
-public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateRequest, ListingResult> {
+public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateRequest, Void> {
 
-    public static final int BATCH_SIZE = 10;
+    private static final int BATCH_SIZE = 10;
     private static final String PERSISTED_RESOURCE_QUEUE_URL = "PERSISTED_RESOURCE_QUEUE_URL";
+    private static final String EVENT_BUS_NAME = "EVENT_BUS_NAME";
     private static final String INVALID_INPUT_MSG = "Invalid request. Field year is required";
     private final QueueClient<NviSendMessageResponse> queueClient;
     private final NviService nviService;
     private final String queueUrl;
+    private final String eventBusName;
+    private final EventBridgeClient eventBridgeClient;
 
     @JacocoGenerated
     public ReEvaluateNviCandidatesHandler() {
-        this(NviService.defaultNviService(), new NviQueueClient(), new Environment());
+        this(NviService.defaultNviService(), new NviQueueClient(), new Environment(), defaultEventBridgeClient());
     }
 
     public ReEvaluateNviCandidatesHandler(NviService nviService, QueueClient<NviSendMessageResponse> queueClient,
-                                          Environment environment) {
+                                          Environment environment, EventBridgeClient eventBridgeClient) {
         super(ReEvaluateRequest.class);
         this.nviService = nviService;
         this.queueClient = queueClient;
         this.queueUrl = environment.readEnv(PERSISTED_RESOURCE_QUEUE_URL);
+        this.eventBusName = environment.readEnv(EVENT_BUS_NAME);
+        this.eventBridgeClient = eventBridgeClient;
     }
 
     @Override
-    protected ListingResult processInput(ReEvaluateRequest input, AwsEventBridgeEvent<ReEvaluateRequest> event,
-                                         Context context) {
+    protected Void processInput(ReEvaluateRequest input, AwsEventBridgeEvent<ReEvaluateRequest> event,
+                                Context context) {
         validateInput(input);
-        var startMarker = nonNull(input.startMarker()) ? input.startMarker() : null;
-        var candidatePublicationFileUris = nviService.fetchCandidatePublicationFileUrisByYear(input.year(),
-                                                                                              input.pageSize(),
-                                                                                              startMarker);
-        splitIntoBatches(candidatePublicationFileUris).forEach(uris -> sendBatch(createMessages(uris)));
+        var result = getListingResultWithCandidates(input);
+        splitIntoBatches(mapToFileUris(result)).forEach(uris -> sendBatch(createMessages(uris)));
+        if (result.shouldContinueScan()) {
+            sendEventToInvokeNewReEvaluateExecution(input, context, result);
+        }
         return null;
+    }
+
+    @JacocoGenerated
+    private static EventBridgeClient defaultEventBridgeClient() {
+        return EventBridgeClient.builder().httpClientBuilder(UrlConnectionHttpClient.builder()).build();
+    }
+
+    private static List<URI> mapToFileUris(ListingResultWithCandidates result) {
+        return result.getCandidates().stream()
+                   .map(CandidateDao::candidate)
+                   .map(DbCandidate::publicationBucketUri)
+                   .toList();
+    }
+
+    private void sendEventToInvokeNewReEvaluateExecution(ReEvaluateRequest request, Context context,
+                                                         ListingResultWithCandidates result) {
+        var newEvent = request.newReEvaluateRequest(result.startMarker())
+                           .createNewEventEntry(EVENT_BUS_NAME, context.getInvokedFunctionArn());
+        sendEvent(newEvent);
+    }
+
+    private void sendEvent(PutEventsRequestEntry newEvent) {
+        var putEventRequest = PutEventsRequest.builder().entries(newEvent).build();
+        eventBridgeClient.putEvents(putEventRequest);
+    }
+
+    private ListingResultWithCandidates getListingResultWithCandidates(ReEvaluateRequest input) {
+        return nviService.fetchCandidatePublicationFileUrisByYear(input.year(),
+                                                                  input.pageSize(),
+                                                                  input.startMarker());
     }
 
     private Stream<List<URI>> splitIntoBatches(List<URI> fileUris) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/PersistedResourceMessage.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/PersistedResourceMessage.java
@@ -1,7 +1,12 @@
 package no.sikt.nva.nvi.events.model;
 
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
 
 public record PersistedResourceMessage(URI resourceFileUri) {
 
+    public static PersistedResourceMessage fromJson(String body) {
+        return attempt(() -> dtoObjectMapper.readValue(body, PersistedResourceMessage.class)).orElseThrow();
+    }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
@@ -10,11 +10,13 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
 public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) Integer pageSize,
                                 @JsonProperty(START_MARKER_FIELD) Map<String, String> startMarker,
-                                @JsonProperty(YEAR_FIELD) String year) {
+                                @JsonProperty(YEAR_FIELD) String year,
+                                @JsonProperty(TOPIC_FIELD) String topic) {
 
     public static final String PAGE_SIZE_FIELD = "pageSize";
     public static final String START_MARKER_FIELD = "startMarker";
     public static final String YEAR_FIELD = "year";
+    public static final String TOPIC_FIELD = "topic";
     public static final int DEFAULT_PAGE_SIZE = 500;
     public static final int MAX_PAGE_SIZE = 1000;
 
@@ -33,8 +35,8 @@ public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) Integer pageSize,
                    : DEFAULT_PAGE_SIZE;
     }
 
-    public ReEvaluateRequest newReEvaluateRequest(Map<String, String> stringStringMap) {
-        return new ReEvaluateRequest(this.pageSize(), stringStringMap, year);
+    public ReEvaluateRequest newReEvaluateRequest(Map<String, String> stringStringMap, String outputTopic) {
+        return new ReEvaluateRequest(this.pageSize(), stringStringMap, year, outputTopic);
     }
 
     public PutEventsRequestEntry createNewEventEntry(
@@ -64,6 +66,7 @@ public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) Integer pageSize,
         private Integer pageSize;
         private Map<String, String> startMarker;
         private String year;
+        private String topic;
 
         private Builder() {
         }
@@ -79,7 +82,7 @@ public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) Integer pageSize,
         }
 
         public ReEvaluateRequest build() {
-            return new ReEvaluateRequest(pageSize, startMarker, year);
+            return new ReEvaluateRequest(pageSize, startMarker, year, topic);
         }
     }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
@@ -1,0 +1,53 @@
+package no.sikt.nva.nvi.events.model;
+
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
+                                @JsonProperty(START_MARKER_FIELD) Map<String, String> startMarker,
+                                @JsonProperty(YEAR_FIELD) String year) {
+
+    public static final String PAGE_SIZE_FIELD = "pageSize";
+    public static final String START_MARKER_FIELD = "startMarker";
+    public static final String YEAR_FIELD = "year";
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public String toJsonString() {
+        return attempt(() -> dtoObjectMapper.writeValueAsString(this)).orElseThrow();
+    }
+
+    public static final class Builder {
+
+        private int pageSize;
+        private Map<String, String> startMarker;
+
+        private String year;
+
+        private Builder() {
+        }
+
+        public Builder withPageSize(int pageSize) {
+            this.pageSize = pageSize;
+            return this;
+        }
+
+        public Builder withStartMarker(Map<String, String> startMarker) {
+            this.startMarker = startMarker;
+            return this;
+        }
+
+        public Builder withYear(String year) {
+            this.year = year;
+            return this;
+        }
+
+        public ReEvaluateRequest build() {
+            return new ReEvaluateRequest(pageSize, startMarker, year);
+        }
+    }
+}

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
@@ -81,6 +81,16 @@ public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) Integer pageSize,
             return this;
         }
 
+        public Builder withStartMarker(Map<String, String> startMarker) {
+            this.startMarker = startMarker;
+            return this;
+        }
+
+        public Builder withTopic(String topic) {
+            this.topic = topic;
+            return this;
+        }
+
         public ReEvaluateRequest build() {
             return new ReEvaluateRequest(pageSize, startMarker, year, topic);
         }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
@@ -53,7 +53,7 @@ public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) Integer pageSize,
                    .build();
     }
 
-    private String toJsonString() {
+    public String toJsonString() {
         return attempt(() -> dtoObjectMapper.writeValueAsString(this)).orElseThrow();
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ReEvaluateRequest.java
@@ -1,44 +1,41 @@
 package no.sikt.nva.nvi.events.model;
 
-import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
-import static nva.commons.core.attempt.Try.attempt;
+import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 
-public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
+public record ReEvaluateRequest(@JsonProperty(PAGE_SIZE_FIELD) Integer pageSize,
                                 @JsonProperty(START_MARKER_FIELD) Map<String, String> startMarker,
                                 @JsonProperty(YEAR_FIELD) String year) {
 
     public static final String PAGE_SIZE_FIELD = "pageSize";
     public static final String START_MARKER_FIELD = "startMarker";
     public static final String YEAR_FIELD = "year";
+    public static final int DEFAULT_PAGE_SIZE = 500;
+    public static final int MAX_PAGE_SIZE = 1000;
 
     public static Builder builder() {
         return new Builder();
     }
 
-    public String toJsonString() {
-        return attempt(() -> dtoObjectMapper.writeValueAsString(this)).orElseThrow();
+    @Override
+    public Integer pageSize() {
+        return pageSizeWithinLimits(pageSize)
+                   ? pageSize
+                   : DEFAULT_PAGE_SIZE;
+    }
+
+    private boolean pageSizeWithinLimits(Integer pageSize) {
+        return nonNull(pageSize) && pageSize > 0 && pageSize <= MAX_PAGE_SIZE;
     }
 
     public static final class Builder {
 
-        private int pageSize;
+        private Integer pageSize;
         private Map<String, String> startMarker;
-
         private String year;
 
         private Builder() {
-        }
-
-        public Builder withPageSize(int pageSize) {
-            this.pageSize = pageSize;
-            return this;
-        }
-
-        public Builder withStartMarker(Map<String, String> startMarker) {
-            this.startMarker = startMarker;
-            return this;
         }
 
         public Builder withYear(String year) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -191,7 +191,7 @@ class EventBasedBatchScanHandlerTest extends LocalDynamoTest {
         consumeEvents();
         var result = JsonUtils.dtoObjectMapper.readValue(output.toByteArray(), ListingResult.class);
 
-        assertThat(result.totalItem(), is(0));
+        assertThat(result.getTotalItemCount(), is(0));
     }
 
     private void createPeriod() {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -1,0 +1,38 @@
+package no.sikt.nva.nvi.events.batch;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import com.amazonaws.services.lambda.runtime.Context;
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+import no.sikt.nva.nvi.events.model.ReEvaluateRequest;
+import nva.commons.core.ioutils.IoUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ReEvaluateNviCandidatesHandlerTest {
+
+    private final Context context = mock(Context.class);
+    private ByteArrayOutputStream outputStream;
+
+    @BeforeEach
+    void setUp() {
+        outputStream = new ByteArrayOutputStream();
+    }
+
+    @Test
+    void shouldThrowExceptionWhenRequestDoesNotContainYear() {
+        assertThrows(IllegalArgumentException.class, () -> {
+            var handler = new ReEvaluateNviCandidatesHandler();
+            handler.handleRequest(eventStream(emptyRequest()), outputStream, context);
+        });
+    }
+
+    private static ReEvaluateRequest emptyRequest() {
+        return ReEvaluateRequest.builder().build();
+    }
+
+    private InputStream eventStream(ReEvaluateRequest input) {
+        return IoUtils.stringToStream(input.toJsonString());
+    }
+}

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -1,38 +1,101 @@
 package no.sikt.nva.nvi.events.batch;
 
+import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
+import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
+import java.util.List;
+import java.util.stream.IntStream;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
+import no.sikt.nva.nvi.common.db.CandidateRepository;
+import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.service.NviService;
+import no.sikt.nva.nvi.events.evaluator.FakeSqsClient;
 import no.sikt.nva.nvi.events.model.ReEvaluateRequest;
+import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.unit.nva.events.models.AwsEventBridgeEvent;
+import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class ReEvaluateNviCandidatesHandlerTest {
+class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
 
+    private static final Environment environment = new Environment();
     private final Context context = mock(Context.class);
     private ByteArrayOutputStream outputStream;
+    private ReEvaluateNviCandidatesHandler handler;
+    private FakeSqsClient sqsClient;
+    private CandidateRepository candidateRepository;
 
     @BeforeEach
     void setUp() {
         outputStream = new ByteArrayOutputStream();
+        sqsClient = new FakeSqsClient();
+        var localDynamoDbClient = initializeTestDatabase();
+        candidateRepository = new CandidateRepository(localDynamoDbClient);
+        var periodRepository = new PeriodRepository(localDynamoDbClient);
+        var nviService = new NviService(periodRepository, candidateRepository);
+        handler = new ReEvaluateNviCandidatesHandler(nviService, sqsClient, environment);
     }
 
     @Test
     void shouldThrowExceptionWhenRequestDoesNotContainYear() {
         assertThrows(IllegalArgumentException.class, () -> {
-            var handler = new ReEvaluateNviCandidatesHandler();
             handler.handleRequest(eventStream(emptyRequest()), outputStream, context);
         });
+    }
+
+    @Test
+    void shouldSendMessagesBatchWithSize10() {
+        var numberOfCandidates = 11;
+        var batchSize = 10;
+        var randomYear = 2020;
+        createNumberOfCandidatesForYear(randomYear, numberOfCandidates);
+        handler.handleRequest(eventStream(requestWithYear(randomYear)), outputStream, context);
+        var sentBatches = sqsClient.getSentBatches();
+        var expectedBatches = 2;
+        assertEquals(expectedBatches, sentBatches.size());
+        var firstBatch = sentBatches.get(0);
+        var secondBatch = sentBatches.get(1);
+        assertEquals(batchSize, firstBatch.entries().size());
+        assertEquals(numberOfCandidates - batchSize, secondBatch.entries().size());
     }
 
     private static ReEvaluateRequest emptyRequest() {
         return ReEvaluateRequest.builder().build();
     }
 
-    private InputStream eventStream(ReEvaluateRequest input) {
-        return IoUtils.stringToStream(input.toJsonString());
+    private static DbPublicationDate publicationDate(int year) {
+        return new DbPublicationDate(String.valueOf(year), null, null);
+    }
+
+    private static DbCandidate createCandidate(int year) {
+        return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
+    }
+
+    private void createNumberOfCandidatesForYear(int year, int numberOfCandidates) {
+        IntStream.range(0, numberOfCandidates).forEach(i -> {
+            candidateRepository.create(createCandidate(year), List.of());
+        });
+    }
+
+    private ReEvaluateRequest requestWithYear(int year) {
+        return ReEvaluateRequest.builder().withYear(String.valueOf(year)).build();
+    }
+
+    private InputStream eventStream(ReEvaluateRequest request) {
+        var event = new AwsEventBridgeEvent<ReEvaluateRequest>();
+        event.setDetail(request);
+        event.setId(randomString());
+        var jsonString = attempt(() -> objectMapper.writeValueAsString(event)).orElseThrow();
+        return IoUtils.stringToStream(jsonString);
     }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -168,11 +168,16 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
     }
 
     private ReEvaluateRequest createRequest(String year) {
-        return ReEvaluateRequest.builder().withYear(year).build();
+        return ReEvaluateRequest.builder().withYear(year).withTopic(outputTopic).withStartMarker(null).build();
     }
 
     private ReEvaluateRequest createRequest(String year, int pageSize) {
-        return ReEvaluateRequest.builder().withYear(year).withPageSize(pageSize).build();
+        return ReEvaluateRequest.builder()
+                   .withYear(year)
+                   .withPageSize(pageSize)
+                   .withTopic(outputTopic)
+                   .withStartMarker(null)
+                   .build();
     }
 
     private InputStream eventStream(ReEvaluateRequest request) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -47,7 +47,7 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
     private static final int MAX_PAGE_SIZE = 1000;
     private static final int DEFAULT_PAGE_SIZE = 500;
     private static final Environment environment = new Environment();
-    private static final String outputTopic = environment.readEnv("TOPIC_REEVALUATE_CANDIDATES");
+    private static final String OUTPUT_TOPIC = environment.readEnv("TOPIC_REEVALUATE_CANDIDATES");
     private static final int BATCH_SIZE = 10;
     private final Context context = mock(Context.class);
     private ByteArrayOutputStream outputStream;
@@ -109,7 +109,7 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
         handler.handleRequest(eventStream(createRequest(year)), outputStream, context);
         var batch = sqsClient.getSentBatches().get(0);
         var expectedCandidates = sortByIdentifier(candidates, BATCH_SIZE).stream().map(CandidateDao::candidate)
-                                      .map(DbCandidate::publicationBucketUri).toList();
+                                     .map(DbCandidate::publicationBucketUri).toList();
         var actualCandidates = batch.entries().stream()
                                    .map(SendMessageBatchRequestEntry::messageBody)
                                    .map(PersistedResourceMessage::fromJson)
@@ -137,7 +137,7 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
         handler.handleRequest(eventStream(createRequest(year, pageSize)), outputStream, context);
         var expectedStartMarker = getYearIndexStartMarker(
             sortByIdentifier(candidates, numberOfCandidates).get(pageSize - 1));
-        var expectedEmittedEvent = new ReEvaluateRequest(pageSize, expectedStartMarker, year, outputTopic);
+        var expectedEmittedEvent = new ReEvaluateRequest(pageSize, expectedStartMarker, year, OUTPUT_TOPIC);
         var actualEmittedEvent = getEmittedEvent();
         assertEquals(expectedEmittedEvent, actualEmittedEvent);
     }
@@ -189,14 +189,14 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
     }
 
     private ReEvaluateRequest createRequest(String year) {
-        return ReEvaluateRequest.builder().withYear(year).withTopic(outputTopic).withStartMarker(null).build();
+        return ReEvaluateRequest.builder().withYear(year).withTopic(OUTPUT_TOPIC).withStartMarker(null).build();
     }
 
     private ReEvaluateRequest createRequest(String year, int pageSize) {
         return ReEvaluateRequest.builder()
                    .withYear(year)
                    .withPageSize(pageSize)
-                   .withTopic(outputTopic)
+                   .withTopic(OUTPUT_TOPIC)
                    .withStartMarker(null)
                    .build();
     }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -37,6 +37,7 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
     private static final int MAX_PAGE_SIZE = 1000;
     private static final int DEFAULT_PAGE_SIZE = 500;
     private static final Environment environment = new Environment();
+    private static final String outputTopic = environment.readEnv("TOPIC_REEVALUATE_CANDIDATES");
     private static final int BATCH_SIZE = 10;
     private final Context context = mock(Context.class);
     private ByteArrayOutputStream outputStream;
@@ -99,7 +100,7 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
         handler.handleRequest(eventStream(createRequest(year, pageSize)), outputStream, context);
         var expectedStartMarker = getYearIndexStartMarker(
             sortByIdentifier(candidates, numberOfCandidates).get(pageSize - 1));
-        var expectedEmittedEvent = new ReEvaluateRequest(pageSize, expectedStartMarker, year);
+        var expectedEmittedEvent = new ReEvaluateRequest(pageSize, expectedStartMarker, year, outputTopic);
         var actualEmittedEvent = getEmittedEvent();
         assertEquals(expectedEmittedEvent, actualEmittedEvent);
     }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -86,6 +86,17 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
         assertEquals(expectedEmittedEvent, actualEmittedEvent);
     }
 
+    @Test
+    void shouldNotEmitNewEventWhenBatchIsComplete() {
+        var numberOfCandidates = 9;
+        var pageSize = 10;
+        var year = randomYear();
+        createNumberOfCandidatesForYear(year, numberOfCandidates, candidateRepository);
+        handler.handleRequest(eventStream(createRequest(year, pageSize)), outputStream, context);
+        var emittedEvents = eventBridgeClient.getRequestEntries();
+        assertEquals(0, emittedEvents.size());
+    }
+
     private static Map<String, String> getStartMarker(CandidateDao dao) {
         return Map.of("PrimaryKeyRangeKey", dao.primaryKeyRangeKey(),
                       "PrimaryKeyHashKey", dao.primaryKeyHashKey(),

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/FakeSqsClient.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/FakeSqsClient.java
@@ -1,10 +1,13 @@
 package no.sikt.nva.nvi.events.evaluator;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import no.sikt.nva.nvi.common.queue.NviSendMessageResponse;
 import no.sikt.nva.nvi.common.queue.QueueClient;
 import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
@@ -13,8 +16,14 @@ public class FakeSqsClient implements QueueClient<NviSendMessageResponse> {
 
     private final List<SendMessageRequest> sentMessages = new ArrayList<>();
 
+    private final List<SendMessageBatchRequest> sentBatches = new ArrayList<>();
+
     public List<SendMessageRequest> getSentMessages() {
         return sentMessages;
+    }
+
+    public List<SendMessageBatchRequest> getSentBatches() {
+        return sentBatches;
     }
 
     @Override
@@ -24,6 +33,28 @@ public class FakeSqsClient implements QueueClient<NviSendMessageResponse> {
         return createResponse(SendMessageResponse.builder()
                                   .messageId(request.messageDeduplicationId())
                                   .build());
+    }
+
+    @Override
+    public NviSendMessageResponse sendMessageBatch(Collection<String> messages, String queueUrl) {
+        var request = createBatchRequest(messages, queueUrl);
+        sentBatches.add(request);
+        return createResponse(SendMessageResponse.builder().build());
+    }
+
+    private SendMessageBatchRequest createBatchRequest(Collection<String> messages, String queueUrl) {
+        return SendMessageBatchRequest.builder()
+                   .queueUrl(queueUrl)
+                   .entries(createBatchEntries(messages))
+                   .build();
+    }
+
+    private Collection<SendMessageBatchRequestEntry> createBatchEntries(Collection<String> messages) {
+        return messages.stream().map(this::createBatchEntry).toList();
+    }
+
+    private SendMessageBatchRequestEntry createBatchEntry(String message) {
+        return SendMessageBatchRequestEntry.builder().messageBody(message).build();
     }
 
     private SendMessageRequest createRequest(String body, String queueUrl) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.common.db;
 
 import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
 import static java.util.Objects.nonNull;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toMap;
@@ -27,6 +28,7 @@ import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.NoteDao.DbNote;
 import no.sikt.nva.nvi.common.model.ListingResult;
+import no.sikt.nva.nvi.common.model.ListingResultWithCandidates;
 import no.sikt.nva.nvi.common.service.Candidate;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -91,12 +93,18 @@ public class CandidateRepository extends DynamoRepository {
         return new ListingResult(thereAreMorePagesToScan(scan), toStringMap(scan.lastEvaluatedKey()), count);
     }
 
-    public List<CandidateDao> fetchCandidatesByYear(String year, Integer pageSize, Map<String, String> startMarker) {
-        return this.yearIndex.query(createQuery(year, pageSize, startMarker))
-                   .stream()
-                   .findFirst()
-                   .map(Page::items)
-                   .orElse(emptyList());
+    public ListingResultWithCandidates fetchCandidatesByYear(String year,
+                                                             Integer pageSize, Map<String, String> startMarker) {
+        var page = this.yearIndex.query(createQuery(year, pageSize, startMarker))
+                       .stream()
+                       .findFirst()
+                       .orElse(Page.create(emptyList()));
+
+        return new ListingResultWithCandidates(thereAreMorePagesToScan(page),
+                                               nonNull(page.lastEvaluatedKey()) ?
+                                                   toStringMap(page.lastEvaluatedKey()) : emptyMap(),
+                                               page.items().size(),
+                                               page.items());
     }
 
     public Candidate create(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses) {
@@ -259,8 +267,8 @@ public class CandidateRepository extends DynamoRepository {
                    .collect(toMap(Map.Entry::getKey, e -> AttributeValue.builder().s(e.getValue()).build()));
     }
 
-    private static Map<String, String> toStringMap(Map<String, AttributeValue> startMarker) {
-        return startMarker.entrySet()
+    private static Map<String, String> toStringMap(Map<String, AttributeValue> lastEvaluatedKey) {
+        return lastEvaluatedKey.entrySet()
                    .stream()
                    .collect(toMap(Map.Entry::getKey, e -> e.getValue().s()));
     }
@@ -333,6 +341,10 @@ public class CandidateRepository extends DynamoRepository {
         mutableMap.put(DynamoEntryWithRangeKey.VERSION_FIELD_NAME,
                        AttributeValue.builder().s(randomUUID().toString()).build());
         return mutableMap;
+    }
+
+    private boolean thereAreMorePagesToScan(Page<CandidateDao> page) {
+        return nonNull(page) && nonNull(page.lastEvaluatedKey()) && !page.lastEvaluatedKey().isEmpty();
     }
 
     private boolean thereAreMorePagesToScan(ScanResponse scanResult) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -91,7 +91,7 @@ public class CandidateRepository extends DynamoRepository {
         return new ListingResult(thereAreMorePagesToScan(scan), toStringMap(scan.lastEvaluatedKey()), count);
     }
 
-    public List<CandidateDao> fetchCandidatesByYear(int year, Integer pageSize, Map<String, String> startMarker) {
+    public List<CandidateDao> fetchCandidatesByYear(String year, Integer pageSize, Map<String, String> startMarker) {
         return this.yearIndex.query(createQuery(year, pageSize, startMarker))
                    .stream()
                    .findFirst()
@@ -316,12 +316,12 @@ public class CandidateRepository extends DynamoRepository {
                    .build();
     }
 
-    private QueryEnhancedRequest createQuery(int year, Integer pageSize, Map<String, String> startMarker) {
+    private QueryEnhancedRequest createQuery(String year, Integer pageSize, Map<String, String> startMarker) {
         var start = nonNull(startMarker) ? toAttributeMap(startMarker) : null;
         var limit = nonNull(pageSize) ? pageSize : DEFAULT_PAGE_SIZE;
         return QueryEnhancedRequest.builder()
                    .queryConditional(keyEqualTo(Key.builder()
-                                                    .partitionValue(String.valueOf(year))
+                                                    .partitionValue(year)
                                                     .build()))
                    .limit(limit)
                    .exclusiveStartKey(start)

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -95,11 +95,7 @@ public class CandidateRepository extends DynamoRepository {
 
     public ListingResultWithCandidates fetchCandidatesByYear(String year,
                                                              Integer pageSize, Map<String, String> startMarker) {
-        var page = this.yearIndex.query(createQuery(year, pageSize, startMarker))
-                       .stream()
-                       .findFirst()
-                       .orElse(Page.create(emptyList()));
-
+        var page = queryYearIndex(year, pageSize, startMarker);
         return new ListingResultWithCandidates(thereAreMorePagesToScan(page),
                                                nonNull(page.lastEvaluatedKey())
                                                    ? toStringMap(page.lastEvaluatedKey()) : emptyMap(),
@@ -322,6 +318,13 @@ public class CandidateRepository extends DynamoRepository {
                    .item(insert)
                    .conditionExpression(uniquePrimaryKeysExpression())
                    .build();
+    }
+
+    private Page<CandidateDao> queryYearIndex(String year, Integer pageSize, Map<String, String> startMarker) {
+        return this.yearIndex.query(createQuery(year, pageSize, startMarker))
+                   .stream()
+                   .findFirst()
+                   .orElse(Page.create(emptyList()));
     }
 
     private QueryEnhancedRequest createQuery(String year, Integer pageSize, Map<String, String> startMarker) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -101,8 +101,8 @@ public class CandidateRepository extends DynamoRepository {
                        .orElse(Page.create(emptyList()));
 
         return new ListingResultWithCandidates(thereAreMorePagesToScan(page),
-                                               nonNull(page.lastEvaluatedKey()) ?
-                                                   toStringMap(page.lastEvaluatedKey()) : emptyMap(),
+                                               nonNull(page.lastEvaluatedKey())
+                                                   ? toStringMap(page.lastEvaluatedKey()) : emptyMap(),
                                                page.items().size(),
                                                page.items());
     }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResult.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResult.java
@@ -12,38 +12,38 @@ import nva.commons.core.JacocoGenerated;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class ListingResult {
 
-    public static final String SHOULD_CONTINUE_SCAN = "shouldContinueScan";
+    public static final String MORE_ITEMS_TO_SCAN = "moreItemsToScan";
     public static final String START_MARKER = "startMarker";
-    public static final String TOTAL_ITEM = "totalItem";
-    private final boolean shouldContinueScan;
+    public static final String ITEM_COUNT = "totalItemCount";
+    private final boolean moreItemsToScan;
     private final Map<String, String> startMarker;
-    private final int totalItem;
+    private final int totalItemCount;
 
     @JsonCreator
-    public ListingResult(@JsonProperty(SHOULD_CONTINUE_SCAN) boolean shouldContinueScan,
+    public ListingResult(@JsonProperty(MORE_ITEMS_TO_SCAN) boolean moreItemsToScan,
                          @JsonProperty(START_MARKER) Map<String, String> startMarker,
-                         @JsonProperty(TOTAL_ITEM) int totalItem) {
-        this.shouldContinueScan = shouldContinueScan;
+                         @JsonProperty(ITEM_COUNT) int totalItemCount) {
+        this.moreItemsToScan = moreItemsToScan;
         this.startMarker = startMarker;
-        this.totalItem = totalItem;
+        this.totalItemCount = totalItemCount;
     }
 
     public boolean shouldContinueScan() {
-        return shouldContinueScan;
+        return moreItemsToScan;
     }
 
-    public Map<String, String> startMarker() {
+    public Map<String, String> getStartMarker() {
         return startMarker;
     }
 
-    public int totalItem() {
-        return totalItem;
+    public int getTotalItemCount() {
+        return totalItemCount;
     }
 
     @Override
     @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(shouldContinueScan, startMarker, totalItem);
+        return Objects.hash(moreItemsToScan, startMarker, totalItemCount);
     }
 
     @Override
@@ -56,8 +56,8 @@ public class ListingResult {
             return false;
         }
         var that = (ListingResult) obj;
-        return this.shouldContinueScan == that.shouldContinueScan
+        return this.moreItemsToScan == that.moreItemsToScan
                && Objects.equals(this.startMarker, that.startMarker)
-               && this.totalItem == that.totalItem;
+               && this.totalItemCount == that.totalItemCount;
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResult.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResult.java
@@ -1,16 +1,25 @@
 package no.sikt.nva.nvi.common.model;
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.Map;
 import java.util.Objects;
 import nva.commons.core.JacocoGenerated;
 
+@JsonSerialize
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class ListingResult {
 
     private final boolean shouldContinueScan;
     private final Map<String, String> startMarker;
     private final int totalItem;
 
-    public ListingResult(boolean shouldContinueScan, Map<String, String> startMarker, int totalItem) {
+    @JsonCreator
+    public ListingResult(@JsonProperty("shouldContinueScan") boolean shouldContinueScan,
+                         @JsonProperty("startMarker") Map<String, String> startMarker,
+                         @JsonProperty("totalItem") int totalItem) {
         this.shouldContinueScan = shouldContinueScan;
         this.startMarker = startMarker;
         this.totalItem = totalItem;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResult.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResult.java
@@ -12,14 +12,17 @@ import nva.commons.core.JacocoGenerated;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class ListingResult {
 
+    public static final String SHOULD_CONTINUE_SCAN = "shouldContinueScan";
+    public static final String START_MARKER = "startMarker";
+    public static final String TOTAL_ITEM = "totalItem";
     private final boolean shouldContinueScan;
     private final Map<String, String> startMarker;
     private final int totalItem;
 
     @JsonCreator
-    public ListingResult(@JsonProperty("shouldContinueScan") boolean shouldContinueScan,
-                         @JsonProperty("startMarker") Map<String, String> startMarker,
-                         @JsonProperty("totalItem") int totalItem) {
+    public ListingResult(@JsonProperty(SHOULD_CONTINUE_SCAN) boolean shouldContinueScan,
+                         @JsonProperty(START_MARKER) Map<String, String> startMarker,
+                         @JsonProperty(TOTAL_ITEM) int totalItem) {
         this.shouldContinueScan = shouldContinueScan;
         this.startMarker = startMarker;
         this.totalItem = totalItem;
@@ -53,16 +56,8 @@ public class ListingResult {
             return false;
         }
         var that = (ListingResult) obj;
-        return this.shouldContinueScan == that.shouldContinueScan &&
-               Objects.equals(this.startMarker, that.startMarker) &&
-               this.totalItem == that.totalItem;
-    }
-
-    @Override
-    public String toString() {
-        return "ListingResult[" +
-               "shouldContinueScan=" + shouldContinueScan + ", " +
-               "startMarker=" + startMarker + ", " +
-               "totalItem=" + totalItem + ']';
+        return this.shouldContinueScan == that.shouldContinueScan
+               && Objects.equals(this.startMarker, that.startMarker)
+               && this.totalItem == that.totalItem;
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResult.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResult.java
@@ -1,7 +1,59 @@
 package no.sikt.nva.nvi.common.model;
 
 import java.util.Map;
+import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
 
-public record ListingResult(boolean shouldContinueScan, Map<String, String> startMarker, int totalItem) {
+public class ListingResult {
 
+    private final boolean shouldContinueScan;
+    private final Map<String, String> startMarker;
+    private final int totalItem;
+
+    public ListingResult(boolean shouldContinueScan, Map<String, String> startMarker, int totalItem) {
+        this.shouldContinueScan = shouldContinueScan;
+        this.startMarker = startMarker;
+        this.totalItem = totalItem;
+    }
+
+    public boolean shouldContinueScan() {
+        return shouldContinueScan;
+    }
+
+    public Map<String, String> startMarker() {
+        return startMarker;
+    }
+
+    public int totalItem() {
+        return totalItem;
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(shouldContinueScan, startMarker, totalItem);
+    }
+
+    @Override
+    @JacocoGenerated
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        var that = (ListingResult) obj;
+        return this.shouldContinueScan == that.shouldContinueScan &&
+               Objects.equals(this.startMarker, that.startMarker) &&
+               this.totalItem == that.totalItem;
+    }
+
+    @Override
+    public String toString() {
+        return "ListingResult[" +
+               "shouldContinueScan=" + shouldContinueScan + ", " +
+               "startMarker=" + startMarker + ", " +
+               "totalItem=" + totalItem + ']';
+    }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResultWithCandidates.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResultWithCandidates.java
@@ -8,8 +8,9 @@ public class ListingResultWithCandidates extends ListingResult {
 
     private final List<CandidateDao> candidates;
 
-    public ListingResultWithCandidates(boolean shouldContinueScan, Map<String, String> startMarker, int totalItem, List<CandidateDao> candidates) {
-          super(shouldContinueScan, startMarker, totalItem);
+    public ListingResultWithCandidates(boolean shouldContinueScan, Map<String, String> startMarker, int totalItem,
+                                       List<CandidateDao> candidates) {
+        super(shouldContinueScan, startMarker, totalItem);
         this.candidates = candidates;
     }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResultWithCandidates.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/ListingResultWithCandidates.java
@@ -1,0 +1,19 @@
+package no.sikt.nva.nvi.common.model;
+
+import java.util.List;
+import java.util.Map;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+
+public class ListingResultWithCandidates extends ListingResult {
+
+    private final List<CandidateDao> candidates;
+
+    public ListingResultWithCandidates(boolean shouldContinueScan, Map<String, String> startMarker, int totalItem, List<CandidateDao> candidates) {
+          super(shouldContinueScan, startMarker, totalItem);
+        this.candidates = candidates;
+    }
+
+    public List<CandidateDao> getCandidates() {
+        return candidates;
+    }
+}

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.common.queue;
 
 import java.time.Duration;
 import java.util.Collection;
+import java.util.List;
 import no.sikt.nva.nvi.common.utils.ApplicationConstants;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -10,6 +11,7 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
@@ -80,10 +82,11 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse> {
     }
 
     private NviSendMessageResponse createResponse(SendMessageResponse response) {
-        return new NviSendMessageResponse(response.messageId());
+        return new NviSendMessageResponse(List.of(response.messageId()));
     }
 
     private NviSendMessageResponse createResponse(SendMessageBatchResponse response) {
-        return new NviSendMessageResponse(String.valueOf(response.successful().size()));
+        return new NviSendMessageResponse(
+            response.successful().stream().map(SendMessageBatchResultEntry::id).toList());
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
@@ -3,6 +3,7 @@ package no.sikt.nva.nvi.common.queue;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.UUID;
 import no.sikt.nva.nvi.common.utils.ApplicationConstants;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.http.SdkHttpClient;
@@ -78,7 +79,7 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse> {
     }
 
     private SendMessageBatchRequestEntry createBatchEntry(String message) {
-        return SendMessageBatchRequestEntry.builder().messageBody(message).build();
+        return SendMessageBatchRequestEntry.builder().id(UUID.randomUUID().toString()).messageBody(message).build();
     }
 
     private NviSendMessageResponse createResponse(SendMessageResponse response) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
@@ -1,11 +1,15 @@
 package no.sikt.nva.nvi.common.queue;
 
 import java.time.Duration;
+import java.util.Collection;
 import no.sikt.nva.nvi.common.utils.ApplicationConstants;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
@@ -28,6 +32,11 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse> {
     @Override
     public NviSendMessageResponse sendMessage(String message, String queueUrl) {
         return createResponse(sqsClient.sendMessage(createRequest(message, queueUrl)));
+    }
+
+    @Override
+    public NviSendMessageResponse sendMessageBatch(Collection<String> messages, String queueUrl) {
+        return createResponse(sqsClient.sendMessageBatch(createBatchRequest(messages, queueUrl)));
     }
 
     @JacocoGenerated
@@ -55,7 +64,26 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse> {
                    .build();
     }
 
+    private SendMessageBatchRequest createBatchRequest(Collection<String> messages, String queueUrl) {
+        return SendMessageBatchRequest.builder()
+                   .queueUrl(queueUrl)
+                   .entries(createBatchEntries(messages))
+                   .build();
+    }
+
+    private Collection<SendMessageBatchRequestEntry> createBatchEntries(Collection<String> messages) {
+        return messages.stream().map(this::createBatchEntry).toList();
+    }
+
+    private SendMessageBatchRequestEntry createBatchEntry(String message) {
+        return SendMessageBatchRequestEntry.builder().messageBody(message).build();
+    }
+
     private NviSendMessageResponse createResponse(SendMessageResponse response) {
         return new NviSendMessageResponse(response.messageId());
+    }
+
+    private NviSendMessageResponse createResponse(SendMessageBatchResponse response) {
+        return new NviSendMessageResponse(String.valueOf(response.successful().size()));
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviSendMessageResponse.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviSendMessageResponse.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.common.queue;
 
-public record NviSendMessageResponse(String messageId) {
+import java.util.List;
+
+public record NviSendMessageResponse(List<String> messageIds) {
 
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/QueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/QueueClient.java
@@ -1,6 +1,10 @@
 package no.sikt.nva.nvi.common.queue;
 
+import java.util.Collection;
+
 public interface QueueClient<T> {
 
     T sendMessage(String message, String queueUrl);
+
+    T sendMessageBatch(Collection<String> messages, String queueUrl);
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
@@ -121,8 +121,8 @@ public class NviService {
         return candidateRepository.refresh(pageSize, startMarker);
     }
 
-    public ListingResultWithCandidates fetchCandidatePublicationFileUrisByYear(String year, int pageSize,
-                                                                               Map<String, String> startMarker) {
+    public ListingResultWithCandidates fetchCandidatesByYear(String year, Integer pageSize,
+                                                             Map<String, String> startMarker) {
         return candidateRepository.fetchCandidatesByYear(year, pageSize, startMarker);
     }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
@@ -12,7 +12,6 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
-import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
@@ -25,6 +24,7 @@ import no.sikt.nva.nvi.common.db.PeriodStatus.Status;
 import no.sikt.nva.nvi.common.db.model.InstanceType;
 import no.sikt.nva.nvi.common.model.InvalidNviCandidateException;
 import no.sikt.nva.nvi.common.model.ListingResult;
+import no.sikt.nva.nvi.common.model.ListingResultWithCandidates;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
@@ -121,13 +121,9 @@ public class NviService {
         return candidateRepository.refresh(pageSize, startMarker);
     }
 
-    public List<URI> fetchCandidatePublicationFileUrisByYear(String year, int pageSize,
-                                                             Map<String, String> startMarker) {
-        return candidateRepository.fetchCandidatesByYear(year, pageSize, startMarker)
-                   .stream()
-                   .map(CandidateDao::candidate)
-                   .map(DbCandidate::publicationBucketUri)
-                   .toList();
+    public ListingResultWithCandidates fetchCandidatePublicationFileUrisByYear(String year, int pageSize,
+                                                                               Map<String, String> startMarker) {
+        return candidateRepository.fetchCandidatesByYear(year, pageSize, startMarker);
     }
 
     private static boolean isNoteOwner(String requestUsername, DbNote note) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -1,8 +1,10 @@
 package no.sikt.nva.nvi.common.db;
 
+import static no.sikt.nva.nvi.test.TestUtils.createNumberOfCandidatesForYear;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
 import static no.sikt.nva.nvi.test.TestUtils.randomIntBetween;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
+import static no.sikt.nva.nvi.test.TestUtils.sortByIdentifier;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -11,13 +13,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
-import java.util.stream.IntStream;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.sikt.nva.nvi.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +23,6 @@ import org.junit.jupiter.api.Test;
 class CandidateRepositoryTest extends LocalDynamoTest {
 
     public static final int DEFAULT_PAGE_SIZE = 700;
-    public static final String UUID_SEPERATOR = "-";
     private CandidateRepository candidateRepository;
 
     @BeforeEach
@@ -61,11 +57,11 @@ class CandidateRepositoryTest extends LocalDynamoTest {
     @Test
     void shouldFetchCandidatesByGivenYearAndPageSize() {
         var searchYear = randomYear();
-        var candidates = createNumberOfCandidatesForYear(searchYear, 10);
-        createNumberOfCandidatesForYear(randomYear(), 10);
+        var candidates = createNumberOfCandidatesForYear(searchYear, 10, candidateRepository);
+        createNumberOfCandidatesForYear(randomYear(), 10, candidateRepository);
         int pageSize = 5;
         var expectedCandidates = sortByIdentifier(candidates, pageSize);
-        var results = candidateRepository.fetchCandidatesByYear(searchYear, pageSize, null);
+        var results = candidateRepository.fetchCandidatesByYear(searchYear, pageSize, null).getCandidates();
         assertThat(results.size(), is(equalTo(pageSize)));
         assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
     }
@@ -73,12 +69,12 @@ class CandidateRepositoryTest extends LocalDynamoTest {
     @Test
     void shouldFetchCandidatesByGivenYearAndStartMarker() {
         var year = randomYear();
-        var candidates = createNumberOfCandidatesForYear(year, 2);
+        var candidates = createNumberOfCandidatesForYear(year, 2, candidateRepository);
         var expectedCandidates = sortByIdentifier(candidates, DEFAULT_PAGE_SIZE);
         var firstCandidateInIndex = expectedCandidates.get(0);
         var secondCandidateInIndex = expectedCandidates.get(1);
         var startMarker = getStartMarker(firstCandidateInIndex);
-        var results = candidateRepository.fetchCandidatesByYear(year, null, startMarker);
+        var results = candidateRepository.fetchCandidatesByYear(year, null, startMarker).getCandidates();
         assertThat(results.size(), is(equalTo(1)));
         assertEquals(secondCandidateInIndex, results.get(0));
     }
@@ -87,9 +83,9 @@ class CandidateRepositoryTest extends LocalDynamoTest {
     void shouldFetchCandidatesByGivenYearWithDefaultPageSizeAndStartMarkerIfNotSet() {
         var year = randomYear();
         int numberOfCandidates = DEFAULT_PAGE_SIZE + randomIntBetween(1, 10);
-        var candidates = createNumberOfCandidatesForYear(year, numberOfCandidates);
+        var candidates = createNumberOfCandidatesForYear(year, numberOfCandidates, candidateRepository);
         var expectedCandidates = sortByIdentifier(candidates, DEFAULT_PAGE_SIZE);
-        var results = candidateRepository.fetchCandidatesByYear(year, null, null);
+        var results = candidateRepository.fetchCandidatesByYear(year, null, null).getCandidates();
         assertThat(results.size(), is(equalTo(DEFAULT_PAGE_SIZE)));
         assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
     }
@@ -99,32 +95,5 @@ class CandidateRepositoryTest extends LocalDynamoTest {
                       "PrimaryKeyHashKey", dao.primaryKeyHashKey(),
                       "SearchByYearHashKey", String.valueOf(dao.searchByYearHashKey()),
                       "SearchByYearRangeKey", dao.searchByYearSortKey());
-    }
-
-    private static DbCandidate randomCandidate(String year) {
-        return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
-    }
-
-    private static DbPublicationDate publicationDate(String year) {
-        return new DbPublicationDate(year, null, null);
-    }
-
-    private static List<CandidateDao> sortByIdentifier(List<CandidateDao> candidates, int limit) {
-        var comparator = Comparator.comparing(CandidateRepositoryTest::getCharacterValues);
-        return candidates.stream()
-                   .sorted(Comparator.comparing(CandidateDao::identifier, comparator))
-                   .limit(limit)
-                   .toList();
-    }
-
-    private static String getCharacterValues(UUID uuid) {
-        return uuid.toString().replaceAll(UUID_SEPERATOR, "");
-    }
-
-    private List<CandidateDao> createNumberOfCandidatesForYear(String year, int number) {
-        return IntStream.range(0, number)
-                   .mapToObj(i -> randomCandidate(year))
-                   .map(candidate -> candidateRepository.createDao(candidate, List.of()))
-                   .toList();
     }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.common.db;
 
 import static no.sikt.nva.nvi.test.TestUtils.createNumberOfCandidatesForYear;
+import static no.sikt.nva.nvi.test.TestUtils.getYearIndexStartMarker;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
 import static no.sikt.nva.nvi.test.TestUtils.randomIntBetween;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
@@ -14,7 +15,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.List;
-import java.util.Map;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.sikt.nva.nvi.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +73,7 @@ class CandidateRepositoryTest extends LocalDynamoTest {
         var expectedCandidates = sortByIdentifier(candidates, DEFAULT_PAGE_SIZE);
         var firstCandidateInIndex = expectedCandidates.get(0);
         var secondCandidateInIndex = expectedCandidates.get(1);
-        var startMarker = getStartMarker(firstCandidateInIndex);
+        var startMarker = getYearIndexStartMarker(firstCandidateInIndex);
         var results = candidateRepository.fetchCandidatesByYear(year, null, startMarker).getCandidates();
         assertThat(results.size(), is(equalTo(1)));
         assertEquals(secondCandidateInIndex, results.get(0));
@@ -88,12 +88,5 @@ class CandidateRepositoryTest extends LocalDynamoTest {
         var results = candidateRepository.fetchCandidatesByYear(year, null, null).getCandidates();
         assertThat(results.size(), is(equalTo(DEFAULT_PAGE_SIZE)));
         assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
-    }
-
-    private static Map<String, String> getStartMarker(CandidateDao dao) {
-        return Map.of("PrimaryKeyRangeKey", dao.primaryKeyRangeKey(),
-                      "PrimaryKeyHashKey", dao.primaryKeyHashKey(),
-                      "SearchByYearHashKey", String.valueOf(dao.searchByYearHashKey()),
-                      "SearchByYearRangeKey", dao.searchByYearSortKey());
     }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -60,9 +60,9 @@ class CandidateRepositoryTest extends LocalDynamoTest {
 
     @Test
     void shouldFetchCandidatesByGivenYearAndPageSize() {
-        int searchYear = Integer.parseInt(randomYear());
+        var searchYear = randomYear();
         var candidates = createNumberOfCandidatesForYear(searchYear, 10);
-        createNumberOfCandidatesForYear(Integer.parseInt(randomYear()), 10);
+        createNumberOfCandidatesForYear(randomYear(), 10);
         int pageSize = 5;
         var expectedCandidates = sortByIdentifier(candidates, pageSize);
         var results = candidateRepository.fetchCandidatesByYear(searchYear, pageSize, null);
@@ -72,7 +72,7 @@ class CandidateRepositoryTest extends LocalDynamoTest {
 
     @Test
     void shouldFetchCandidatesByGivenYearAndStartMarker() {
-        int year = Integer.parseInt(randomYear());
+        var year = randomYear();
         var candidates = createNumberOfCandidatesForYear(year, 2);
         var expectedCandidates = sortByIdentifier(candidates, DEFAULT_PAGE_SIZE);
         var firstCandidateInIndex = expectedCandidates.get(0);
@@ -85,7 +85,7 @@ class CandidateRepositoryTest extends LocalDynamoTest {
 
     @Test
     void shouldFetchCandidatesByGivenYearWithDefaultPageSizeAndStartMarkerIfNotSet() {
-        int year = Integer.parseInt(randomYear());
+        var year = randomYear();
         int numberOfCandidates = DEFAULT_PAGE_SIZE + randomIntBetween(1, 10);
         var candidates = createNumberOfCandidatesForYear(year, numberOfCandidates);
         var expectedCandidates = sortByIdentifier(candidates, DEFAULT_PAGE_SIZE);
@@ -101,12 +101,12 @@ class CandidateRepositoryTest extends LocalDynamoTest {
                       "SearchByYearRangeKey", dao.searchByYearSortKey());
     }
 
-    private static DbCandidate randomCandidate(int year) {
+    private static DbCandidate randomCandidate(String year) {
         return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
     }
 
-    private static DbPublicationDate publicationDate(int year) {
-        return new DbPublicationDate(String.valueOf(year), null, null);
+    private static DbPublicationDate publicationDate(String year) {
+        return new DbPublicationDate(year, null, null);
     }
 
     private static List<CandidateDao> sortByIdentifier(List<CandidateDao> candidates, int limit) {
@@ -121,7 +121,7 @@ class CandidateRepositoryTest extends LocalDynamoTest {
         return uuid.toString().replaceAll(UUID_SEPERATOR, "");
     }
 
-    private List<CandidateDao> createNumberOfCandidatesForYear(int year, int number) {
+    private List<CandidateDao> createNumberOfCandidatesForYear(String year, int number) {
         return IntStream.range(0, number)
                    .mapToObj(i -> randomCandidate(year))
                    .map(candidate -> candidateRepository.createDao(candidate, List.of()))

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/queue/NviQueueClientTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/queue/NviQueueClientTest.java
@@ -6,8 +6,12 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
+import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
@@ -26,6 +30,19 @@ public class NviQueueClientTest {
 
         var result = client.sendMessage(TEST_PAYLOAD, TEST_QUEUE_URL);
 
-        assertThat(result.messageId(), is(equalTo(TEST_MESSAGE_ID)));
+        assertThat(result.messageIds().get(0), is(equalTo(TEST_MESSAGE_ID)));
+    }
+
+    @Test
+    void shouldSendSqsMessageBatchAndReturnId() {
+        var sqsClient = mock(SqsClient.class);
+        when(sqsClient.sendMessageBatch(any(SendMessageBatchRequest.class))).thenReturn(
+            SendMessageBatchResponse.builder().successful(
+                SendMessageBatchResultEntry.builder().id(TEST_MESSAGE_ID).build()).build());
+        var client = new NviQueueClient(sqsClient);
+
+        var result = client.sendMessageBatch(List.of(TEST_PAYLOAD), TEST_QUEUE_URL);
+
+        assertThat(result.messageIds().get(0), is(equalTo(TEST_MESSAGE_ID)));
     }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
@@ -84,8 +84,8 @@ public class NviServiceTest extends LocalDynamoTest {
         var result = nviService.refresh(10, null);
         var modified = candidateRepository.findDaoById(candidate.identifier());
         assertThat(modified.version(), is(not(equalTo(original.version()))));
-        assertThat(result.startMarker().size(), is(equalTo(0)));
-        assertThat(result.totalItem(), is(equalTo(1)));
+        assertThat(result.getStartMarker().size(), is(equalTo(0)));
+        assertThat(result.getTotalItemCount(), is(equalTo(1)));
         assertThat(result.shouldContinueScan(), is(equalTo(false)));
     }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
@@ -5,8 +5,10 @@ import static no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus.APPROVED;
 import static no.sikt.nva.nvi.common.db.PeriodStatus.Status.CLOSED_PERIOD;
 import static no.sikt.nva.nvi.common.db.PeriodStatus.Status.NO_PERIOD;
 import static no.sikt.nva.nvi.common.db.PeriodStatus.Status.OPEN_PERIOD;
+import static no.sikt.nva.nvi.test.TestUtils.createNumberOfCandidatesForYear;
 import static no.sikt.nva.nvi.test.TestUtils.generatePublicationId;
 import static no.sikt.nva.nvi.test.TestUtils.generateS3BucketUri;
+import static no.sikt.nva.nvi.test.TestUtils.getYearIndexStartMarker;
 import static no.sikt.nva.nvi.test.TestUtils.nviServiceReturningClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.nviServiceReturningNotStartedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
@@ -15,10 +17,13 @@ import static no.sikt.nva.nvi.test.TestUtils.randomCandidateWithPublicationYear;
 import static no.sikt.nva.nvi.test.TestUtils.randomInstanceType;
 import static no.sikt.nva.nvi.test.TestUtils.randomInstanceTypeExcluding;
 import static no.sikt.nva.nvi.test.TestUtils.randomPublicationDate;
+import static no.sikt.nva.nvi.test.TestUtils.randomYear;
+import static no.sikt.nva.nvi.test.TestUtils.sortByIdentifier;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
@@ -26,6 +31,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -69,6 +75,43 @@ public class NviServiceTest extends LocalDynamoTest {
     private static final int SECOND_ROW = 1;
     private NviService nviService;
     private CandidateRepositoryHelper candidateRepository;
+
+    @Test
+    public void shouldWriteVersionOnRefreshWhenStartMarkerIsNotSet() {
+        var originalCandidate = randomCandidate();
+        var candidate = candidateRepository.create(originalCandidate, List.of());
+        var original = candidateRepository.findDaoById(candidate.identifier());
+        var result = nviService.refresh(10, null);
+        var modified = candidateRepository.findDaoById(candidate.identifier());
+        assertThat(modified.version(), is(not(equalTo(original.version()))));
+        assertThat(result.startMarker().size(), is(equalTo(0)));
+        assertThat(result.totalItem(), is(equalTo(1)));
+        assertThat(result.shouldContinueScan(), is(equalTo(false)));
+    }
+
+    @Test
+    public void refreshVersionShouldContinue() {
+        IntStream.range(0, 3).forEach(i -> candidateRepository.create(randomCandidate(), List.of()));
+
+        var result = nviService.refresh(1, null);
+        assertThat(result.shouldContinueScan(), is(equalTo(true)));
+    }
+
+    @Test
+    public void shouldWriteVersionOnRefreshWithStartMarker() {
+        IntStream.range(0, 2).forEach(i -> candidateRepository.create(randomCandidate(), List.of()));
+
+        var candidates = getCandidatesInOrder();
+
+        var originalRows = getCandidateDaos(candidates);
+
+        nviService.refresh(1000, getStartMarker(originalRows.get(FIRST_ROW)));
+
+        var modifiedRows = getCandidateDaos(candidates);
+
+        assertThat(modifiedRows.get(FIRST_ROW).version(), is(equalTo(originalRows.get(FIRST_ROW).version())));
+        assertThat(modifiedRows.get(SECOND_ROW).version(), is(not(equalTo(originalRows.get(SECOND_ROW).version()))));
+    }
 
     @BeforeEach
     void setup() {
@@ -490,45 +533,28 @@ public class NviServiceTest extends LocalDynamoTest {
     }
 
     @Test
-    public void shouldWriteVersionOnRefreshWhenStartMarkerIsNotSet() {
-        var originalCandidate = randomCandidate();
-        var candidate = candidateRepository.create(originalCandidate, List.of());
-        var original = candidateRepository.findDaoById(candidate.identifier());
-        var result = nviService.refresh(10, null);
-        var modified = candidateRepository.findDaoById(candidate.identifier());
-        assertThat(modified.version(), is(not(equalTo(original.version()))));
-        assertThat(result.startMarker().size(), is(equalTo(0)));
-        assertThat(result.totalItem(), is(equalTo(1)));
-        assertThat(result.shouldContinueScan(), is(equalTo(false)));
+    void shouldFetchCandidatesByGivenYearAndStartMarker() {
+        var year = randomYear();
+        var candidates = createNumberOfCandidatesForYear(year, 2, candidateRepository);
+        var expectedCandidates = sortByIdentifier(candidates, null);
+        var firstCandidateInIndex = expectedCandidates.get(0);
+        var secondCandidateInIndex = expectedCandidates.get(1);
+        var startMarker = getYearIndexStartMarker(firstCandidateInIndex);
+        var results = nviService.fetchCandidatesByYear(year, null, startMarker).getCandidates();
+        assertThat(results.size(), is(equalTo(1)));
+        assertEquals(secondCandidateInIndex, results.get(0));
     }
 
     @Test
-    public void refreshVersionShouldContinue() {
-        IntStream.range(0, 3).forEach(i -> candidateRepository.create(randomCandidate(), List.of()));
-
-        var result = nviService.refresh(1, null);
-        assertThat(result.shouldContinueScan(), is(equalTo(true)));
-    }
-
-    @Test
-    public void shouldWriteVersionOnRefreshWithStartMarker() {
-        IntStream.range(0, 2).forEach(i -> candidateRepository.create(randomCandidate(), List.of()));
-
-        var candidates = getCandidatesInOrder();
-
-        var originalRows = getCandidateDaos(candidates);
-
-        nviService.refresh(1000, getStartMarker(originalRows.get(FIRST_ROW)));
-
-        var modifiedRows = getCandidateDaos(candidates);
-
-        assertThat(modifiedRows.get(FIRST_ROW).version(), is(equalTo(originalRows.get(FIRST_ROW).version())));
-        assertThat(modifiedRows.get(SECOND_ROW).version(), is(not(equalTo(originalRows.get(SECOND_ROW).version()))));
-    }
-
-    private List<CandidateDao> getCandidateDaos(List<Map<String, AttributeValue>> candidates) {
-        return Arrays.asList(candidateRepository.findDaoById(getIdentifier(candidates, 0)),
-                             candidateRepository.findDaoById(getIdentifier(candidates, 1)));
+    void shouldFetchCandidatesByGivenYearAndPageSize() {
+        var searchYear = randomYear();
+        var candidates = createNumberOfCandidatesForYear(searchYear, 10, candidateRepository);
+        createNumberOfCandidatesForYear(randomYear(), 10, candidateRepository);
+        int pageSize = 5;
+        var expectedCandidates = sortByIdentifier(candidates, pageSize);
+        var results = nviService.fetchCandidatesByYear(searchYear, pageSize, null).getCandidates();
+        assertThat(results.size(), is(equalTo(pageSize)));
+        assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
     }
 
     private static Map<String, String> getStartMarker(CandidateDao dao) {
@@ -543,27 +569,6 @@ public class NviServiceTest extends LocalDynamoTest {
 
     private static UUID getIdentifier(List<Map<String, AttributeValue>> candidates, int index) {
         return UUID.fromString(candidates.get(index).get("identifier").s());
-    }
-
-    private List<Map<String, AttributeValue>> getCandidatesInOrder() {
-        return localDynamo.scan(ScanRequest.builder().tableName(ApplicationConstants.NVI_TABLE_NAME).build())
-                   .items()
-                   .stream()
-                   .filter(a -> a.get("type").s().equals("CANDIDATE"))
-                   .toList();
-    }
-
-    public static class CandidateRepositoryHelper extends CandidateRepository {
-
-        public CandidateRepositoryHelper(DynamoDbClient client) {
-            super(client);
-        }
-
-        public CandidateDao findDaoById(UUID id) {
-            return Optional.of(CandidateDao.builder().identifier(id).build())
-                       .map(candidateTable::getItem)
-                       .orElseThrow();
-        }
     }
 
     private static UUID getNoteIdentifier(Candidate candidateWith2Notes, Username user) {
@@ -629,6 +634,19 @@ public class NviServiceTest extends LocalDynamoTest {
                    .toList();
     }
 
+    private List<CandidateDao> getCandidateDaos(List<Map<String, AttributeValue>> candidates) {
+        return Arrays.asList(candidateRepository.findDaoById(getIdentifier(candidates, 0)),
+                             candidateRepository.findDaoById(getIdentifier(candidates, 1)));
+    }
+
+    private List<Map<String, AttributeValue>> getCandidatesInOrder() {
+        return localDynamo.scan(ScanRequest.builder().tableName(ApplicationConstants.NVI_TABLE_NAME).build())
+                   .items()
+                   .stream()
+                   .filter(a -> a.get("type").s().equals("CANDIDATE"))
+                   .toList();
+    }
+
     private DbCandidate createExpectedCandidate(UUID identifier, List<DbCreator> creators, InstanceType instanceType,
                                                 DbLevel level, DbPublicationDate publicationDate,
                                                 Map<URI, BigDecimal> institutionPoints, boolean applicable) {
@@ -642,5 +660,18 @@ public class NviServiceTest extends LocalDynamoTest {
                    .publicationDate(publicationDate)
                    .points(mapToInstitutionPoints(institutionPoints))
                    .build();
+    }
+
+    public static class CandidateRepositoryHelper extends CandidateRepository {
+
+        public CandidateRepositoryHelper(DynamoDbClient client) {
+            super(client);
+        }
+
+        public CandidateDao findDaoById(UUID id) {
+            return Optional.of(CandidateDao.builder().identifier(id).build())
+                       .map(candidateTable::getItem)
+                       .orElseThrow();
+        }
     }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -131,6 +131,18 @@ public final class TestUtils {
         return randomCandidateBuilder(true).build();
     }
 
+    private static DbCandidate randomCandidate(String year) {
+        return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
+    }
+
+    public static List<CandidateDao> createNumberOfCandidatesForYear(String year, int number,
+                                                                     CandidateRepository repository) {
+        return IntStream.range(0, number)
+                   .mapToObj(i -> randomCandidate(year))
+                   .map(candidate -> repository.createDao(candidate, List.of()))
+                   .toList();
+    }
+
     public static DbCandidate randomCandidateWithPublicationYear(int year) {
         return randomCandidateBuilder(true)
                    .publicationDate(DbPublicationDate.builder().year(String.valueOf(year)).build()).build();
@@ -376,18 +388,6 @@ public final class TestUtils {
 
     public static CreateNoteRequest createNoteRequest(String text, String username) {
         return new CreateNoteRequest(text, username);
-    }
-
-    public static List<CandidateDao> createNumberOfCandidatesForYear(String year, int number,
-                                                                     CandidateRepository repository) {
-        return IntStream.range(0, number)
-                   .mapToObj(i -> randomCandidate(year))
-                   .map(candidate -> repository.createDao(candidate, List.of()))
-                   .toList();
-    }
-
-    private static DbCandidate randomCandidate(String year) {
-        return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
     }
 
     private static DbPublicationDate publicationDate(String year) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.test;
 
+import static java.util.Objects.nonNull;
 import static no.sikt.nva.nvi.common.db.model.InstanceType.NON_CANDIDATE;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
@@ -143,12 +144,19 @@ public final class TestUtils {
                    .publishingYear(randomYear());
     }
 
-    public static List<CandidateDao> sortByIdentifier(List<CandidateDao> candidates, int limit) {
+    public static List<CandidateDao> sortByIdentifier(List<CandidateDao> candidates, Integer limit) {
         var comparator = Comparator.comparing(TestUtils::getCharacterValues);
         return candidates.stream()
                    .sorted(Comparator.comparing(CandidateDao::identifier, comparator))
-                   .limit(limit)
+                   .limit(nonNull(limit) ? limit : candidates.size())
                    .toList();
+    }
+
+    public static Map<String, String> getYearIndexStartMarker(CandidateDao dao) {
+        return Map.of("PrimaryKeyRangeKey", dao.primaryKeyRangeKey(),
+                      "PrimaryKeyHashKey", dao.primaryKeyHashKey(),
+                      "SearchByYearHashKey", String.valueOf(dao.searchByYearHashKey()),
+                      "SearchByYearRangeKey", String.valueOf(dao.searchByYearSortKey()));
     }
 
     public static Username randomUsername() {
@@ -371,7 +379,7 @@ public final class TestUtils {
     }
 
     public static List<CandidateDao> createNumberOfCandidatesForYear(String year, int number,
-                                                               CandidateRepository repository) {
+                                                                     CandidateRepository repository) {
         return IntStream.range(0, number)
                    .mapToObj(i -> randomCandidate(year))
                    .map(candidate -> repository.createDao(candidate, List.of()))

--- a/template.yaml
+++ b/template.yaml
@@ -65,6 +65,9 @@ Parameters:
   UpsertCandidateDLQName:
     Type: String
     Default: UpsertCandidateDLQ
+  ReEvaluateDLQName:
+    Type: String
+    Default: ReEvaluateDLQ
   SearchInfrastructureApiHost:
     Type: String
     Description: Host of external search infrastructure API (SWS).
@@ -136,6 +139,11 @@ Resources:
     Type: AWS::SQS::Queue
     Properties:
       QueueName: !Ref PersistedResourceDLQName
+      MessageRetentionPeriod: 1209600 #14 days
+  ReEvaluateDLQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Ref ReEvaluateDLQName
       MessageRetentionPeriod: 1209600 #14 days
 
   #============================= Permissions =======================================================
@@ -539,6 +547,33 @@ Resources:
         Variables:
           EVENT_BUS_NAME: !GetAtt InternalBus.Name
           OUTPUT_EVENT_TOPIC: 'NviService.BatchScan'
+  
+  ReEvaluateNviCandidatesHandler:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: event-handlers
+      Handler: no.sikt.nva.nvi.events.batch.ReEvaluateNviCandidatesHandler::handleRequest
+      Runtime: java17
+      Timeout: 60
+      Role: !GetAtt NvaNviRole.Arn
+      AutoPublishAlias: live
+      Environment:
+        Variables:
+          EVENT_BUS_NAME: !GetAtt InternalBus.Name
+          TOPIC_REEVALUATE_CANDIDATES: 'NviService.ReEvaluate'
+      Events:
+        EventBridgeEvent:
+          Type: EventBridgeRule
+          Properties:
+            EventBusName: !GetAtt InternalBus.Name
+            Pattern:
+              detail:
+                topic: [ "NviService.ReEvaluate" ]
+      EventInvokeConfig:
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt ReEvaluateDLQ.Arn
 
   # ======================= API HANDLERS ========================
 

--- a/template.yaml
+++ b/template.yaml
@@ -562,6 +562,7 @@ Resources:
         Variables:
           EVENT_BUS_NAME: !GetAtt InternalBus.Name
           TOPIC_REEVALUATE_CANDIDATES: 'NviService.ReEvaluate'
+          PERSISTED_RESOURCE_QUEUE_URL: !Ref PersistedResourceQueue
       Events:
         EventBridgeEvent:
           Type: EventBridgeRule

--- a/template.yaml
+++ b/template.yaml
@@ -188,6 +188,7 @@ Resources:
                   - !GetAtt BatchScanDLQ.Arn
                   - !GetAtt UpdateIndexDLQ.Arn
                   - !GetAtt UpsertCandidateDLQ.Arn
+                  - !GetAtt ReEvaluateDLQ.Arn
         - PolicyName: writeLog
           PolicyDocument:
             Version: 2012-10-17


### PR DESCRIPTION
Last part of jira task: [Tool for re-evaluating nvi candidates](https://unit.atlassian.net/browse/NP-45666)

Implemented new handler: `ReEvaluateCandidatesHandler`, this handler:
- Takes input `ReEvaluateRequest` with required field `year`
- Scans through the `SearchByYear` index (with pagination)
- Puts a `SQSEevent` (batches of 10) on the `PersistedResourceQueue` (consumed by `EvaluateNviCandidateHandler`)
- If there are more candidates to scan, the handler emits a new event to be consumed by itself on the EventBrigde topic `NviService.ReEvaluate`

Also added a DLQ for this handler: `ReEvaluateDLQ`