### PR TITLE
Fix: Pointcalculator extractChannelLevel

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
@@ -1,10 +1,12 @@
 package no.sikt.nva.nvi.events.evaluator.calculator;
 
 import static java.math.BigDecimal.ZERO;
+import static java.util.Objects.nonNull;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_AFFILIATIONS;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CHAPTER_PUBLISHER;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CHAPTER_SERIES;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CHAPTER_SERIES_LEVEL;
+import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CHAPTER_SERIES_SCIENTIFIC_VALUE;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CONTRIBUTOR;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_COUNTRY_CODE;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ID;
@@ -14,6 +16,7 @@ import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_PUBLISHER;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ROLE_TYPE;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_SERIES;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_SERIES_LEVEL;
+import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_SERIES_SCIENTIFIC_VALUE;
 import static no.sikt.nva.nvi.common.utils.JsonUtils.extractJsonNodeTextValue;
 import static no.sikt.nva.nvi.common.utils.JsonUtils.streamNode;
 import static no.sikt.nva.nvi.events.evaluator.calculator.PointCalculationConstants.INSTANCE_TYPE_AND_LEVEL_POINT_MAP;
@@ -197,7 +200,7 @@ public final class PointCalculator {
     }
 
     private static boolean hasId(JsonNode affiliation) {
-        return Objects.nonNull(extractId(affiliation));
+        return nonNull(extractId(affiliation));
     }
 
     private static boolean doesNotHaveId(JsonNode affiliation) {
@@ -234,7 +237,8 @@ public final class PointCalculator {
     }
 
     private static String extractAcademicChapterChannel(JsonNode jsonNode) {
-        if (Objects.nonNull(extractJsonNodeTextValue(jsonNode, JSON_PTR_CHAPTER_SERIES_LEVEL))) {
+        if (nonNull(extractJsonNodeTextValue(jsonNode, JSON_PTR_CHAPTER_SERIES_LEVEL))
+            || nonNull(extractJsonNodeTextValue(jsonNode, JSON_PTR_CHAPTER_SERIES_SCIENTIFIC_VALUE))) {
             return jsonNode.at(JSON_PTR_CHAPTER_SERIES).toString();
         } else {
             return jsonNode.at(JSON_PTR_CHAPTER_PUBLISHER).toString();
@@ -242,7 +246,8 @@ public final class PointCalculator {
     }
 
     private static String extractAcademicMonographChannel(JsonNode jsonNode) {
-        if (Objects.nonNull(extractJsonNodeTextValue(jsonNode, JSON_PTR_SERIES_LEVEL))) {
+        if (nonNull(extractJsonNodeTextValue(jsonNode, JSON_PTR_SERIES_LEVEL))
+            || nonNull(extractJsonNodeTextValue(jsonNode, JSON_PTR_SERIES_SCIENTIFIC_VALUE))) {
             return jsonNode.at(JSON_PTR_SERIES).toString();
         } else {
             return jsonNode.at(JSON_PTR_PUBLISHER).toString();

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -262,8 +262,8 @@ class EvaluateNviCandidateHandlerTest {
     @Test
     void shouldCalculatePointsOnValidAcademicArticle() throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
-        var content = IoUtils.inputStreamFromResources("evaluator/candidate_academicArticle.json");
-        var fileUri = s3Driver.insertFile(UnixPath.of("evaluator/candidate_academicArticle.json"), content);
+        var content = IoUtils.inputStreamFromResources(ACADEMIC_ARTICLE_PATH);
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), content);
         var event = createEvent(new PersistedResourceMessage(fileUri));
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
@@ -276,8 +276,8 @@ class EvaluateNviCandidateHandlerTest {
     @Test
     void shouldCreateInstitutionApprovalsForTopLevelInstitutions() throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
-        var content = IoUtils.inputStreamFromResources("evaluator/candidate_academicArticle.json");
-        var fileUri = s3Driver.insertFile(UnixPath.of("evaluator/candidate_academicArticle.json"), content);
+        var content = IoUtils.inputStreamFromResources(ACADEMIC_ARTICLE_PATH);
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), content);
         var event = createEvent(new PersistedResourceMessage(fileUri));
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
@@ -301,9 +301,8 @@ class EvaluateNviCandidateHandlerTest {
     @Test
     void shouldCreateNewCandidateEventOnValidAcademicMonograph() throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
-        var path = "evaluator/candidate_academicMonograph.json";
-        var content = IoUtils.inputStreamFromResources(path);
-        var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
+        var content = IoUtils.inputStreamFromResources(ACADEMIC_MONOGRAPH_JSON_PATH);
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_MONOGRAPH_JSON_PATH), content);
         var event = createEvent(new PersistedResourceMessage(fileUri));
         handler.handleRequest(event, context);
         var candidate = (NviCandidate) getMessageBody().candidate();
@@ -313,9 +312,8 @@ class EvaluateNviCandidateHandlerTest {
     @Test
     void shouldCreateNewCandidateEventOnValidAcademicLiteratureReview() throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
-        var path = "evaluator/candidate_academicLiteratureReview.json";
-        var content = IoUtils.inputStreamFromResources(path);
-        var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
+        var content = IoUtils.inputStreamFromResources(ACADEMIC_LITERATURE_REVIEW_JSON_PATH);
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_LITERATURE_REVIEW_JSON_PATH), content);
         var event = createEvent(new PersistedResourceMessage(fileUri));
         handler.handleRequest(event, context);
         var candidate = (NviCandidate) getMessageBody().candidate();
@@ -327,10 +325,10 @@ class EvaluateNviCandidateHandlerTest {
     void shouldCreateCandidateWhenLevelValueHasVersionTwoValues(String versionOneValue, String versionTwoValue)
         throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
-        var candidateWithNewLevel = IoUtils.stringFromResources(Path.of("evaluator/candidate_academicArticle.json"))
+        var candidateWithNewLevel = IoUtils.stringFromResources(Path.of(ACADEMIC_ARTICLE_PATH))
                                         .replace("\"level\": " + "\"" + versionOneValue + "\"",
                                                  "\"scientificValue\": " + "\"" + versionTwoValue + "\"");
-        var fileUri = s3Driver.insertFile(UnixPath.of("evaluator/candidate_academicArticle.json"),
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH),
                                           IoUtils.stringToStream(candidateWithNewLevel));
 
         var event = createEvent(new PersistedResourceMessage(fileUri));
@@ -414,8 +412,8 @@ class EvaluateNviCandidateHandlerTest {
     @Test
     void shouldCreateNonCandidateEventWhenZeroNviInstitutions() throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(notFoundResponse);
-        var fileUri = s3Driver.insertFile(UnixPath.of("evaluator/candidate_academicArticle.json"),
-                                          IoUtils.inputStreamFromResources("evaluator/candidate_academicArticle.json"));
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH),
+                                          IoUtils.inputStreamFromResources(ACADEMIC_ARTICLE_PATH));
         var event = createEvent(new PersistedResourceMessage(fileUri));
         handler.handleRequest(event, context);
         var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
@@ -425,8 +423,8 @@ class EvaluateNviCandidateHandlerTest {
     @Test
     void shouldThrowExceptionWhenProblemsFetchingCristinOrganization() throws IOException {
         when(uriRetriever.fetchResponse(any(), any())).thenReturn(Optional.of(badResponse));
-        var fileUri = s3Driver.insertFile(UnixPath.of("evaluator/candidate_academicArticle.json"),
-                                          IoUtils.inputStreamFromResources("evaluator/candidate_academicArticle.json"));
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH),
+                                          IoUtils.inputStreamFromResources(ACADEMIC_ARTICLE_PATH));
         var event = createEvent(new PersistedResourceMessage(fileUri));
         var appender = LogUtils.getTestingAppenderForRootLogger();
         assertThrows(RuntimeException.class, () -> handler.handleRequest(event, context));
@@ -436,8 +434,8 @@ class EvaluateNviCandidateHandlerTest {
     @Test
     void shouldThrowExceptionWhenProblemsFetchingCustomer() throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(badResponse);
-        var fileUri = s3Driver.insertFile(UnixPath.of("evaluator/candidate_academicArticle.json"),
-                                          IoUtils.inputStreamFromResources("evaluator/candidate_academicArticle.json"));
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH),
+                                          IoUtils.inputStreamFromResources(ACADEMIC_ARTICLE_PATH));
         var event = createEvent(new PersistedResourceMessage(fileUri));
         var appender = LogUtils.getTestingAppenderForRootLogger();
         assertThrows(RuntimeException.class, () -> handler.handleRequest(event, context));
@@ -447,8 +445,8 @@ class EvaluateNviCandidateHandlerTest {
     @Test
     void shouldCreateNewCandidateEventWhenAffiliationAreNviInstitutions() throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
-        var fileUri = s3Driver.insertFile(UnixPath.of("evaluator/candidate_academicArticle.json"),
-                                          IoUtils.inputStreamFromResources("evaluator/candidate_academicArticle.json"));
+        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH),
+                                          IoUtils.inputStreamFromResources(ACADEMIC_ARTICLE_PATH));
         var event = createEvent(new PersistedResourceMessage(fileUri));
         handler.handleRequest(event, context);
         var candidate = (NviCandidate) getMessageBody().candidate();

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -159,18 +159,6 @@ class EvaluateNviCandidateHandlerTest {
     }
 
     @Test
