### PR TITLE
Np 45509 index document handler

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -1,13 +1,84 @@
 package no.sikt.nva.nvi.index;
 
+import static no.unit.nva.commons.json.JsonUtils.dynamoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import java.net.URI;
+import no.sikt.nva.nvi.common.S3StorageReader;
+import no.sikt.nva.nvi.common.StorageReader;
+import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
+import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
+import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
+import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
 
+    public static final String EXPANDED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
+    private static final Logger LOGGER = LoggerFactory.getLogger(IndexDocumentHandler.class);
+    private final StorageReader<URI> storageReader;
+
+    private final NviCandidateIndexDocumentGenerator documentGenerator;
+
+    @JacocoGenerated
+    public IndexDocumentHandler() {
+        this(new S3StorageReader(new Environment().readEnv(EXPANDED_RESOURCES_BUCKET)),
+             new NviCandidateIndexDocumentGenerator(defaultUriRetriever(new Environment())));
+    }
+
+    public IndexDocumentHandler(StorageReader<URI> storageReader,
+                                NviCandidateIndexDocumentGenerator documentGenerator) {
+        this.storageReader = storageReader;
+        this.documentGenerator = documentGenerator;
+    }
+
     @Override
     public Void handleRequest(SQSEvent input, Context context) {
+        LOGGER.info("Received event with records count: {}", input.getRecords().size());
+        input.getRecords()
+            .stream()
+            .map(SQSMessage::getBody)
+            .map(this::mapToDynamoDbRecord)
+            .map(this::fetchCandidate)
+            .map(this::generateIndexDocument)
+            .forEach(this::saveInCandidateBucket);
         return null;
+    }
+
+    @JacocoGenerated
+    private static AuthorizedBackendUriRetriever defaultUriRetriever(Environment env) {
+        return new AuthorizedBackendUriRetriever(env.readEnv("BACKEND_CLIENT_AUTH_URL"),
+                                                 env.readEnv("BACKEND_CLIENT_SECRET_NAME"));
+    }
+
+    private void saveInCandidateBucket(NviCandidateIndexDocument nviCandidateIndexDocument) {
+        return;
+    }
+
+    private NviCandidateIndexDocument generateIndexDocument(Candidate candidate) {
+        var expandedResource = getPublicationFromBucket(candidate);
+        return documentGenerator.generateDocument(expandedResource, candidate);
+    }
+
+    private Candidate fetchCandidate(DynamodbStreamRecord record) {
+        return null;
+    }
+
+    private String getPublicationFromBucket(Candidate candidate) {
+        var bucketUri = candidate.getPublicationDetails().publicationBucketUri();
+        var result = storageReader.read(bucketUri);
+        LOGGER.info("Fetched {} from bucket", bucketUri);
+        return result;
+    }
+
+    private DynamodbStreamRecord mapToDynamoDbRecord(String body) {
+        return attempt(() -> dynamoObjectMapper.readValue(body, DynamodbStreamRecord.class)).orElseThrow();
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -29,15 +29,16 @@ import org.slf4j.LoggerFactory;
 
 public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
 
-    public static final String ERROR_MESSAGE = "Error message: {}";
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexDocumentHandler.class);
     private static final String EXPANDED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
     private static final String IDENTIFIER = "identifier";
+    private static final String ERROR_MESSAGE = "Error message: {}";
     private static final String FAILED_TO_PERSIST_MESSAGE = "Failed to save {} in bucket";
     private static final String FAILED_TO_PARSE_EVENT_MESSAGE = "Failed to map body to DynamodbStreamRecord: {}";
     private static final String FAILED_TO_FETCH_CANDIDATE_MESSAGE = "Failed to fetch candidate with identifier: {}";
     private static final String FAILED_TO_GENERATE_INDEX_DOCUMENT_MESSAGE =
         "Failed to generate index document for candidate with identifier: {}";
+
     private final StorageReader<URI> storageReader;
     private final StorageWriter<NviCandidateIndexDocument> storageWriter;
     private final CandidateRepository candidateRepository;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -1,0 +1,13 @@
