### PR TITLE
Np 45509 DataEntryUpdateHandler

### DIFF
--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 
     implementation libs.aws.sdk2.sqs
     implementation libs.aws.sdk2.s3
+    implementation libs.aws.sdk2.sns
     implementation libs.aws.sdk2.eventbridge
     implementation libs.aws.sdk2.dynamodb
     implementation libs.aws.sdk2.urlconnectionclient

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandler.java
@@ -1,0 +1,33 @@
+package no.sikt.nva.nvi.events.db;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import no.sikt.nva.nvi.common.notification.NotificationClient;
+import no.sikt.nva.nvi.common.notification.NviNotificationClient;
+import no.sikt.nva.nvi.common.notification.NviPublishMessageResponse;
+import nva.commons.core.JacocoGenerated;
+
+public class DataEntryUpdateHandler implements RequestHandler<SQSEvent, Void> {
+
+    public static final String CANDIDATE_UPDATE_APPLICABLE = "Candidate.Update.Applicable";
+    private final NotificationClient<NviPublishMessageResponse> snsClient;
+
+    @JacocoGenerated
+    public DataEntryUpdateHandler() {
+        this(new NviNotificationClient());
+    }
+
+    public DataEntryUpdateHandler(NotificationClient<NviPublishMessageResponse> snsClient) {
+        this.snsClient = snsClient;
+    }
+
+    //TODO: Handle all dao types
+    @Override
+    public Void handleRequest(SQSEvent input, Context context) {
+        input.getRecords().stream()
+            .map(SQSEvent.SQSMessage::getBody)
+            .forEach(message -> snsClient.publish(message, CANDIDATE_UPDATE_APPLICABLE));
+        return null;
+    }
+}

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -32,8 +32,7 @@ public class DataEntryUpdateHandlerTest {
         var event = createEvent(candidate);
 
         handler.handleRequest(event, CONTEXT);
-        var expectedPublishedMessage = createExpectedPublishedMessage(extractFirstMessage(event)
-        );
+        var expectedPublishedMessage = createExpectedPublishedMessage(extractFirstMessage(event));
         assertEquals(expectedPublishedMessage, snsClient.getPublishedMessages().get(0));
     }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -1,0 +1,54 @@
+package no.sikt.nva.nvi.events.db;
+
+import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEvent;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+import no.sikt.nva.nvi.test.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+
+public class DataEntryUpdateHandlerTest {
+
+    public static final Context CONTEXT = mock(Context.class);
+    private static final String CANDIDATE_UPDATE_TOPIC = "Candidate.Update.Applicable";
+    private FakeNotificationClient snsClient;
+    private DataEntryUpdateHandler handler;
+
+    @BeforeEach
+    void setUp() {
+        snsClient = new FakeNotificationClient();
+        handler = new DataEntryUpdateHandler(snsClient);
+    }
+
+    //TODO: Parameterize this test to test with all Dao types
+    @Test
+    void shouldConvertDynamoDbEventToDataEntryUpdateEvent() {
+        var candidate = randomCandidateDao();
+        var event = createEvent(candidate);
+
+        handler.handleRequest(event, CONTEXT);
+        var expectedPublishedMessage = createExpectedPublishedMessage(extractFirstMessage(event)
+        );
+        assertEquals(expectedPublishedMessage, snsClient.getPublishedMessages().get(0));
+    }
+
+    private static String extractFirstMessage(SQSEvent event) {
+        return event.getRecords().get(0).getBody();
+    }
+
+    private static PublishRequest createExpectedPublishedMessage(String message) {
+        return PublishRequest.builder()
+                   .message(message)
+                   .topicArn(DataEntryUpdateHandlerTest.CANDIDATE_UPDATE_TOPIC)
+                   .build();
+    }
+
+    private CandidateDao randomCandidateDao() {
+        return new CandidateDao(UUID.randomUUID(), TestUtils.randomCandidate(), UUID.randomUUID().toString());
+    }
+}

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -1,13 +1,13 @@
 package no.sikt.nva.nvi.events.db;
 
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEvent;
+import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateDao;
-import no.sikt.nva.nvi.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.sns.model.PublishRequest;
@@ -49,6 +49,6 @@ public class DataEntryUpdateHandlerTest {
     }
 
     private CandidateDao randomCandidateDao() {
-        return new CandidateDao(UUID.randomUUID(), TestUtils.randomCandidate(), UUID.randomUUID().toString());
+        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString());
     }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/FakeNotificationClient.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/FakeNotificationClient.java