-    void shouldCreateNewCandidateEventOnValidAcademicChapter() throws IOException {
-        mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
-        mockOrganizationResponseForAffiliation(SIKT_CRISTIN_ORG_ID, null, uriRetriever);
-        var content = IoUtils.inputStreamFromResources(ACADEMIC_ARTICLE_PATH);
-        var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), content);
-        var event = createEvent(new PersistedResourceMessage(fileUri));
-        handler.handleRequest(event, context);
-        var candidate = (NviCandidate) getMessageBody().candidate();
-        assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
-    }
-
-    @Test
     void shouldCreateNewCandidateWithPointsOnlyForNviInstitutions() throws IOException {
         mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
         mockCristinResponseAndCustomerApiResponseForNonNviInstitution();
@@ -489,7 +477,7 @@ class EvaluateNviCandidateHandlerTest {
                    .withCandidateType(createExpectedCandidate(instanceType,
                                                               Map.of(CRISTIN_NVI_ORG_TOP_LEVEL_ID,
                                                                      points.setScale(SCALE, RoundingMode.HALF_UP)),
-                                                              publicationChannel, Level.LEVEL_ONE.getValue(),
+                                                              publicationChannel, Level.LEVEL_ONE_V2.getValue(),
                                                               basePoints, totalPoints, bucketUri))
                    .build();
     }

--- a/event-handlers/src/test/resources/evaluator/candidate_academicArticle.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicArticle.json
@@ -237,7 +237,7 @@
         "publicationContext": {
           "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
           "type": "Journal",
-          "level": "1"
+          "scientificValue": "LevelOne"
         },
         "publicationInstance": {
           "type": "AcademicArticle"

--- a/event-handlers/src/test/resources/evaluator/candidate_academicArticle_deprecated.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicArticle_deprecated.json
@@ -1,0 +1,253 @@
+{
+  "body": {
+    "type": "Publication",
+    "publicationContextUris": [
+      "https://api.dev.nva.aws.unit.no/publication-channels/journal/490845/2023"
+    ],
+    "@context": {
+      "@vocab": "https://nva.sikt.no/ontology/publication#",
+      "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+      "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+      "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+      "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+      "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+      "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+      "Film": "https://nva.sikt.no/ontology/publication#Film",
+      "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+      "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+      "approvedBy": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+        },
+        "@type": "@vocab"
+      },
+      "activeFrom": {
+        "@type": "xsd:dateTime"
+      },
+      "activeTo": {
+        "@type": "xsd:dateTime"
+      },
+      "additionalIdentifiers": {
+        "@container": "@set",
+        "@id": "additionalIdentifier"
+      },
+      "affiliations": {
+        "@container": "@set",
+        "@id": "affiliation"
+      },
+      "alternativeTitles": {
+        "@container": "@language",
+        "@id": "alternativeTitle"
+      },
+      "approvals": {
+        "@container": "@set",
+        "@id": "approval"
+      },
+      "approvalStatus": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "architectureOutput": {
+        "@container": "@set",
+        "@id": "architectureOutput"
+      },
+      "associatedArtifacts": {
+        "@container": "@set",
+        "@id": "associatedArtifact"
+      },
+      "compliesWith": {
+        "@container": "@set",
+        "@id": "compliesWith"
+      },
+      "concertProgramme": {
+        "@container": "@set",
+        "@id": "concertProgramme"
+      },
+      "contributors": {
+        "@container": "@set",
+        "@id": "contributor"
+      },
+      "createdDate": {
+        "@type": "xsd:dateTime"
+      },
+      "doi": {
+        "@type": "@id"
+      },
+      "embargoDate": {
+        "@type": "xsd:dateTime"
+      },
+      "from": {
+        "@type": "xsd:dateTime"
+      },
+      "fundings": {
+        "@container": "@set",
+        "@id": "funding"
+      },
+      "handle": {
+        "@type": "@id"
+      },
+      "id": "@id",
+      "indexedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "isbnList": {
+        "@container": "@set",
+        "@id": "isbn"
+      },
+      "labels": {
+        "@container": "@language",
+        "@id": "label"
+      },
+      "language": {
+        "@type": "@id"
+      },
+      "link": {
+        "@type": "@id"
+      },
+      "manifestations": {
+        "@container": "@set",
+        "@id": "manifestation"
+      },
+      "metadataSource": {
+        "@type": "@id"
+      },
+      "modifiedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "musicalWorks": {
+        "@container": "@set",
+        "@id": "musicalWork"
+      },
+      "nameType": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "outputs": {
+        "@container": "@set",
+        "@id": "output"
+      },
+      "ownerAffiliation": {
+        "@type": "@id"
+      },
+      "projects": {
+        "@container": "@set",
+        "@id": "project"
+      },
+      "publishedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "referencedBy": {
+        "@container": "@set",
+        "@id": "referencedBy"
+      },
+      "related": {
+        "@container": "@set",
+        "@id": "related"
+      },
+      "status": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "subjects": {
+        "@container": "@set",
+        "@id": "subject",
+        "@type": "@id"
+      },
+      "tags": {
+        "@container": "@set",
+        "@id": "tag"
+      },
+      "to": {
+        "@type": "xsd:dateTime"
+      },
+      "trackList": {
+        "@container": "@set",
+        "@id": "trackList"
+      },
+      "type": "@type",
+      "venues": {
+        "@container": "@set",
+        "@id": "venue"
+      },
+      "nviType": {
+        "@type": "@vocab",
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        }
+      },
+      "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+      "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+      "publicationContextUris": {
+        "@container": "@set"
+      }
+    },
+    "id": "https://api.dev.nva.aws.unit.no/publication/01888b283f29-cae193c7-80fa-4f92-a164-c73b02c19f2d",
+    "entityDescription": {
+      "type": "EntityDescription",
+      "contributors": [
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://www.example.org/9e3de71b-0ecb-4464-b9f1-2f92b974839c",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "type": "Identity",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/123456",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "RoleOther"
+          }
+        },
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.20.0",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/997998",
+            "type": "Identity",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "Creator"
+          }
+        }
+      ],
+      "publicationDate": {
+        "type": "PublicationDate",
+        "year": "2023"
+      },
+      "reference": {
+        "type": "Reference",
+        "publicationContext": {
+          "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
+          "type": "Journal",
+          "level": "1"
+        },
+        "publicationInstance": {
+          "type": "AcademicArticle"
+        }
+      }
+    },
+    "status": "PUBLISHED"
+  },
+  "consumptionAttributes": {
+    "index": "resources",
+    "documentIdentifier": "01888b283f29-cae193c7-80fa-4f92-a164-c73b02c19f2d"
+  }
+}