+package no.sikt.nva.nvi.index;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+
+public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
+
+    @Override
+    public Void handleRequest(SQSEvent input, Context context) {
+        return null;
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/UpdateIndexHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/UpdateIndexHandler.java
@@ -30,6 +30,7 @@ import no.sikt.nva.nvi.index.aws.SearchClient;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
+import no.unit.nva.auth.uriretriever.UriRetriever;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
@@ -57,7 +58,7 @@ public class UpdateIndexHandler implements RequestHandler<DynamodbEvent, Void> {
     public UpdateIndexHandler() {
         this(new S3StorageReader(new Environment().readEnv("EXPANDED_RESOURCES_BUCKET")), defaultOpenSearchClient(),
              new CandidateRepository(defaultDynamoClient()), new PeriodRepository(defaultDynamoClient()),
-             new NviCandidateIndexDocumentGenerator(defaultUriRetriever(new Environment())), new NviQueueClient(),
+             new NviCandidateIndexDocumentGenerator(new UriRetriever()), new NviQueueClient(),
              new Environment());
     }
 
@@ -109,12 +110,6 @@ public class UpdateIndexHandler implements RequestHandler<DynamodbEvent, Void> {
 
     private static boolean isCandidate(DynamodbStreamRecord record) {
         return CANDIDATE_TYPE.equals(extractRecordType(record));
-    }
-
-    @JacocoGenerated
-    private static AuthorizedBackendUriRetriever defaultUriRetriever(Environment env) {
-        return new AuthorizedBackendUriRetriever(env.readEnv("BACKEND_CLIENT_AUTH_URL"),
-                                                 env.readEnv("BACKEND_CLIENT_SECRET_NAME"));
     }
 
     private static String getRecordThatCouldNotBeIndexed(DynamodbStreamRecord record) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/S3StorageWriter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/S3StorageWriter.java
@@ -1,0 +1,33 @@
+package no.sikt.nva.nvi.index.aws;
+
+import java.io.IOException;
+import java.net.URI;
+import no.sikt.nva.nvi.common.StorageWriter;
+import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
+import no.unit.nva.s3.S3Driver;
+import nva.commons.core.paths.UnixPath;
+import software.amazon.awssdk.services.s3.S3Client;
+
+public class S3StorageWriter implements StorageWriter<NviCandidateIndexDocument> {
+
+    public static final String NVI_CANDIDATES_FOLDER = "nvi-candidates";
+    public static final String GZIP_ENDING = ".gz";
+    private final S3Driver s3Driver;
+
+    public S3StorageWriter(String bucket) {
+        this(S3Driver.defaultS3Client().build(), bucket);
+    }
+
+    public S3StorageWriter(S3Client client, String bucket) {
+        this.s3Driver = new S3Driver(client, bucket);
+    }
+
+    @Override
+    public URI write(NviCandidateIndexDocument document) throws IOException {
+        return s3Driver.insertFile(createFilePath(document), document.toJsonString());
+    }
+
+    private static UnixPath createFilePath(NviCandidateIndexDocument document) {
+        return UnixPath.of(NVI_CANDIDATES_FOLDER).addChild(document.identifier() + GZIP_ENDING);
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/S3StorageWriter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/S3StorageWriter.java
@@ -5,6 +5,7 @@ import java.net.URI;
 import no.sikt.nva.nvi.common.StorageWriter;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
 import no.unit.nva.s3.S3Driver;
+import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UnixPath;
 import software.amazon.awssdk.services.s3.S3Client;
 
@@ -14,6 +15,7 @@ public class S3StorageWriter implements StorageWriter<NviCandidateIndexDocument>
     public static final String GZIP_ENDING = ".gz";
     private final S3Driver s3Driver;
 
+    @JacocoGenerated
     public S3StorageWriter(String bucket) {
         this(S3Driver.defaultS3Client().build(), bucket);
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Affiliation.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Affiliation.java
@@ -11,13 +11,14 @@ import nva.commons.core.JacocoGenerated;
 public record Affiliation(String id,
                           List<String> partOf) {
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public static final class Builder {
 
         private String id;
         private List<String> partOf;
-
-        public Builder() {
-        }
 
         public Builder withId(String id) {
             this.id = id;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Approval.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Approval.java
@@ -13,15 +13,16 @@ public record Approval(String id,
                        ApprovalStatus approvalStatus,
                        String assignee) {
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public static final class Builder {
 
         private String id;
         private Map<String, String> labels;
         private ApprovalStatus approvalStatus;
         private String assignee;
-
-        public Builder() {
-        }
 
         public Builder withId(String id) {
             this.id = id;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
@@ -12,6 +12,10 @@ public record Contributor(String id,
                           String role,
                           List<Affiliation> affiliations) {
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     public static final class Builder {
 
         private String id;
@@ -19,9 +23,6 @@ public record Contributor(String id,
         private String orcid;
         private String role;
         private List<Affiliation> affiliations;
-
-        public Builder() {
-        }
 
         public Builder withId(String id) {
             this.id = id;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -22,6 +22,10 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
 
     private static final String CONTEXT = "@context";
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
     @JacocoGenerated
     public static class Builder {
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.index.model;
 
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -24,6 +26,10 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public String toJsonString() {
+        return attempt(() -> dtoObjectMapper.writeValueAsString(this)).orElseThrow();
     }
 
     @JacocoGenerated

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -1,10 +1,10 @@
 package no.sikt.nva.nvi.index.model;
 
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
-import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.math.BigDecimal;
 import java.net.URI;
@@ -28,8 +28,8 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         return new Builder();
     }
 
-    public String toJsonString() {
-        return attempt(() -> dtoObjectMapper.writeValueAsString(this)).orElseThrow();
+    public String toJsonString() throws JsonProcessingException {
+        return dtoObjectMapper.writeValueAsString(this);
     }
 
     @JacocoGenerated

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -42,7 +42,7 @@ import no.sikt.nva.nvi.index.model.ExpandedResource.Organization;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.PublicationDate;
 import no.sikt.nva.nvi.index.model.PublicationDetails;
-import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
+import no.unit.nva.auth.uriretriever.UriRetriever;
 import nva.commons.core.attempt.Failure;
 import org.apache.jena.rdf.model.RDFNode;
 import org.slf4j.Logger;
@@ -52,10 +52,10 @@ public final class NviCandidateIndexDocumentGenerator {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NviCandidateIndexDocumentGenerator.class);
     private static final String APPLICATION_JSON = "application/json";
-    private final AuthorizedBackendUriRetriever uriRetriever;
+    private final UriRetriever uriRetriever;
     private final Map<String, String> temporaryCache = new HashMap<>();
 
-    public NviCandidateIndexDocumentGenerator(AuthorizedBackendUriRetriever uriRetriever) {
+    public NviCandidateIndexDocumentGenerator(UriRetriever uriRetriever) {
         this.uriRetriever = uriRetriever;
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -111,11 +111,13 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
                    .withApprovals(expandApprovals(candidate))
                    .withPoints(candidate.getTotalPoints())
                    .withPublicationDetails(expandPublicationDetails(candidate, expandedResource))
+                   .withNumberOfApprovals(candidate.getApprovals().size())
                    .build();
     }
 
     private PublicationDetails expandPublicationDetails(Candidate candidate, JsonNode expandedResource) {
         return PublicationDetails.builder()
+                   .withType(ExpandedResourceGenerator.extractType(expandedResource))
                    .withId(candidate.getPublicationDetails().publicationId().toString())
                    .withTitle(ExpandedResourceGenerator.extractTitle(expandedResource))
                    .withPublicationDate(mapToPublicationDate(candidate.getPublicationDetails().publicationDate()))

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -1,0 +1,188 @@
+package no.sikt.nva.nvi.index;
+
+import static no.sikt.nva.nvi.test.DynamoDbTestUtils.eventWithCandidateIdentifier;
+import static no.sikt.nva.nvi.test.DynamoDbTestUtils.mapToString;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.EN_FIELD;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_LABEL;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.NB_FIELD;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.createExpandedResource;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractAffiliations;
+import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.db.CandidateRepository;
+import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.service.model.Approval;
+import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.utils.JsonUtils;
+import no.sikt.nva.nvi.index.model.Affiliation;
+import no.sikt.nva.nvi.index.model.ApprovalStatus;
+import no.sikt.nva.nvi.index.model.Contributor;
+import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
+import no.sikt.nva.nvi.index.model.PublicationDate;
+import no.sikt.nva.nvi.index.model.PublicationDetails;
+import no.sikt.nva.nvi.test.ExpandedResourceGenerator;
+import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.unit.nva.s3.S3Driver;
+import no.unit.nva.stubs.FakeS3Client;
+import nva.commons.core.paths.UnixPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class IndexDocumentHandlerTest extends LocalDynamoTest {
+
+    private static final URI NVI_CONTEXT = URI.create("https://api.nva.aws.unit.no/context/nvi.jsonld");
+    private static final String HARD_CODED_PART_OF = "HARD_CODED_PART_OF";
+    private static final String RESOURCES_BUCKET_NAME = "RESOURCES_BUCKET_NAME";
+    private static final String CANDIDATES_BUCKET_NAME = "CANDIDATES_BUCKET_NAME";
+    private static final Context CONTEXT = mock(Context.class);
+    private IndexDocumentHandler handler;
+    private CandidateRepository candidateRepository;
+    private PeriodRepository periodRepository;
+
+    private S3Driver resourcesS3Driver;
+    private S3Driver candidateS3Driver;
+
+    @BeforeEach
+    void setup() {
+        var s3Client = new FakeS3Client();
+        resourcesS3Driver = new S3Driver(s3Client, RESOURCES_BUCKET_NAME);
+        candidateS3Driver = new S3Driver(s3Client, CANDIDATES_BUCKET_NAME);
+        var localDynamoDbClient = initializeTestDatabase();
+        candidateRepository = new CandidateRepository(localDynamoDbClient);
+        periodRepository = new PeriodRepository(localDynamoDbClient);
+        handler = new IndexDocumentHandler();
+    }
+
+    @Test
+    void shouldBuildIndexDocumentAndPersistInS3WhenReceivingSQSEvent() {
+        var candidate = randomApplicableCandidate();
+        var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(candidate);
+        var event = createSqsEventWithDynamoDbRecord(candidate.getIdentifier());
+        handler.handleRequest(event, CONTEXT);
+        var actualPersistedIndexDocument = candidateS3Driver.getFile(UnixPath.of(candidate.getIdentifier().toString()));
+        var actualIndexDocument = parseJson(actualPersistedIndexDocument);
+        assertEquals(expectedIndexDocument, actualIndexDocument);
+    }
+
+    private static NviCandidateIndexDocument parseJson(String actualPersistedIndexDocument) {
+        return attempt(() -> dtoObjectMapper.readValue(
+            actualPersistedIndexDocument, NviCandidateIndexDocument.class)).orElseThrow();
+    }
+
+    private static String asString(JsonNode jsonNode) {
+        return attempt(() -> dtoObjectMapper.writeValueAsString(jsonNode)).orElseThrow();
+    }
+
+    private static String generateSingleDynamoDbEventRecord(UUID candidateIdentifier) {
+        return mapToString(eventWithCandidateIdentifier(candidateIdentifier).getRecords().get(0));
+    }
+
+    private NviCandidateIndexDocument setUpExistingResourceInS3AndGenerateExpectedDocument(
+        Candidate persistedCandidate) {
+        var expandedResource = createExpandedResource(persistedCandidate);
+        insertResourceInS3(expandedResource,
+                           UnixPath.of(persistedCandidate.getPublicationDetails().publicationBucketUri().toString()));
+        return createExpectedIndexDocument(expandedResource, persistedCandidate);
+    }
+
+    private void insertResourceInS3(JsonNode expandedResource, UnixPath path) {
+        attempt(() -> resourcesS3Driver.insertFile(path, asString(expandedResource)));
+    }
+
+    private NviCandidateIndexDocument createExpectedIndexDocument(JsonNode expandedResource, Candidate candidate) {
+        return NviCandidateIndexDocument.builder()
+                   .withContext(NVI_CONTEXT)
+                   .withIdentifier(candidate.getIdentifier().toString())
+                   .withApprovals(expandApprovals(candidate))
+                   .withPoints(candidate.getTotalPoints())
+                   .withPublicationDetails(expandPublicationDetails(candidate, expandedResource))
+                   .build();
+    }
+
+    private PublicationDetails expandPublicationDetails(Candidate candidate, JsonNode expandedResource) {
+        return PublicationDetails.builder()
+                   .withId(candidate.getPublicationDetails().publicationId().toString())
+                   .withTitle(ExpandedResourceGenerator.extractTitle(expandedResource))
+                   .withPublicationDate(mapToPublicationDate(candidate.getPublicationDetails().publicationDate()))
+                   .withContributors(mapToContributors(ExpandedResourceGenerator.extractContributors(expandedResource)))
+                   .build();
+    }
+
+    private PublicationDate mapToPublicationDate(
+        no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate publicationDate) {
+        return new PublicationDate(publicationDate.year(), publicationDate.month(), publicationDate.day());
+    }
+
+    private List<Contributor> mapToContributors(ArrayNode contributorNodes) {
+        return JsonUtils.streamNode(contributorNodes)
+                   .map(this::toContributor)
+                   .toList();
+    }
+
+    private Contributor toContributor(JsonNode contributorNode) {
+        return Contributor.builder()
+                   .withId(ExpandedResourceGenerator.extractId(contributorNode))
+                   .withName(ExpandedResourceGenerator.extractName(contributorNode))
+                   .withOrcid(ExpandedResourceGenerator.extractOrcid(contributorNode))
+                   .withRole(ExpandedResourceGenerator.extractRole(contributorNode))
+                   .withAffiliations(mapToAffiliations(extractAffiliations(contributorNode)))
+                   .build();
+    }
+
+    private List<Affiliation> mapToAffiliations(List<URI> uris) {
+        return uris.stream().map(this::toAffiliation).toList();
+    }
+
+    private Affiliation toAffiliation(URI uri) {
+        return Affiliation.builder()
+                   .withId(uri.toString())
+                   .withPartOf(List.of(HARD_CODED_PART_OF))
+                   .build();
+    }
+
+    private List<no.sikt.nva.nvi.index.model.Approval> expandApprovals(Candidate candidate) {
+        return candidate.getApprovals()
+                   .entrySet()
+                   .stream()
+                   .map(this::toApproval)
+                   .toList();
+    }
+
+    private no.sikt.nva.nvi.index.model.Approval toApproval(Entry<URI, Approval> approvalEntry) {
+        var assignee = approvalEntry.getValue().getAssignee();
+        return no.sikt.nva.nvi.index.model.Approval.builder()
+                   .withId(approvalEntry.getKey().toString())
+                   .withApprovalStatus(ApprovalStatus.fromValue(approvalEntry.getValue().getStatus().getValue()))
+                   .withAssignee(Objects.nonNull(assignee) ? assignee.value() : null)
+                   .withLabels(Map.of(EN_FIELD, HARDCODED_ENGLISH_LABEL, NB_FIELD, HARDCODED_NORWEGIAN_LABEL))
+                   .build();
+    }
+
+    private Candidate randomApplicableCandidate() {
+        return Candidate.fromRequest(createUpsertCandidateRequest(2023), candidateRepository, periodRepository)
+                   .orElseThrow();
+    }
+
+    private SQSEvent createSqsEventWithDynamoDbRecord(UUID candidateIdentifier) {
+        var sqsEvent = new SQSEvent();
+        var message = new SQSMessage();
+        message.setBody(generateSingleDynamoDbEventRecord(candidateIdentifier));
+        sqsEvent.setRecords(List.of(message));
+        return sqsEvent;
+    }
+}

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -49,7 +49,7 @@ import no.sikt.nva.nvi.index.model.PublicationDetails;
 import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.sikt.nva.nvi.test.ExpandedResourceGenerator;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
-import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
+import no.unit.nva.auth.uriretriever.UriRetriever;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
 import nva.commons.core.Environment;
@@ -77,7 +77,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     private PeriodRepository periodRepository;
     private S3Driver s3Reader;
     private S3Driver s3Writer;
-    private AuthorizedBackendUriRetriever uriRetriever;
+    private UriRetriever uriRetriever;
     private NviCandidateIndexDocumentGenerator documentGenerator;
 
     @BeforeEach
@@ -87,7 +87,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         var localDynamoDbClient = initializeTestDatabase();
         candidateRepository = new CandidateRepository(localDynamoDbClient);
         periodRepository = new PeriodRepository(localDynamoDbClient);
-        uriRetriever = mock(AuthorizedBackendUriRetriever.class);
+        uriRetriever = mock(UriRetriever.class);
         documentGenerator = new NviCandidateIndexDocumentGenerator(uriRetriever);
         handler = new IndexDocumentHandler(new S3StorageReader(s3Client, BUCKET_NAME),
                                            new S3StorageWriter(s3Client, BUCKET_NAME), candidateRepository,

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -10,19 +10,25 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.createExpandedResou
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractAffiliations;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.S3StorageReader;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -30,6 +36,7 @@ import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.model.Approval;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.utils.JsonUtils;
+import no.sikt.nva.nvi.index.aws.S3StorageWriter;
 import no.sikt.nva.nvi.index.model.Affiliation;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.Contributor;
@@ -42,36 +49,46 @@ import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
+import nva.commons.core.Environment;
 import nva.commons.core.paths.UnixPath;
+import nva.commons.core.paths.UriWrapper;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
-    private static final URI NVI_CONTEXT = URI.create("https://api.nva.aws.unit.no/context/nvi.jsonld");
-    private static final String HARD_CODED_PART_OF = "HARD_CODED_PART_OF";
-    private static final String RESOURCES_BUCKET_NAME = "RESOURCES_BUCKET_NAME";
-    private static final String CANDIDATES_BUCKET_NAME = "CANDIDATES_BUCKET_NAME";
+    private static final String BODY = "body";
+    private static final String NVI_CANDIDATES_FOLDER = "nvi-candidates";
+    private static final String GZIP_ENDING = ".gz";
+    private static final String ORGANIZATION_CONTEXT = "https://bibsysdev.github.io/src/organization-context.json";
+    private static final URI NVI_CONTEXT = URI.create("https://bibsysdev.github.io/src/nvi-context.json");
+    private static final String HARD_CODED_PART_OF = "https://example.org/organization/hardCodedPartOf";
+    private static final String EXPANDED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
     private static final Context CONTEXT = mock(Context.class);
     private IndexDocumentHandler handler;
     private CandidateRepository candidateRepository;
     private PeriodRepository periodRepository;
-
-    private S3Driver resourcesS3Driver;
-    private S3Driver candidateS3Driver;
+    private S3Driver s3Reader;
+    private S3Driver s3Writer;
+    private AuthorizedBackendUriRetriever uriRetriever;
 
     @BeforeEach
     void setup() {
         var s3Client = new FakeS3Client();
-        resourcesS3Driver = new S3Driver(s3Client, RESOURCES_BUCKET_NAME);
-        candidateS3Driver = new S3Driver(s3Client, CANDIDATES_BUCKET_NAME);
-        var storageReader = new S3StorageReader(s3Client, RESOURCES_BUCKET_NAME);
+        var environment = new Environment();
+        var bucketName = environment.readEnv(EXPANDED_RESOURCES_BUCKET);
+        s3Reader = new S3Driver(s3Client, bucketName);
+        var storageReader = new S3StorageReader(s3Client, bucketName);
+        s3Writer = new S3Driver(s3Client, bucketName);
+        var storageWriter = new S3StorageWriter(s3Client, bucketName);
         var localDynamoDbClient = initializeTestDatabase();
         candidateRepository = new CandidateRepository(localDynamoDbClient);
         periodRepository = new PeriodRepository(localDynamoDbClient);
-        AuthorizedBackendUriRetriever uriRetriever = mock(AuthorizedBackendUriRetriever.class);
-        NviCandidateIndexDocumentGenerator documentGenerator = new NviCandidateIndexDocumentGenerator(uriRetriever);
-        handler = new IndexDocumentHandler(storageReader, documentGenerator);
+        uriRetriever = mock(AuthorizedBackendUriRetriever.class);
+        var documentGenerator = new NviCandidateIndexDocumentGenerator(uriRetriever);
+        handler = new IndexDocumentHandler(storageReader, storageWriter, candidateRepository, periodRepository,
+                                           documentGenerator);
     }
 
     @Test
@@ -79,10 +96,15 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         var candidate = randomApplicableCandidate();
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(candidate);
         var event = createSqsEventWithDynamoDbRecord(candidate.getIdentifier());
+        mockUriRetrieverOrgResponse(candidate);
         handler.handleRequest(event, CONTEXT);
-        var actualPersistedIndexDocument = candidateS3Driver.getFile(UnixPath.of(candidate.getIdentifier().toString()));
+        var actualPersistedIndexDocument = s3Writer.getFile(createPath(candidate));
         var actualIndexDocument = parseJson(actualPersistedIndexDocument);
         assertEquals(expectedIndexDocument, actualIndexDocument);
+    }
+
+    private static UnixPath createPath(Candidate candidate) {
+        return UnixPath.of(NVI_CANDIDATES_FOLDER).addChild(candidate.getIdentifier().toString() + GZIP_ENDING);
     }
 
     private static NviCandidateIndexDocument parseJson(String actualPersistedIndexDocument) {
@@ -98,19 +120,61 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         return mapToString(eventWithCandidateIdentifier(candidateIdentifier).getRecords().get(0));
     }
 
+    @NotNull
+    private static ObjectNode generateOrganizationNode(String hardCodedPartOf) {
+        var hardCodedPartOfNode = dtoObjectMapper.createObjectNode();
+        hardCodedPartOfNode.put("id", hardCodedPartOf);
+        hardCodedPartOfNode.put("type", "Organization");
+        hardCodedPartOfNode.put("@context", ORGANIZATION_CONTEXT);
+        return hardCodedPartOfNode;
+    }
+
+    private void mockUriRetrieverOrgResponse(Candidate candidate) {
+        candidate.getPublicationDetails()
+            .creators()
+            .stream()
+            .flatMap(creator -> creator.affiliations().stream())
+            .forEach(this::mockOrganizationResponse);
+    }
+
+    private void mockOrganizationResponse(URI affiliation) {
+        when(uriRetriever.getRawContent(eq(affiliation), any())).thenReturn(
+            generateResponse(affiliation));
+    }
+
+    private Optional<String> generateResponse(URI affiliation) {
+        var affiliationOrganizationNode = generateOrganizationNode(affiliation.toString());
+        var partOfArrayNode = dtoObjectMapper.createArrayNode();
+        var partOfOrganizationNode = generateOrganizationNode(HARD_CODED_PART_OF);
+        partOfArrayNode.add(partOfOrganizationNode);
+        affiliationOrganizationNode.set("partOf", partOfArrayNode);
+        return Optional.of(
+            attempt(() -> dtoObjectMapper.writeValueAsString(affiliationOrganizationNode)).orElseThrow());
+    }
+
     private NviCandidateIndexDocument setUpExistingResourceInS3AndGenerateExpectedDocument(
         Candidate persistedCandidate) {
         var expandedResource = createExpandedResource(persistedCandidate);
-        insertResourceInS3(expandedResource,
-                           UnixPath.of(persistedCandidate.getPublicationDetails().publicationBucketUri().toString()));
-        return createExpectedIndexDocument(expandedResource, persistedCandidate);
+        var resourceIndexDocument = createResourceIndexDocument(expandedResource);
+        var resourcePath =
+            UriWrapper.fromUri(persistedCandidate.getPublicationDetails().publicationBucketUri())
+                .getPath()
+                .getLastPathElement();
+        insertResourceInS3(resourceIndexDocument, UnixPath.of(resourcePath));
+        return createExpectedNviIndexDocument(expandedResource, persistedCandidate);
     }
 
-    private void insertResourceInS3(JsonNode expandedResource, UnixPath path) {
-        attempt(() -> resourcesS3Driver.insertFile(path, asString(expandedResource)));
+    private JsonNode createResourceIndexDocument(JsonNode expandedResource) {
+        var root = objectMapper.createObjectNode();
+        root.set(BODY, expandedResource);
+        return root;
     }
 
-    private NviCandidateIndexDocument createExpectedIndexDocument(JsonNode expandedResource, Candidate candidate) {
+    private void insertResourceInS3(JsonNode indexDocument, UnixPath path) {
+        attempt(() -> s3Reader.insertFile(path, asString(indexDocument)));
+    }
+
+    private NviCandidateIndexDocument createExpectedNviIndexDocument(JsonNode expandedResource, Candidate candidate) {
         return NviCandidateIndexDocument.builder()
                    .withContext(NVI_CONTEXT)
                    .withIdentifier(candidate.getIdentifier().toString())

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
@@ -62,7 +62,7 @@ import no.sikt.nva.nvi.index.model.PublicationDate;
 import no.sikt.nva.nvi.index.model.PublicationDetails;
 import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
-import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
+import no.unit.nva.auth.uriretriever.UriRetriever;
 import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.Environment;
 import nva.commons.core.StringUtils;
@@ -94,7 +94,7 @@ class UpdateIndexHandlerTest extends LocalDynamoTest {
     private FakeSearchClient openSearchClient;
     private CandidateRepository candidateRepository;
     private PeriodRepository periodRepository;
-    private AuthorizedBackendUriRetriever uriRetriever;
+    private UriRetriever uriRetriever;
     private NviCandidateIndexDocumentGenerator generator;
     private QueueClient<NviSendMessageResponse, NviSendMessageBatchResponse> queueClient;
     private Environment env;
@@ -105,7 +105,7 @@ class UpdateIndexHandlerTest extends LocalDynamoTest {
         when(env.readEnv("UPDATE_INDEX_DLQ_QUEUE_URL")).thenReturn(DLQ_QUEUE_URL);
 
         storageReader = mock(StorageReader.class);
-        uriRetriever = mock(AuthorizedBackendUriRetriever.class);
+        uriRetriever = mock(UriRetriever.class);
         openSearchClient = new FakeSearchClient();
         candidateRepository = new CandidateRepository(initializeTestDatabase());
         periodRepository = new PeriodRepository(initializeTestDatabase());

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/StorageWriter.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/StorageWriter.java
@@ -1,0 +1,9 @@
+package no.sikt.nva.nvi.common;
+
+import java.io.IOException;
+import java.net.URI;
+
+public interface StorageWriter<T> {
+
+    URI write(T blob) throws IOException;
+}

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
@@ -66,6 +66,7 @@ public final class ExpandedResourceGenerator {
 
     public static List<URI> extractAffiliations(JsonNode contributorNode) {
         return JsonUtils.streamNode(contributorNode.at("/affiliations"))
+                   .map(affiliationNode -> affiliationNode.at("/id"))
                    .map(JsonNode::asText)
                    .map(URI::create)
                    .toList();
@@ -84,7 +85,12 @@ public final class ExpandedResourceGenerator {
     }
 
     public static String extractRole(JsonNode contributorNode) {
-        return JsonUtils.extractJsonNodeTextValue(contributorNode, "/role");
+        return JsonUtils.extractJsonNodeTextValue(contributorNode, "/role/type");
+    }
+
+    public static String extractType(JsonNode expandedResource) {
+        return JsonUtils.extractJsonNodeTextValue(expandedResource,
+                                                  "/entityDescription/reference/publicationInstance/type");
     }
 
     private static ObjectNode createAndPopulatePublicationDate(PublicationDate date) {


### PR DESCRIPTION
First version of `IndexDocumentHandler`, there is more to come covering rest of tests for todays `UpdateIndexHandler`.

Implemented "happy case" and error handling (except for sending message to common DLQ, see todo)).
Worried the error handling implementation is a bit of an overkill? Should I extract most of the implementation to a `IndexDocumentService` and have more of a catch-all error handling? Let med know your thoughts :)