@@ -1,0 +1,28 @@
+package no.sikt.nva.nvi.events.db;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.notification.NotificationClient;
+import no.sikt.nva.nvi.common.notification.NviPublishMessageResponse;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+
+public class FakeNotificationClient implements NotificationClient<NviPublishMessageResponse> {
+
+    private final List<PublishRequest> publishedMessages = new ArrayList<>();
+
+    public List<PublishRequest> getPublishedMessages() {
+        return publishedMessages;
+    }
+
+    @Override
+    public NviPublishMessageResponse publish(String message, String topic) {
+        var request = createRequest(message, topic);
+        publishedMessages.add(request);
+        return new NviPublishMessageResponse(UUID.randomUUID().toString());
+    }
+
+    private static PublishRequest createRequest(String message, String topic) {
+        return PublishRequest.builder().message(message).topicArn(topic).build();
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ aws-sdk2-eventbridge = { group = 'software.amazon.awssdk', name = 'eventbridge',
 aws-sdk2-urlconnectionclient = { group = 'software.amazon.awssdk', name = 'url-connection-client', version.ref = 'awsSdk2' }
 aws-sdk2-s3 = { group = 'software.amazon.awssdk', name = 's3', version.ref = 'awsSdk2' }
 aws-sdk2-sqs = { group = 'software.amazon.awssdk', name = 'sqs', version.ref = 'awsSdk2' }
+aws-sdk2-sns = { group = 'software.amazon.awssdk', name = 'sns', version.ref = 'awsSdk2' }
 aws-sdk2-core = { group = 'software.amazon.awssdk', name = 'sdk-core', version.ref = 'awsSdk2' }
 aws-sdk2-urlconnection = { group = 'software.amazon.awssdk', name = 'url-connection-client', version.ref = 'awsSdk2' }
 aws-sdk2-apache-client = { group = 'software.amazon.awssdk', name = 'apache-client', version.ref = 'awsSdk2' }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -1,7 +1,5 @@
 package no.sikt.nva.nvi.index;
 
-import static no.sikt.nva.nvi.test.DynamoDbTestUtils.eventWithCandidateIdentifier;
-import static no.sikt.nva.nvi.test.DynamoDbTestUtils.mapToString;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.EN_FIELD;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_LABEL;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
@@ -22,8 +20,6 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
-import com.amazonaws.services.lambda.runtime.events.SQSEvent;
-import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -206,7 +202,6 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         return attempt(() -> dtoObjectMapper.writeValueAsString(jsonNode)).orElseThrow();
     }
 
-
     @NotNull
     private static ObjectNode generateOrganizationNode(String hardCodedPartOf) {
         var hardCodedPartOfNode = dtoObjectMapper.createObjectNode();
@@ -215,8 +210,6 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         hardCodedPartOfNode.put("@context", ORGANIZATION_CONTEXT);
         return hardCodedPartOfNode;
     }
-
-
 
     private static String extractResourceIdentifier(Candidate persistedCandidate) {
         return UriWrapper.fromUri(persistedCandidate.getPublicationDetails().publicationBucketUri())
@@ -363,6 +356,4 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         return Candidate.fromRequest(createUpsertCandidateRequest(2023), candidateRepository, periodRepository)
                    .orElseThrow();
     }
-
-
 }

--- a/nvi-commons/build.gradle
+++ b/nvi-commons/build.gradle
@@ -11,6 +11,7 @@ dependencies {
     implementation libs.aws.sdk2.apache.client
     implementation libs.aws.sdk2.s3
     implementation libs.aws.sdk2.sqs
+    implementation libs.aws.sdk2.sns
     implementation libs.aws.sdk2.dynamodb
     implementation libs.aws.sdk2.dynamodbenhanced
     implementation libs.aws.sdk2.urlconnection

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NotificationClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NotificationClient.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.common.notification;
 
-public interface NotificationClient <T>{
+public interface NotificationClient<T> {
+
     T publish(String message, String topic);
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NotificationClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NotificationClient.java
@@ -1,0 +1,5 @@
+package no.sikt.nva.nvi.common.notification;
+
+public interface NotificationClient <T>{
+    T publish(String message, String topic);
+}

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NviNotificationClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NviNotificationClient.java
@@ -1,0 +1,55 @@
+package no.sikt.nva.nvi.common.notification;
+
+import java.time.Duration;
+import no.sikt.nva.nvi.common.utils.ApplicationConstants;
+import nva.commons.core.JacocoGenerated;
+import software.amazon.awssdk.http.SdkHttpClient;
+import software.amazon.awssdk.http.apache.ApacheHttpClient;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+
+public class NviNotificationClient implements NotificationClient<NviPublishMessageResponse> {
+
+    private static final int MAX_CONNECTIONS = 10_000;
+    private static final int IDLE_TIME = 30;
+    private static final int TIMEOUT_TIME = 30;
+
+    private final SnsClient snsClient;
+
+    @JacocoGenerated
+    public NviNotificationClient() {
+        this(defaultSnsClient());
+    }
+
+    public NviNotificationClient(SnsClient snsClient) {
+        this.snsClient = snsClient;
+    }
+
+    @Override
+    public NviPublishMessageResponse publish(String message, String topic) {
+        var request = createRequest(message, topic);
+        return new NviPublishMessageResponse(snsClient.publish(request).messageId());
+    }
+
+    private static PublishRequest createRequest(String message, String topic) {
+        return PublishRequest.builder().message(message).topicArn(topic).build();
+    }
+
+    @JacocoGenerated
+    private static SnsClient defaultSnsClient() {
+        return SnsClient.builder()
+                   .region(ApplicationConstants.REGION)
+                   .httpClient(httpClientForConcurrentQueries())
+                   .build();
+    }
+
+    @JacocoGenerated
+    private static SdkHttpClient httpClientForConcurrentQueries() {
+        return ApacheHttpClient.builder()
+                   .useIdleConnectionReaper(true)
+                   .maxConnections(MAX_CONNECTIONS)
+                   .connectionMaxIdleTime(Duration.ofMinutes(IDLE_TIME))
+                   .connectionTimeout(Duration.ofMinutes(TIMEOUT_TIME))
+                   .build();
+    }
+}

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NviNotificationClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NviNotificationClient.java
@@ -48,8 +48,8 @@ public class NviNotificationClient implements NotificationClient<NviPublishMessa
         return ApacheHttpClient.builder()
                    .useIdleConnectionReaper(true)
                    .maxConnections(MAX_CONNECTIONS)
-                   .connectionMaxIdleTime(Duration.ofMinutes(IDLE_TIME))
-                   .connectionTimeout(Duration.ofMinutes(TIMEOUT_TIME))
+                   .connectionMaxIdleTime(Duration.ofSeconds(IDLE_TIME))
+                   .connectionTimeout(Duration.ofSeconds(TIMEOUT_TIME))
                    .build();
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NviPublishMessageResponse.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NviPublishMessageResponse.java
@@ -1,0 +1,5 @@
+package no.sikt.nva.nvi.common.notification;
+
+public record NviPublishMessageResponse(String messageId) {
+
+}

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
@@ -72,8 +72,8 @@ public class NviQueueClient implements QueueClient<NviSendMessageResponse, NviSe
         return ApacheHttpClient.builder()
                    .useIdleConnectionReaper(true)
                    .maxConnections(MAX_CONNECTIONS)
-                   .connectionMaxIdleTime(Duration.ofMinutes(IDLE_TIME))
-                   .connectionTimeout(Duration.ofMinutes(TIMEOUT_TIME))
+                   .connectionMaxIdleTime(Duration.ofSeconds(IDLE_TIME))
+                   .connectionTimeout(Duration.ofSeconds(TIMEOUT_TIME))
                    .build();
     }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/notification/NviNotificationClientTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/notification/NviNotificationClientTest.java
@@ -1,0 +1,31 @@
+package no.sikt.nva.nvi.common.notification;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sns.SnsClient;
+import software.amazon.awssdk.services.sns.model.PublishRequest;
+import software.amazon.awssdk.services.sns.model.PublishResponse;
+
+class NviNotificationClientTest {
+
+    private static final String TEST_TOPIC = "topic";
+    private static final String TEST_MESSAGE_ID = "some_message_id";
+    private static final String TEST_PAYLOAD = "{}";
+
+    @Test
+    void shouldPublishMessageAndReturnMessageId() {
+        var client = mock(SnsClient.class);
+        when(client.publish(any(PublishRequest.class))).thenReturn(
+            PublishResponse.builder().messageId(TEST_MESSAGE_ID).build());
+        var notificationClient = new NviNotificationClient(client);
+
+        var result = notificationClient.publish(TEST_PAYLOAD, TEST_TOPIC);
+
+        assertThat(result.messageId(), is(equalTo(TEST_MESSAGE_ID)));
+    }
+}

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
@@ -7,7 +7,6 @@ import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -16,7 +15,6 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.Dao;
-import no.sikt.nva.nvi.common.db.DynamoEntryWithRangeKey;
 
 public final class DynamoDbTestUtils {
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
@@ -110,6 +110,8 @@ public final class DynamoDbTestUtils {
 
     private static AttributeValue getAttributeValue(
         software.amazon.awssdk.services.dynamodb.model.AttributeValue value) {
+        //This is a workaround because we were not able to serialize with jackson
+        //Do not use this method in production code
         return switch (value.type()) {
             case S -> new AttributeValue().withS(value.s());
             case SS -> new AttributeValue().withSS(value.ss());

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
@@ -7,10 +7,16 @@ import com.amazonaws.services.lambda.runtime.events.DynamodbEvent;
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue;
 import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+import no.sikt.nva.nvi.common.db.Dao;
+import no.sikt.nva.nvi.common.db.DynamoEntryWithRangeKey;
 
 public final class DynamoDbTestUtils {
 
@@ -22,6 +28,13 @@ public final class DynamoDbTestUtils {
     public static DynamodbEvent eventWithCandidateIdentifier(UUID candidateIdentifier) {
         var dynamoDbEvent = new DynamodbEvent();
         var dynamoDbRecord = dynamoRecordWithIdentifier(payloadWithIdentifier(candidateIdentifier));
+        dynamoDbEvent.setRecords(List.of(dynamoDbRecord));
+        return dynamoDbEvent;
+    }
+
+    public static DynamodbEvent eventWithCandidate(CandidateDao candidate) {
+        var dynamoDbEvent = new DynamodbEvent();
+        var dynamoDbRecord = dynamoRecordWithIdentifier(payloadWithCandidate(candidate));
         dynamoDbEvent.setRecords(List.of(dynamoDbRecord));
         return dynamoDbEvent;
     }
@@ -69,6 +82,46 @@ public final class DynamoDbTestUtils {
         streamRecord.setOldImage(randomDynamoPayload(candidateIdentifier));
         streamRecord.setNewImage(randomDynamoPayload(candidateIdentifier));
         return streamRecord;
+    }
+
+    private static StreamRecord payloadWithCandidate(CandidateDao candidate) {
+        var attributeValueMap = attempt(() -> toAttributeValueMap(candidate)).orElseThrow();
+
+        return createPayload(attributeValueMap, attributeValueMap);
+    }
+
+    private static StreamRecord createPayload(Map<String, AttributeValue> oldImage,
+                                              Map<String, AttributeValue> newImage) {
+        var streamRecord = new StreamRecord();
+        streamRecord.setOldImage(oldImage);
+        streamRecord.setNewImage(newImage);
+        return streamRecord;
+    }
+
+    private static Map<String, AttributeValue> toAttributeValueMap(Dao dao) {
+        var dynamoFormat = dao.toDynamoFormat();
+        return getAttributeValueMap(dynamoFormat);
+    }
+
+    private static Map<String, AttributeValue> getAttributeValueMap(
+        Map<String, software.amazon.awssdk.services.dynamodb.model.AttributeValue> value) {
+        return value.entrySet()
+                   .stream()
+                   .collect(Collectors.toMap(Entry::getKey, mapValue -> getAttributeValue(mapValue.getValue())));
+    }
+
+    private static AttributeValue getAttributeValue(
+        software.amazon.awssdk.services.dynamodb.model.AttributeValue value) {
+        return switch (value.type()) {
+            case S -> new AttributeValue().withS(value.s());
+            case SS -> new AttributeValue().withSS(value.ss());
+            case N -> new AttributeValue().withN(value.n());
+            case M -> new AttributeValue().withM(getAttributeValueMap(value.m()));
+            case L -> new AttributeValue().withL(value.l().stream().map(DynamoDbTestUtils::getAttributeValue).toList());
+            case NUL -> new AttributeValue().withNULL(value.nul());
+            case BOOL -> new AttributeValue().withBOOL(value.bool());
+            default -> throw new IllegalArgumentException("Unknown type: " + value.type());
+        };
     }
 
     private static StreamRecord randomPayload() {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/QueueServiceTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/QueueServiceTestUtils.java
@@ -8,7 +8,6 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import java.util.List;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateDao;
-import no.sikt.nva.nvi.common.service.model.Candidate;
 
 public final class QueueServiceTestUtils {
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/QueueServiceTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/QueueServiceTestUtils.java
@@ -1,0 +1,72 @@
+package no.sikt.nva.nvi.test;
+
+import static no.sikt.nva.nvi.test.DynamoDbTestUtils.eventWithCandidate;
+import static no.sikt.nva.nvi.test.DynamoDbTestUtils.eventWithCandidateIdentifier;
+import static no.sikt.nva.nvi.test.DynamoDbTestUtils.mapToString;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import java.util.List;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+import no.sikt.nva.nvi.common.service.model.Candidate;
+
+public final class QueueServiceTestUtils {
+
+    private QueueServiceTestUtils() {
+    }
+
+    public static SQSEvent createEvent(UUID candidateIdentifier) {
+        var sqsEvent = new SQSEvent();
+        var message = createMessage(candidateIdentifier);
+        sqsEvent.setRecords(List.of(message));
+        return sqsEvent;
+    }
+
+    public static SQSEvent createEvent(CandidateDao candidate) {
+        var sqsEvent = new SQSEvent();
+        var message = createMessage(candidate);
+        sqsEvent.setRecords(List.of(message));
+        return sqsEvent;
+    }
+
+    public static SQSEvent createEvent(List<UUID> candidateIdentifiers) {
+        var sqsEvent = new SQSEvent();
+        var records = candidateIdentifiers.stream().map(
+            QueueServiceTestUtils::createMessage).toList();
+        sqsEvent.setRecords(records);
+        return sqsEvent;
+    }
+
+    public static SQSEvent createEventWithOneInvalidRecord(UUID candidateIdentifier) {
+        var sqsEvent = new SQSEvent();
+        var message = createMessage(candidateIdentifier);
+        sqsEvent.setRecords(List.of(message, invalidSqsMessage()));
+        return sqsEvent;
+    }
+
+    private static SQSMessage createMessage(UUID candidateIdentifier) {
+        var message = new SQSMessage();
+        message.setBody(generateSingleDynamoDbEventRecord(candidateIdentifier));
+        return message;
+    }
+
+    private static SQSMessage createMessage(CandidateDao candidate) {
+        var message = new SQSMessage();
+        message.setBody(generateSingleDynamoDbEventRecord(candidate));
+        return message;
+    }
+
+    private static String generateSingleDynamoDbEventRecord(UUID candidateIdentifier) {
+        return mapToString(eventWithCandidateIdentifier(candidateIdentifier).getRecords().get(0));
+    }
+
+    private static String generateSingleDynamoDbEventRecord(CandidateDao candidate) {
+        return mapToString(eventWithCandidate(candidate).getRecords().get(0));
+    }
+
+    private static SQSMessage invalidSqsMessage() {
+        var message = new SQSMessage();
+        message.setBody("invalid indexDocument");
+        return message;
+    }
+}


### PR DESCRIPTION
First, simple version of `DataEntryUpdateHandler`. Only implemented handling of dynamoDb events for `CandidateDao`. See todos, handling of rest of the dao types coming in next PR.