### PR TITLE
Np 45509 RemoveIndexDocumentHandler

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandler.java
@@ -11,8 +11,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import no.sikt.nva.nvi.index.aws.OpenSearchClient;
+import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
-import org.opensearch.client.opensearch.core.DeleteResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -21,14 +21,18 @@ public class RemoveIndexDocumentHandler implements RequestHandler<SQSEvent, Void
     private static final Logger LOGGER = LoggerFactory.getLogger(RemoveIndexDocumentHandler.class);
     private static final String FAILED_TO_REMOVE_DOCUMENT_MESSAGE = "Failed to remove document from index: {}";
     private static final String FAILED_TO_EXTRACT_IDENTIFIER_MESSAGE = "Failed to extract identifier from dynamodb "
-                                                                      + "record: {}";
+                                                                       + "record: {}";
     private static final String FAILED_TO_PARSE_EVENT_MESSAGE = "Failed to map body to DynamodbStreamRecord: {}";
     private static final String ERROR_MESSAGE = "Error message: {}";
     private static final String IDENTIFIER = "identifier";
     private final OpenSearchClient openSearchClient;
 
-    public RemoveIndexDocumentHandler(OpenSearchClient openSearchClient) {
+    @JacocoGenerated
+    public RemoveIndexDocumentHandler() {
+        this(OpenSearchClient.defaultOpenSearchClient());
+    }
 
+    public RemoveIndexDocumentHandler(OpenSearchClient openSearchClient) {
         this.openSearchClient = openSearchClient;
     }
 
@@ -40,7 +44,7 @@ public class RemoveIndexDocumentHandler implements RequestHandler<SQSEvent, Void
             .filter(Objects::nonNull)
             .map(RemoveIndexDocumentHandler::extractIdentifier)
             .filter(Objects::nonNull)
-            .forEach(identifier -> getRemoveDocumentFromIndex(identifier));
+            .forEach(this::getRemoveDocumentFromIndex);
         return null;
     }
 
@@ -64,8 +68,8 @@ public class RemoveIndexDocumentHandler implements RequestHandler<SQSEvent, Void
         //TODO: Send message to DLQ
     }
 
