### PR TITLE
DynamoDbEventToQueueHandler DLQ

### DIFF
--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -58,6 +58,7 @@ test {
     environment("UPSERT_CANDIDATE_DLQ_QUEUE_URL", "UpsertCandidateDLQ")
     environment("PERSISTED_RESOURCE_QUEUE_URL", "PersistedResourceQueue")
     environment("DB_EVENTS_QUEUE_URL", "DbEventsQueue")
+    environment("INDEX_DLQ", "IndexDlq")
     environment "EXPANDED_RESOURCES_BUCKET", "ignoredBucket"
     environment "BACKEND_CLIENT_AUTH_URL", "My url"
     environment "BACKEND_CLIENT_SECRET_NAME", "My secret name"

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DynamoDbEventToQueueHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DynamoDbEventToQueueHandler.java
@@ -27,6 +27,7 @@ public class DynamoDbEventToQueueHandler implements RequestHandler<DynamodbEvent
     private static final int BATCH_SIZE = 10;
     private static final String DB_EVENTS_QUEUE_URL = "DB_EVENTS_QUEUE_URL";
     private static final String DLQ_URL = "INDEX_DLQ";
+    private static final String DLQ_MESSAGE = "Failed to process record %s. Exception message: %s ";
     private static final String FAILURE_MESSAGE = "Failure while sending database events to queue";
     private static final String FAILED_RECORDS_MESSAGE = "Failed records: {}";
     private static final String INFO_MESSAGE = "Sent {} messages to queue. Failures: {}";
@@ -83,12 +84,12 @@ public class DynamoDbEventToQueueHandler implements RequestHandler<DynamodbEvent
     private RuntimeException handleFailure(Failure<Object> failure, List<DynamodbStreamRecord> records) {
         LOGGER.error(FAILURE_MESSAGE, failure.getException());
         LOGGER.error(FAILED_RECORDS_MESSAGE, records.stream().map(DynamodbStreamRecord::toString).toList());
-        records.forEach(record -> sendToDlq(failure, record));
+        records.forEach(record -> sendToDlq(record, failure.getException()));
         return new RuntimeException(failure.getException());
     }
 
-    private void sendToDlq(Failure<Object> failure, DynamodbStreamRecord record) {
-        var message = failure.getException().getMessage();
+    private void sendToDlq(DynamodbStreamRecord record, Exception exception) {
+        var message = String.format(DLQ_MESSAGE, record.toString(), exception.getMessage());
         extractIdFromRecord(record)
             .ifPresentOrElse(id -> queueClient.sendMessage(message, dlqUrl, id),
                              () -> queueClient.sendMessage(message, dlqUrl));

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DynamoDbEventToQueueHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DynamoDbEventToQueueHandler.java
@@ -7,6 +7,8 @@ import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.queue.NviQueueClient;
@@ -24,9 +26,12 @@ public class DynamoDbEventToQueueHandler implements RequestHandler<DynamodbEvent
     private static final Logger LOGGER = LoggerFactory.getLogger(DynamoDbEventToQueueHandler.class);
     private static final int BATCH_SIZE = 10;
     private static final String DB_EVENTS_QUEUE_URL = "DB_EVENTS_QUEUE_URL";
+    private static final String DLQ_URL = "INDEX_DLQ";
     private static final String FAILURE_MESSAGE = "Failure while sending database events to queue";
     private static final String FAILED_RECORDS_MESSAGE = "Failed records: {}";
     private static final String INFO_MESSAGE = "Sent {} messages to queue. Failures: {}";
+    private static final String IDENTIFIER = "identifier";
+    public final String dlqUrl;
     private final QueueClient<NviSendMessageResponse, NviSendMessageBatchResponse> queueClient;
     private final String queueUrl;
 
@@ -39,6 +44,7 @@ public class DynamoDbEventToQueueHandler implements RequestHandler<DynamodbEvent
                                        Environment environment) {
         this.queueClient = queueClient;
         this.queueUrl = environment.readEnv(DB_EVENTS_QUEUE_URL);
+        this.dlqUrl = environment.readEnv(DLQ_URL);
     }
 
     @Override
@@ -58,6 +64,16 @@ public class DynamoDbEventToQueueHandler implements RequestHandler<DynamodbEvent
         return attempt(() -> dtoObjectMapper.writeValueAsString(record)).orElseThrow();
     }
 
+    private static UUID extractIdFromRecord(DynamodbStreamRecord record) {
+        return attempt(() -> UUID.fromString(extractIdentifier(record))).orElse(failure -> null);
+    }
+
+    private static String extractIdentifier(DynamodbStreamRecord record) {
+        return Optional.ofNullable(record.getDynamodb().getOldImage())
+                   .orElse(record.getDynamodb().getNewImage())
+                   .get(IDENTIFIER).getS();
+    }
+
     private void splitIntoBatchesAndSend(DynamodbEvent input) {
         splitIntoBatches(input.getRecords())
             .map(DynamoDbEventToQueueHandler::mapToJsonStrings)
@@ -67,7 +83,12 @@ public class DynamoDbEventToQueueHandler implements RequestHandler<DynamodbEvent
     private RuntimeException handleFailure(Failure<Object> failure, List<DynamodbStreamRecord> records) {
         LOGGER.error(FAILURE_MESSAGE, failure.getException());
         LOGGER.error(FAILED_RECORDS_MESSAGE, records.stream().map(DynamodbStreamRecord::toString).toList());
+        records.forEach(record -> sendToDlq(failure, record));
         return new RuntimeException(failure.getException());
+    }
+
+    private void sendToDlq(Failure<Object> failure, DynamodbStreamRecord record) {
+        queueClient.sendMessage(failure.getException().getMessage(), dlqUrl, extractIdFromRecord(record));
     }
 
     private void sendBatch(List<String> messages) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbEventToQueueHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbEventToQueueHandlerTest.java
@@ -1,6 +1,8 @@
 package no.sikt.nva.nvi.events.db;
 
+import static no.sikt.nva.nvi.test.DynamoDbTestUtils.eventWithCandidateIdentifier;
 import static no.sikt.nva.nvi.test.DynamoDbTestUtils.mapToMessageBodies;
+import static no.sikt.nva.nvi.test.DynamoDbTestUtils.randomDynamoDbEvent;
 import static no.sikt.nva.nvi.test.DynamoDbTestUtils.randomEventWithNumberOfDynamoRecords;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -17,7 +19,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import java.util.List;
 import java.util.UUID;
 import no.sikt.nva.nvi.events.evaluator.FakeSqsClient;
-import no.sikt.nva.nvi.test.DynamoDbTestUtils;
 import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,12 +55,22 @@ public class DynamoDbEventToQueueHandlerTest {
     @Test
     void shouldSendMessageToDlqIfSendingBatchFails() {
         var candidateIdentifier = UUID.randomUUID();
-        var dynamoDbEvent = DynamoDbTestUtils.eventWithCandidateIdentifier(candidateIdentifier);
+        var dynamoDbEvent = eventWithCandidateIdentifier(candidateIdentifier);
         var fakeSqsClient = mock(FakeSqsClient.class);
         when(fakeSqsClient.sendMessageBatch(any(), any())).thenThrow(sqsExceptionWIthMessage());
         var handler = new DynamoDbEventToQueueHandler(fakeSqsClient, new Environment());
         assertThrows(RuntimeException.class, () -> handler.handleRequest(dynamoDbEvent, CONTEXT));
         verify(fakeSqsClient, times(1)).sendMessage(anyString(), eq(DLQ_URL), eq(candidateIdentifier));
+    }
+
+    @Test
+    void shouldSendMessageToDlqWithoutCandidateIdentifierIfSendingBatchFailsAndUnableToExtractRecordIdentifier() {
+        var dynamoDbEvent = randomDynamoDbEvent();
+        var fakeSqsClient = mock(FakeSqsClient.class);
+        when(fakeSqsClient.sendMessageBatch(any(), any())).thenThrow(sqsExceptionWIthMessage());
+        var handler = new DynamoDbEventToQueueHandler(fakeSqsClient, new Environment());
+        assertThrows(RuntimeException.class, () -> handler.handleRequest(dynamoDbEvent, CONTEXT));
+        verify(fakeSqsClient, times(1)).sendMessage(anyString(), eq(DLQ_URL));
     }
 
     @Test

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
@@ -1,8 +1,10 @@
 package no.sikt.nva.nvi.common.queue;
 
+import static java.util.Objects.nonNull;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.utils.ApplicationConstants;
 import nva.commons.core.JacocoGenerated;
@@ -10,6 +12,7 @@ import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
@@ -19,6 +22,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
 public class NviQueueClient implements QueueClient<NviSendMessageResponse, NviSendMessageBatchResponse> {
 
+    public static final String CANDIDATE_IDENTIFIER = "candidateIdentifier";
     private static final int MAX_CONNECTIONS = 10_000;
     private static final int IDLE_TIME = 30;
     private static final int TIMEOUT_TIME = 30;
@@ -39,6 +43,14 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse, NviSe
     }
 
     @Override
+    public NviSendMessageResponse sendMessage(String message, String queueUrl, UUID candidateIdentifier) {
+        return createResponse(sqsClient.sendMessage(createRequest(message, queueUrl,
+                                                                  nonNull(candidateIdentifier)
+                                                                      ? getMessageAttributes(candidateIdentifier)
+                                                                      : Map.of())));
+    }
+
+    @Override
     public NviSendMessageBatchResponse sendMessageBatch(Collection<String> messages, String queueUrl) {
         return createResponse(sqsClient.sendMessageBatch(createBatchRequest(messages, queueUrl)));
     }
@@ -49,6 +61,13 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse, NviSe
                    .region(ApplicationConstants.REGION)
                    .httpClient(httpClientForConcurrentQueries())
                    .build();
+    }
+
+    private static Map<String, MessageAttributeValue> getMessageAttributes(UUID candidateIdentifier) {
+        return Map.of(CANDIDATE_IDENTIFIER,
+                      MessageAttributeValue.builder()
+                          .stringValue(candidateIdentifier.toString())
+                          .build());
     }
 
     @JacocoGenerated
@@ -73,6 +92,15 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse, NviSe
         return SendMessageRequest.builder()
                    .queueUrl(queueUrl)
                    .messageBody(body)
+                   .build();
+    }
+
+    private SendMessageRequest createRequest(String body, String queueUrl,
+                                             Map<String, MessageAttributeValue> messageAttributes) {
+        return SendMessageRequest.builder()
+                   .queueUrl(queueUrl)
+                   .messageBody(body)
+                   .messageAttributes(messageAttributes)
                    .build();
     }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.common.queue;
 
-import static java.util.Objects.nonNull;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
@@ -45,9 +44,7 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse, NviSe
     @Override
     public NviSendMessageResponse sendMessage(String message, String queueUrl, UUID candidateIdentifier) {
         return createResponse(sqsClient.sendMessage(createRequest(message, queueUrl,
-                                                                  nonNull(candidateIdentifier)
-                                                                      ? getMessageAttributes(candidateIdentifier)
-                                                                      : Map.of())));
+                                                                  getMessageAttributes(candidateIdentifier))));
     }
 
     @Override

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/QueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/QueueClient.java
@@ -1,10 +1,13 @@
 package no.sikt.nva.nvi.common.queue;
 
 import java.util.Collection;