--- a/event-handlers/src/test/resources/evaluator/candidate_academicChapter.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicChapter.json
@@ -260,12 +260,12 @@
                 "publisher": {
                   "id": "https://api.dev.nva.aws.unit.no/publication-channels/3bbb6017-ca4a-496a-8ca7-d3ac78f65abf",
                   "type": "Publisher",
-                  "level": "1"
+                  "scientificValue": "LevelOne"
                 },
                 "series": {
                   "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
                   "type": "Series",
-                  "level": "1"
+                  "scientificValue": "LevelOne"
                 }
               }
             }

--- a/event-handlers/src/test/resources/evaluator/candidate_academicChapter_deprecated.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicChapter_deprecated.json
@@ -1,0 +1,285 @@
+{
+  "body": {
+    "type": "Publication",
+    "@context": {
+      "@vocab": "https://nva.sikt.no/ontology/publication#",
+      "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+      "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+      "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+      "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+      "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+      "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+      "Film": "https://nva.sikt.no/ontology/publication#Film",
+      "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+      "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+      "approvedBy": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+        },
+        "@type": "@vocab"
+      },
+      "activeFrom": {
+        "@type": "xsd:dateTime"
+      },
+      "activeTo": {
+        "@type": "xsd:dateTime"
+      },
+      "additionalIdentifiers": {
+        "@container": "@set",
+        "@id": "additionalIdentifier"
+      },
+      "affiliations": {
+        "@container": "@set",
+        "@id": "affiliation"
+      },
+      "alternativeTitles": {
+        "@container": "@language",
+        "@id": "alternativeTitle"
+      },
+      "approvals": {
+        "@container": "@set",
+        "@id": "approval"
+      },
+      "approvalStatus": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "architectureOutput": {
+        "@container": "@set",
+        "@id": "architectureOutput"
+      },
+      "associatedArtifacts": {
+        "@container": "@set",
+        "@id": "associatedArtifact"
+      },
+      "compliesWith": {
+        "@container": "@set",
+        "@id": "compliesWith"
+      },
+      "concertProgramme": {
+        "@container": "@set",
+        "@id": "concertProgramme"
+      },
+      "contributors": {
+        "@container": "@set",
+        "@id": "contributor"
+      },
+      "createdDate": {
+        "@type": "xsd:dateTime"
+      },
+      "doi": {
+        "@type": "@id"
+      },
+      "embargoDate": {
+        "@type": "xsd:dateTime"
+      },
+      "from": {
+        "@type": "xsd:dateTime"
+      },
+      "fundings": {
+        "@container": "@set",
+        "@id": "funding"
+      },
+      "handle": {
+        "@type": "@id"
+      },
+      "id": "@id",
+      "indexedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "isbnList": {
+        "@container": "@set",
+        "@id": "isbn"
+      },
+      "labels": {
+        "@container": "@language",
+        "@id": "label"
+      },
+      "language": {
+        "@type": "@id"
+      },
+      "link": {
+        "@type": "@id"
+      },
+      "manifestations": {
+        "@container": "@set",
+        "@id": "manifestation"
+      },
+      "metadataSource": {
+        "@type": "@id"
+      },
+      "modifiedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "musicalWorks": {
+        "@container": "@set",
+        "@id": "musicalWork"
+      },
+      "nameType": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "outputs": {
+        "@container": "@set",
+        "@id": "output"
+      },
+      "ownerAffiliation": {
+        "@type": "@id"
+      },
+      "projects": {
+        "@container": "@set",
+        "@id": "project"
+      },
+      "publishedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "referencedBy": {
+        "@container": "@set",
+        "@id": "referencedBy"
+      },
+      "related": {
+        "@container": "@set",
+        "@id": "related"
+      },
+      "status": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "subjects": {
+        "@container": "@set",
+        "@id": "subject",
+        "@type": "@id"
+      },
+      "tags": {
+        "@container": "@set",
+        "@id": "tag"
+      },
+      "to": {
+        "@type": "xsd:dateTime"
+      },
+      "trackList": {
+        "@container": "@set",
+        "@id": "trackList"
+      },
+      "type": "@type",
+      "venues": {
+        "@container": "@set",
+        "@id": "venue"
+      },
+      "nviType": {
+        "@type": "@vocab",
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        }
+      },
+      "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+      "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+      "publicationContextUris": {
+        "@container": "@set"
+      }
+    },
+    "id": "https://api.dev.nva.aws.unit.no/publication/01888b283f29-cae193c7-80fa-4f92-a164-c73b02c19f2d",
+    "entityDescription": {
+      "type": "EntityDescription",
+      "alternativeAbstracts": {},
+      "contributors": [
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://www.example.org/9e3de71b-0ecb-4464-b9f1-2f92b974839c",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "type": "Identity",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/123456",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "RoleOther"
+          }
+        },
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.20.0",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "type": "Identity",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/997998",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "Creator"
+          }
+        }
+      ],
+      "publicationDate": {
+        "type": "PublicationDate",
+        "year": "2023"
+      },
+      "reference": {
+        "type": "Reference",
+        "publicationContext": {
+          "id": "https://www.example.org/publication/0188beb8f331-da429b9c-ed21-4741-9127-2c32b2cb6232",
+          "type": "Anthology",
+          "entityDescription": {
+            "type": "EntityDescription",
+            "contributors": [
+              {
+                "type": "Contributor",
+                "identity": {
+                  "type": "Identity",
+                  "name": "aJeLFk7JUx"
+                }
+              },
+              {
+                "type": "Contributor",
+                "identity": {
+                  "type": "Identity",
+                  "name": "u7GaTOPFFHDHlRrn0"
+                }
+              }
+            ],
+            "reference": {
+              "type": "Reference",
+              "publicationContext": {
+                "type": "Book",
+                "publisher": {
+                  "id": "https://api.dev.nva.aws.unit.no/publication-channels/3bbb6017-ca4a-496a-8ca7-d3ac78f65abf",
+                  "type": "Publisher",
+                  "level": "1"
+                },
+                "series": {
+                  "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
+                  "type": "Series",
+                  "level": "1"
+                }
+              }
+            }
+          }
+        },
+        "publicationInstance": {
+          "type": "AcademicChapter"
+        }
+      }
+    },
+    "status": "PUBLISHED"
+  },
+  "consumptionAttributes": {
+    "index": "resources",
+    "documentIdentifier": "0188beb8f346-330c9426-4757-4e36-b08f-4d698d295bb4"
+  }
+}