-    private DeleteResponse getRemoveDocumentFromIndex(UUID identifier) {
-        return attempt(() -> openSearchClient.removeDocumentFromIndex(identifier)).orElse(failure -> {
+    private void getRemoveDocumentFromIndex(UUID identifier) {
+        attempt(() -> openSearchClient.removeDocumentFromIndex(identifier)).orElse(failure -> {
             handleFailure(failure, FAILED_TO_REMOVE_DOCUMENT_MESSAGE, identifier.toString());
             return null;
         });

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandler.java
@@ -1,0 +1,13 @@
+package no.sikt.nva.nvi.index;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+
+public class RemoveIndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
+
+    @Override
+    public Void handleRequest(SQSEvent input, Context context) {
+        return null;
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandler.java
@@ -44,7 +44,7 @@ public class RemoveIndexDocumentHandler implements RequestHandler<SQSEvent, Void
             .filter(Objects::nonNull)
             .map(RemoveIndexDocumentHandler::extractIdentifier)
             .filter(Objects::nonNull)
-            .forEach(this::getRemoveDocumentFromIndex);
+            .forEach(this::removeDocumentFromIndex);
         return null;
     }
 
@@ -68,11 +68,12 @@ public class RemoveIndexDocumentHandler implements RequestHandler<SQSEvent, Void
         //TODO: Send message to DLQ
     }
 
-    private void getRemoveDocumentFromIndex(UUID identifier) {
-        attempt(() -> openSearchClient.removeDocumentFromIndex(identifier)).orElse(failure -> {
-            handleFailure(failure, FAILED_TO_REMOVE_DOCUMENT_MESSAGE, identifier.toString());
-            return null;
-        });
+    private void removeDocumentFromIndex(UUID identifier) {
+        attempt(() -> openSearchClient.removeDocumentFromIndex(identifier)).orElse(
+            failure -> {
+                handleFailure(failure, FAILED_TO_REMOVE_DOCUMENT_MESSAGE, identifier.toString());
+                return null;
+            });
     }
 
     private DynamodbStreamRecord mapToDynamoDbRecord(String body) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandler.java
@@ -1,13 +1,61 @@
 package no.sikt.nva.nvi.index;
 
+import static no.unit.nva.commons.json.JsonUtils.dynamoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import java.util.Optional;
+import java.util.UUID;
+import no.sikt.nva.nvi.index.aws.OpenSearchClient;
+import nva.commons.core.attempt.Failure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class RemoveIndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RemoveIndexDocumentHandler.class);
+
+    private static final String ERROR_MESSAGE = "Error message: {}";
+    private static final String FAILED_TO_PARSE_EVENT_MESSAGE = "Failed to map body to DynamodbStreamRecord: {}";
+    private static final String IDENTIFIER = "identifier";
+
+    private final OpenSearchClient openSearchClient;
+
+    public RemoveIndexDocumentHandler(OpenSearchClient openSearchClient) {
+
+        this.openSearchClient = openSearchClient;
+    }
+
     @Override
     public Void handleRequest(SQSEvent input, Context context) {
+        input.getRecords().stream()
+            .map(SQSMessage::getBody)
+            .map(this::mapToDynamoDbRecord)
+            .map(RemoveIndexDocumentHandler::extractIdentifier)
+            .forEach(openSearchClient::removeDocumentFromIndex);
         return null;
+    }
+
+    private static UUID extractIdentifier(DynamodbStreamRecord record) {
+        return UUID.fromString(Optional.ofNullable(record.getDynamodb().getOldImage())
+                                   .orElse(record.getDynamodb().getNewImage())
+                                   .get(IDENTIFIER).getS());
+    }
+
+    private DynamodbStreamRecord mapToDynamoDbRecord(String body) {
+        return attempt(() -> dynamoObjectMapper.readValue(body, DynamodbStreamRecord.class))
+                   .orElse(failure -> {
+                       handleFailure(failure, FAILED_TO_PARSE_EVENT_MESSAGE, body);
+                       return null;
+                   });
+    }
+
+    private void handleFailure(Failure<?> failure, String message, String messageArgument) {
+        LOGGER.error(message, messageArgument);
+        LOGGER.error(ERROR_MESSAGE, failure.getException().getMessage());
+        //TODO: Send message to DLQ
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/UpdateIndexHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/UpdateIndexHandler.java
@@ -95,10 +95,6 @@ public class UpdateIndexHandler implements RequestHandler<DynamodbEvent, Void> {
         return record.getDynamodb().getKeys().get(SORT_KEY).getS().split(PRIMARY_KEY_DELIMITER)[0];
     }
 
-    private static NviCandidateIndexDocument toIndexDocumentWithId(UUID candidateIdentifier) {
-        return new NviCandidateIndexDocument.Builder().withIdentifier(candidateIdentifier).build();
-    }
-
     private static UUID extractIdentifierFromNewImage(DynamodbStreamRecord record) {
         return UUID.fromString(record.getDynamodb().getNewImage().get(IDENTIFIER).getS());
     }
@@ -166,7 +162,7 @@ public class UpdateIndexHandler implements RequestHandler<DynamodbEvent, Void> {
 
     private void removeDocumentFromIndex(Candidate candidate) {
         LOGGER.info("removeDocumentFromIndex for {}", candidate.getIdentifier());
-        var result = openSearchClient.removeDocumentFromIndex(toIndexDocumentWithId(candidate.getIdentifier()));
+        var result = openSearchClient.removeDocumentFromIndex(candidate.getIdentifier());
         LOGGER.info("done removeDocumentFromIndex for {}, result: {}", candidate.getIdentifier(),
                     result.result().jsonValue());
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Clock;
+import java.util.UUID;
 import no.sikt.nva.nvi.common.model.UsernamePasswordWrapper;
 import no.sikt.nva.nvi.index.Aggregations;
 import no.sikt.nva.nvi.index.model.CandidateSearchParameters;
@@ -87,10 +88,11 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
     }
 
     @Override
-    public DeleteResponse removeDocumentFromIndex(NviCandidateIndexDocument indexDocument) {
-        return attempt(() -> client.withTransportOptions(getOptions()).delete(contructDeleteRequest(indexDocument)))
+    public DeleteResponse removeDocumentFromIndex(UUID identifier) {
+        return attempt(() -> client.withTransportOptions(getOptions()).delete(contructDeleteRequest(
+            identifier)))
                    .map(deleteResponse -> {
-                       LOGGER.info("Removing document from index: {}", indexDocument.identifier());
+                       LOGGER.info("Removing document from index: {}", identifier);
                        return deleteResponse;
                    })
                    .orElseThrow(
@@ -121,9 +123,9 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
                     params.size());
     }
 
-    private static DeleteRequest contructDeleteRequest(NviCandidateIndexDocument indexDocument) {
+    private static DeleteRequest contructDeleteRequest(UUID identifier) {
         return new DeleteRequest.Builder().index(NVI_CANDIDATES_INDEX)
-                   .id(indexDocument.identifier().toString())
+                   .id(identifier.toString())
                    .build();
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/SearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/SearchClient.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.index.aws;
 
 import java.io.IOException;
+import java.util.UUID;
 import no.sikt.nva.nvi.index.model.CandidateSearchParameters;
 import org.opensearch.client.opensearch.core.DeleteResponse;
 import org.opensearch.client.opensearch.core.IndexResponse;
@@ -10,7 +11,7 @@ public interface SearchClient<T> {
 
     IndexResponse addDocumentToIndex(T indexDocument);
 
-    DeleteResponse removeDocumentFromIndex(T indexDocument);
+    DeleteResponse removeDocumentFromIndex(UUID identifier);
 
     SearchResponse<T> search(CandidateSearchParameters candidateSearchParameters)
         throws IOException;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -183,7 +183,7 @@ public class OpenSearchClientTest {
     void shouldRemoveDocumentFromIndex() throws InterruptedException, IOException {
         var document = singleNviCandidateIndexDocument();
         addDocumentsToIndex(document);
-        openSearchClient.removeDocumentFromIndex(document);
+        openSearchClient.removeDocumentFromIndex(document.identifier());
         Thread.sleep(DELAY_ON_INDEX);
         var searchParameters = defaultSearchParameters().build();
         var searchResponse =

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandlerTest.java
@@ -36,7 +36,7 @@ class RemoveIndexDocumentHandlerTest {
     }
 
     @Test
-    void shouldNotFailForWholeBatchFailingToRemoveOneIndexDocument() {
+    void shouldNotFailForWholeBatchWhenFailingToRemoveOneIndexDocument() {
         var candidateToSucceed = randomCandidateDao();
         var candidateToFail = randomCandidateDao();
         var event = createEvent(
@@ -55,7 +55,7 @@ class RemoveIndexDocumentHandlerTest {
     }
 
     @Test
-    void shouldNotFailForWholeBatchFailingToExtractOneIdentifier() {
+    void shouldNotFailForWholeBatchWhenFailingToExtractOneIdentifier() {
         var candidate = randomCandidateDao();
         var eventWithOneInvalidRecord = createEventWithDynamoEventMissingIdentifier(candidate);
         handler.handleRequest(eventWithOneInvalidRecord, null);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandlerTest.java
@@ -1,16 +1,16 @@
 package no.sikt.nva.nvi.index;
 
+import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEvent;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.index.aws.OpenSearchClient;
-import no.sikt.nva.nvi.test.QueueServiceTestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import software.amazon.awssdk.services.dynamodb.model.OperationType;
 
 class RemoveIndexDocumentHandlerTest {
@@ -22,10 +22,11 @@ class RemoveIndexDocumentHandlerTest {
     @Test
     void shouldRemoveIndexDocumentWhenReceivingEvent() {
         var candidate = randomCandidateDao();
-        var event = QueueServiceTestUtils.createEvent(candidate, candidate, OperationType.REMOVE);
-        var handler = new RemoveIndexDocumentHandler();
+        var event = createEvent(candidate, candidate, OperationType.REMOVE);
+        var openSearchClient = mock(OpenSearchClient.class);
+        var handler = new RemoveIndexDocumentHandler(openSearchClient);
         handler.handleRequest(event, null);
-        verify(mock(OpenSearchClient.class), Mockito.times(1)).removeDocumentFromIndex(any());
+        verify(openSearchClient, times(1)).removeDocumentFromIndex(any());
     }
 
     private static CandidateDao randomCandidateDao() {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandlerTest.java
@@ -1,0 +1,34 @@
+package no.sikt.nva.nvi.index;
+
+import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+import no.sikt.nva.nvi.index.aws.OpenSearchClient;
+import no.sikt.nva.nvi.test.QueueServiceTestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.dynamodb.model.OperationType;
+
+class RemoveIndexDocumentHandlerTest {
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    void shouldRemoveIndexDocumentWhenReceivingEvent() {
+        var candidate = randomCandidateDao();
+        var event = QueueServiceTestUtils.createEvent(candidate, candidate, OperationType.REMOVE);
+        var handler = new RemoveIndexDocumentHandler();
+        handler.handleRequest(event, null);
+        verify(mock(OpenSearchClient.class), Mockito.times(1)).removeDocumentFromIndex(any());
+    }
+
+    private static CandidateDao randomCandidateDao() {
+        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString());
+    }
+}

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.StorageReader;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao;
@@ -450,7 +451,7 @@ class UpdateIndexHandlerTest extends LocalDynamoTest {
         }
 
         @Override
-        public DeleteResponse removeDocumentFromIndex(NviCandidateIndexDocument indexDocument) {
+        public DeleteResponse removeDocumentFromIndex(UUID identifier) {
 
             return null;
         }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/DynamoDbTestUtils.java
@@ -49,6 +49,13 @@ public final class DynamoDbTestUtils {
         return dynamoDbEvent;
     }
 
+    public static DynamodbEvent dynamoDbEventWithEmptyPayload() {
+        var dynamoDbEvent = new DynamodbEvent();
+        var dynamoDbRecord = dynamoRecordWithIdentifier(new StreamRecord(), randomOperationType());
+        dynamoDbEvent.setRecords(List.of(dynamoDbRecord));
+        return dynamoDbEvent;
+    }
+
     public static DynamodbEvent randomEventWithNumberOfDynamoRecords(int numberOfRecords) {
         var event = new DynamodbEvent();
         var records = IntStream.range(0, numberOfRecords)

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/QueueServiceTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/QueueServiceTestUtils.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.test;
 
+import static no.sikt.nva.nvi.test.DynamoDbTestUtils.dynamoDbEventWithEmptyPayload;
 import static no.sikt.nva.nvi.test.DynamoDbTestUtils.eventWithCandidate;
 import static no.sikt.nva.nvi.test.DynamoDbTestUtils.eventWithCandidateIdentifier;
 import static no.sikt.nva.nvi.test.DynamoDbTestUtils.mapToString;
@@ -58,6 +59,13 @@ public final class QueueServiceTestUtils {
         return sqsEvent;
     }
 
+    public static SQSEvent createEventWithDynamoEventMissingIdentifier(CandidateDao candidate) {
+        var sqsEvent = new SQSEvent();
+        var message = createMessage(null, candidate, OperationType.INSERT);
+        sqsEvent.setRecords(List.of(message, messageWithoutIdentifier()));
+        return sqsEvent;
+    }
+
     public static SQSMessage createMessage(UUID candidateIdentifier) {
         var message = new SQSMessage();
         message.setBody(generateSingleDynamoDbEventRecord(candidateIdentifier));
@@ -66,7 +74,13 @@ public final class QueueServiceTestUtils {
 
     public static SQSMessage createMessage(Dao oldImage, Dao newImage, OperationType operationType) {
         var message = new SQSMessage();
-        message.setBody(generateSingleDynamoDbEventRecord(oldImage, newImage, operationType));
+        message.setBody(generateSingleDynamoDbEventRecordWithEmptyPayload(oldImage, newImage, operationType));
+        return message;
+    }
+
+    private static SQSMessage messageWithoutIdentifier() {
+        var message = new SQSMessage();
+        message.setBody(generateSingleDynamoDbEventRecordWithEmptyPayload());
         return message;
     }
 
@@ -74,7 +88,12 @@ public final class QueueServiceTestUtils {
         return mapToString(eventWithCandidateIdentifier(candidateIdentifier).getRecords().get(0));
     }
 
-    private static String generateSingleDynamoDbEventRecord(Dao oldImage, Dao newImage, OperationType operationType) {
+    private static String generateSingleDynamoDbEventRecordWithEmptyPayload() {
+        return mapToString(dynamoDbEventWithEmptyPayload().getRecords().get(0));
+    }
+
+    private static String generateSingleDynamoDbEventRecordWithEmptyPayload(Dao oldImage, Dao newImage,
+                                                                            OperationType operationType) {
         return mapToString(eventWithCandidate(oldImage, newImage,
                                               operationType).getRecords().get(0));
     }


### PR DESCRIPTION
`RemoveIndexDocumentHandler` is triggered by a new queue `RemoveDocumentFromIndexQueue` which subscribes to topics `nvi-data-entry-update-candidate-not-applicable-update` and `nvi-data-entry-update-candidate-remove` (not in template yet) and removes the document from `OpenSearch`.