+import java.util.UUID;
 
 public interface QueueClient<T, R> {
 
     T sendMessage(String message, String queueUrl);
+
+    T sendMessage(String message, String queueUrl, UUID candidateIdentifier);
 
     R sendMessageBatch(Collection<String> messages, String queueUrl);
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/queue/NviQueueClientTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/queue/NviQueueClientTest.java
@@ -5,12 +5,16 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequest;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResponse;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchResultEntry;
@@ -23,6 +27,7 @@ public class NviQueueClientTest {
     public static final String TEST_QUEUE_URL = "url";
     public static final String TEST_MESSAGE_ID = "some_test_id";
     public static final String MESSAGE_FAILED_ID = "some_failed_id";
+    public static final String MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER = "candidateIdentifier";
 
     @Test
     void shouldSendSqsMessageAndReturnId() {
@@ -32,6 +37,19 @@ public class NviQueueClientTest {
         var client = new NviQueueClient(sqsClient);
 
         var result = client.sendMessage(TEST_PAYLOAD, TEST_QUEUE_URL);
+
+        assertThat(result.messageId(), is(equalTo(TEST_MESSAGE_ID)));
+    }
+
+    @Test
+    void shouldSendSqsMessageWithCandidateIdentifierAsMessageAttribute() {
+        var sqsClient = mock(SqsClient.class);
+        var candidateIdentifier = UUID.randomUUID();
+        when(sqsClient.sendMessage(eq(expectedSendMessageRequest(candidateIdentifier)))).thenReturn(
+            SendMessageResponse.builder().messageId(TEST_MESSAGE_ID).build());
+        var client = new NviQueueClient(sqsClient);
+
+        var result = client.sendMessage(TEST_PAYLOAD, TEST_QUEUE_URL, candidateIdentifier);
 
         assertThat(result.messageId(), is(equalTo(TEST_MESSAGE_ID)));
     }
@@ -49,5 +67,15 @@ public class NviQueueClientTest {
         var result = client.sendMessageBatch(List.of(TEST_PAYLOAD), TEST_QUEUE_URL);
         assertThat(result.successful(), containsInAnyOrder(TEST_MESSAGE_ID));
         assertThat(result.failed(), containsInAnyOrder(MESSAGE_FAILED_ID));
+    }
+
+    private static SendMessageRequest expectedSendMessageRequest(UUID candidateIdentifier) {
+        return SendMessageRequest.builder()
+                   .messageBody(TEST_PAYLOAD)
+                   .messageAttributes(Map.of(MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER,
+                                             MessageAttributeValue.builder()
+                                                 .stringValue(candidateIdentifier.toString())
+                                                 .build()))
+                   .queueUrl(TEST_QUEUE_URL).build();
     }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
@@ -21,10 +21,16 @@ public final class DynamoDbTestUtils {
     private DynamoDbTestUtils() {
     }
 
-    //TODO: To be used in new tests for new IndexDocumentHandler
     public static DynamodbEvent eventWithCandidateIdentifier(UUID candidateIdentifier) {
         var dynamoDbEvent = new DynamodbEvent();
-        var dynamoDbRecord = dynamoRecordWithIdentifier(candidateIdentifier);
+        var dynamoDbRecord = dynamoRecordWithIdentifier(payloadWithIdentifier(candidateIdentifier));
+        dynamoDbEvent.setRecords(List.of(dynamoDbRecord));
+        return dynamoDbEvent;
+    }
+
+    public static DynamodbEvent randomDynamoDbEvent() {
+        var dynamoDbEvent = new DynamodbEvent();
+        var dynamoDbRecord = dynamoRecordWithIdentifier(randomPayload());
         dynamoDbEvent.setRecords(List.of(dynamoDbRecord));
         return dynamoDbEvent;
     }
@@ -32,7 +38,7 @@ public final class DynamoDbTestUtils {
     public static DynamodbEvent randomEventWithNumberOfDynamoRecords(int numberOfRecords) {
         var event = new DynamodbEvent();
         var records = IntStream.range(0, numberOfRecords)
-                          .mapToObj(index -> dynamoRecordWithIdentifier(UUID.randomUUID()))
+                          .mapToObj(index -> dynamoRecordWithIdentifier(payloadWithIdentifier(UUID.randomUUID())))
                           .toList();
         event.setRecords(records);
         return event;
@@ -49,12 +55,12 @@ public final class DynamoDbTestUtils {
         return attempt(() -> dynamoObjectMapper.writeValueAsString(record)).orElseThrow();
     }
 
-    private static DynamodbStreamRecord dynamoRecordWithIdentifier(UUID candidateIdentifier) {
+    private static DynamodbStreamRecord dynamoRecordWithIdentifier(StreamRecord record) {
         var streamRecord = new DynamodbStreamRecord();
         streamRecord.setEventName(randomElement(OperationType.values()));
         streamRecord.setEventID(randomString());
         streamRecord.setAwsRegion(randomString());
-        streamRecord.setDynamodb(payloadWithIdentifier(candidateIdentifier));
+        streamRecord.setDynamodb(record);
         streamRecord.setEventSource(randomString());
         streamRecord.setEventVersion(randomString());
         return streamRecord;
@@ -64,6 +70,12 @@ public final class DynamoDbTestUtils {
         var streamRecord = new StreamRecord();
         streamRecord.setOldImage(randomDynamoPayload(candidateIdentifier));
         streamRecord.setNewImage(randomDynamoPayload(candidateIdentifier));
+        return streamRecord;
+    }
+
+    private static StreamRecord randomPayload() {
+        var streamRecord = new StreamRecord();
+        streamRecord.setOldImage(Map.of(IDENTIFIER, new AttributeValue(randomString())));
         return streamRecord;
     }
 


### PR DESCRIPTION
`DynamoDbEventToQueueHandler`: Should send message to DLQ with `messageAttribute` `candidateIdentifier` when handling error.
See DLQ in diagram in [Jira task](https://unit.atlassian.net/browse/NP-45509)
(Cfn for DLQ coming later)