--- a/event-handlers/src/test/resources/evaluator/candidate_academicChapter_seriesLevelEmptyPublisherLevelOne.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicChapter_seriesLevelEmptyPublisherLevelOne.json
@@ -259,7 +259,7 @@
                 "publisher": {
                   "id": "https://api.dev.nva.aws.unit.no/publication-channels/3bbb6017-ca4a-496a-8ca7-d3ac78f65abf",
                   "type": "Publisher",
-                  "level": "1"
+                  "scientificValue": "LevelOne"
                 },
                 "series": {
                   "id": "https://api.dev.nva.aws.unit.no/publication-channels/583d74c4-ba08-485f-9e79-c640f5d223ba",

--- a/event-handlers/src/test/resources/evaluator/candidate_academicLiteratureReview.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicLiteratureReview.json
@@ -238,7 +238,7 @@
         "publicationContext": {
           "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
           "type": "Journal",
-          "level": "1"
+          "scientificValue": "LevelOne"
         },
         "publicationInstance": {
           "type": "AcademicLiteratureReview"

--- a/event-handlers/src/test/resources/evaluator/candidate_academicLiteratureReview_deprecated.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicLiteratureReview_deprecated.json
@@ -1,0 +1,255 @@
+{
+  "body": {
+    "type": "Publication",
+    "publicationContextUris": [
+      "https://api.dev.nva.aws.unit.no/publication-channels/12f58e6f-9f61-4440-89f2-549c09599891"
+    ],
+    "@context": {
+      "@vocab": "https://nva.sikt.no/ontology/publication#",
+      "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+      "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+      "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+      "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+      "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+      "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+      "Film": "https://nva.sikt.no/ontology/publication#Film",
+      "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+      "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+      "approvedBy": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+        },
+        "@type": "@vocab"
+      },
+      "activeFrom": {
+        "@type": "xsd:dateTime"
+      },
+      "activeTo": {
+        "@type": "xsd:dateTime"
+      },
+      "additionalIdentifiers": {
+        "@container": "@set",
+        "@id": "additionalIdentifier"
+      },
+      "affiliations": {
+        "@container": "@set",
+        "@id": "affiliation"
+      },
+      "alternativeTitles": {
+        "@container": "@language",
+        "@id": "alternativeTitle"
+      },
+      "approvals": {
+        "@container": "@set",
+        "@id": "approval"
+      },
+      "approvalStatus": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "architectureOutput": {
+        "@container": "@set",
+        "@id": "architectureOutput"
+      },
+      "associatedArtifacts": {
+        "@container": "@set",
+        "@id": "associatedArtifact"
+      },
+      "compliesWith": {
+        "@container": "@set",
+        "@id": "compliesWith"
+      },
+      "concertProgramme": {
+        "@container": "@set",
+        "@id": "concertProgramme"
+      },
+      "contributors": {
+        "@container": "@set",
+        "@id": "contributor"
+      },
+      "createdDate": {
+        "@type": "xsd:dateTime"
+      },
+      "doi": {
+        "@type": "@id"
+      },
+      "embargoDate": {
+        "@type": "xsd:dateTime"
+      },
+      "from": {
+        "@type": "xsd:dateTime"
+      },
+      "fundings": {
+        "@container": "@set",
+        "@id": "funding"
+      },
+      "handle": {
+        "@type": "@id"
+      },
+      "id": "@id",
+      "indexedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "isbnList": {
+        "@container": "@set",
+        "@id": "isbn"
+      },
+      "labels": {
+        "@container": "@language",
+        "@id": "label"
+      },
+      "language": {
+        "@type": "@id"
+      },
+      "link": {
+        "@type": "@id"
+      },
+      "manifestations": {
+        "@container": "@set",
+        "@id": "manifestation"
+      },
+      "metadataSource": {
+        "@type": "@id"
+      },
+      "modifiedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "musicalWorks": {
+        "@container": "@set",
+        "@id": "musicalWork"
+      },
+      "nameType": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "outputs": {
+        "@container": "@set",
+        "@id": "output"
+      },
+      "ownerAffiliation": {
+        "@type": "@id"
+      },
+      "projects": {
+        "@container": "@set",
+        "@id": "project"
+      },
+      "publishedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "referencedBy": {
+        "@container": "@set",
+        "@id": "referencedBy"
+      },
+      "related": {
+        "@container": "@set",
+        "@id": "related"
+      },
+      "status": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "subjects": {
+        "@container": "@set",
+        "@id": "subject",
+        "@type": "@id"
+      },
+      "tags": {
+        "@container": "@set",
+        "@id": "tag"
+      },
+      "to": {
+        "@type": "xsd:dateTime"
+      },
+      "trackList": {
+        "@container": "@set",
+        "@id": "trackList"
+      },
+      "type": "@type",
+      "venues": {
+        "@container": "@set",
+        "@id": "venue"
+      },
+      "nviType": {
+        "@type": "@vocab",
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        }
+      },
+      "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+      "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+      "publicationContextUris": {
+        "@container": "@set"
+      }
+    },
+    "id": "https://api.dev.nva.aws.unit.no/publication/01888b283f29-cae193c7-80fa-4f92-a164-c73b02c19f2d",
+    "entityDescription": {
+      "type": "EntityDescription",
+      "contributors": [
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://www.example.org/9e3de71b-0ecb-4464-b9f1-2f92b974839c",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "type": "Identity",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/123456",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "RoleOther"
+          }
+        },
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.20.0",
+              "type": "Organization"
+            }
+          ],
+          "correspondingAuthor": false,
+          "identity": {
+            "type": "Identity",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/997998",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "Creator"
+          }
+        }
+      ],
+      "publicationDate": {
+        "type": "PublicationDate",
+        "year": "2023"
+      },
+      "reference": {
+        "type": "Reference",
+        "publicationContext": {
+          "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
+          "type": "Journal",
+          "level": "1"
+        },
+        "publicationInstance": {
+          "type": "AcademicLiteratureReview"
+        }
+      }
+    },
+    "status": "PUBLISHED",
+    "identifier": "0188bee8530e-bb78f9a0-d167-4c53-8e70-cedf9994f055"
+  },
+  "consumptionAttributes": {
+    "index": "resources",
+    "documentIdentifier": "0188bee8530e-bb78f9a0-d167-4c53-8e70-cedf9994f055"
+  }
+}

--- a/event-handlers/src/test/resources/evaluator/candidate_academicMonograph.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicMonograph.json
@@ -241,12 +241,12 @@
           "publisher": {
             "id": "https://api.dev.nva.aws.unit.no/publication-channels/d1a0860e-f246-4c8a-a725-98e6bb4fc022",
             "type": "Publisher",
-            "level": "1"
+            "scientificValue": "LevelOne"
           },
           "series": {
             "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
             "type": "Series",
-            "level": "1"
+            "scientificValue": "LevelOne"
           }
         },
         "publicationInstance": {

--- a/event-handlers/src/test/resources/evaluator/candidate_academicMonograph_deprecated.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicMonograph_deprecated.json
@@ -1,0 +1,263 @@
+{
+  "body": {
+    "type": "Publication",
+    "publicationContextUris": [
+      "https://api.dev.nva.aws.unit.no/publication-channels/d1a0860e-f246-4c8a-a725-98e6bb4fc022",
+      "https://api.dev.nva.aws.unit.no/publication-channels/d96f1b8c-a0f0-450d-ac18-5d11a2ea1f1b"
+    ],
+    "@context": {
+      "@vocab": "https://nva.sikt.no/ontology/publication#",
+      "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+      "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+      "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+      "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+      "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+      "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+      "Film": "https://nva.sikt.no/ontology/publication#Film",
+      "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+      "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+      "approvedBy": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+        },
+        "@type": "@vocab"
+      },
+      "activeFrom": {
+        "@type": "xsd:dateTime"
+      },
+      "activeTo": {
+        "@type": "xsd:dateTime"
+      },
+      "additionalIdentifiers": {
+        "@container": "@set",
+        "@id": "additionalIdentifier"
+      },
+      "affiliations": {
+        "@container": "@set",
+        "@id": "affiliation"
+      },
+      "alternativeTitles": {
+        "@container": "@language",
+        "@id": "alternativeTitle"
+      },
+      "approvals": {
+        "@container": "@set",
+        "@id": "approval"
+      },
+      "approvalStatus": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "architectureOutput": {
+        "@container": "@set",
+        "@id": "architectureOutput"
+      },
+      "associatedArtifacts": {
+        "@container": "@set",
+        "@id": "associatedArtifact"
+      },
+      "compliesWith": {
+        "@container": "@set",
+        "@id": "compliesWith"
+      },
+      "concertProgramme": {
+        "@container": "@set",
+        "@id": "concertProgramme"
+      },
+      "contributors": {
+        "@container": "@set",
+        "@id": "contributor"
+      },
+      "createdDate": {
+        "@type": "xsd:dateTime"
+      },
+      "doi": {
+        "@type": "@id"
+      },
+      "embargoDate": {
+        "@type": "xsd:dateTime"
+      },
+      "from": {
+        "@type": "xsd:dateTime"
+      },
+      "fundings": {
+        "@container": "@set",
+        "@id": "funding"
+      },
+      "handle": {
+        "@type": "@id"
+      },
+      "id": "@id",
+      "indexedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "isbnList": {
+        "@container": "@set",
+        "@id": "isbn"
+      },
+      "labels": {
+        "@container": "@language",
+        "@id": "label"
+      },
+      "language": {
+        "@type": "@id"
+      },
+      "link": {
+        "@type": "@id"
+      },
+      "manifestations": {
+        "@container": "@set",
+        "@id": "manifestation"
+      },
+      "metadataSource": {
+        "@type": "@id"
+      },
+      "modifiedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "musicalWorks": {
+        "@container": "@set",
+        "@id": "musicalWork"
+      },
+      "nameType": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "outputs": {
+        "@container": "@set",
+        "@id": "output"
+      },
+      "ownerAffiliation": {
+        "@type": "@id"
+      },
+      "projects": {
+        "@container": "@set",
+        "@id": "project"
+      },
+      "publishedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "referencedBy": {
+        "@container": "@set",
+        "@id": "referencedBy"
+      },
+      "related": {
+        "@container": "@set",
+        "@id": "related"
+      },
+      "status": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "subjects": {
+        "@container": "@set",
+        "@id": "subject",
+        "@type": "@id"
+      },
+      "tags": {
+        "@container": "@set",
+        "@id": "tag"
+      },
+      "to": {
+        "@type": "xsd:dateTime"
+      },
+      "trackList": {
+        "@container": "@set",
+        "@id": "trackList"
+      },
+      "type": "@type",
+      "venues": {
+        "@container": "@set",
+        "@id": "venue"
+      },
+      "nviType": {
+        "@type": "@vocab",
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        }
+      },
+      "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+      "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+      "publicationContextUris": {
+        "@container": "@set"
+      }
+    },
+    "id": "https://api.dev.nva.aws.unit.no/publication/01888b283f29-cae193c7-80fa-4f92-a164-c73b02c19f2d",
+    "entityDescription": {
+      "type": "EntityDescription",
+      "alternativeAbstracts": {},
+      "contributors": [
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://www.example.org/9e3de71b-0ecb-4464-b9f1-2f92b974839c",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "type": "Identity",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/123456",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "RoleOther"
+          }
+        },
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.20.0",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/997998",
+            "type": "Identity",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "Creator"
+          }
+        }
+      ],
+      "publicationDate": {
+        "type": "PublicationDate",
+        "year": "2023"
+      },
+      "reference": {
+        "type": "Reference",
+        "publicationContext": {
+          "type": "Book",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/publication-channels/d1a0860e-f246-4c8a-a725-98e6bb4fc022",
+            "type": "Publisher",
+            "level": "1"
+          },
+          "series": {
+            "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
+            "type": "Series",
+            "level": "1"
+          }
+        },
+        "publicationInstance": {
+          "type": "AcademicMonograph"
+        }
+      }
+    },
+    "status": "PUBLISHED"
+  },
+  "consumptionAttributes": {
+    "index": "resources",
+    "documentIdentifier": "0188bee5a7f1-17acf7d5-5658-4a5a-89b2-b2ea73032661"
+  }
+}

--- a/event-handlers/src/test/resources/evaluator/candidate_academicMonograph_series_multiple_types.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicMonograph_series_multiple_types.json
@@ -241,12 +241,15 @@
           "publisher": {
             "id": "https://api.dev.nva.aws.unit.no/publication-channels/d1a0860e-f246-4c8a-a725-98e6bb4fc022",
             "type": "Publisher",
-            "level": "1"
+            "scientificValue": "LevelOne"
           },
           "series": {
             "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
-            "type": ["Series", "Journal"],
-            "level": "1"
+            "type": [
+              "Series",
+              "Journal"
+            ],
+            "scientificValue": "LevelOne"
           }
         },
         "publicationInstance": {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
@@ -12,16 +12,22 @@ public final class JsonPointers {
     public static final String JSON_POINTER_IDENTITY_VERIFICATION_STATUS = "/identity/verificationStatus";
     public static final String JSON_PTR_INSTANCE_TYPE = "/entityDescription/reference/publicationInstance/type";
     public static final String JSON_PTR_PUBLICATION_CONTEXT = "/entityDescription/reference/publicationContext";
+    @Deprecated
     public static final String JSON_PTR_SERIES_LEVEL = "/entityDescription/reference/publicationContext/series/level";
+    public static final String JSON_PTR_SERIES_SCIENTIFIC_VALUE =
+        "/entityDescription/reference/publicationContext/series/scientificValue";
     public static final String JSON_PTR_SERIES = "/entityDescription/reference/publicationContext/series";
     public static final String JSON_PTR_PUBLISHER =
         "/entityDescription/reference/publicationContext/publisher";
     public static final String JSON_PTR_CHAPTER_PUBLISHER =
         "/entityDescription/reference/publicationContext/entityDescription/reference/publicationContext"
         + "/publisher";
-
+    @Deprecated
     public static final String JSON_PTR_CHAPTER_SERIES_LEVEL =
         "/entityDescription/reference/publicationContext/entityDescription/reference/publicationContext/series/level";
+    public static final String JSON_PTR_CHAPTER_SERIES_SCIENTIFIC_VALUE =
+        "/entityDescription/reference/publicationContext/entityDescription/reference/publicationContext/series"
+        + "/scientificValue";
     public static final String JSON_PTR_CHAPTER_SERIES =
         "/entityDescription/reference/publicationContext/entityDescription/reference/publicationContext/series";
     public static final String JSON_PTR_YEAR = "/year";


### PR DESCRIPTION
Noticed jackson error logged by `EvaluateNviCandidateHandler` for academic chapters and monographs because json pointer for series `level` did not support the new field name `scientificValue`.
Impemented support for both field names `level` an `scientificValue`, and marked old json pointers with Deprecated annotation