### PR TITLE
Np 45509 IndexDocumentHandler: Send event after persisting index document

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
@@ -11,7 +11,7 @@ import static org.mockito.Mockito.mock;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import no.sikt.nva.nvi.events.evaluator.FakeSqsClient;
+import no.sikt.nva.nvi.test.FakeSqsClient;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
 import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -29,7 +29,7 @@ import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.model.ListingResult;
 import no.sikt.nva.nvi.common.service.NviService;
-import no.sikt.nva.nvi.events.evaluator.FakeSqsClient;
+import no.sikt.nva.nvi.test.FakeSqsClient;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
 import no.sikt.nva.nvi.events.model.ReEvaluateRequest;
 import no.sikt.nva.nvi.test.LocalDynamoTest;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbEventToQueueHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbEventToQueueHandlerTest.java
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.List;
 import java.util.UUID;
-import no.sikt.nva.nvi.events.evaluator.FakeSqsClient;
+import no.sikt.nva.nvi.test.FakeSqsClient;
 import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,7 +30,6 @@ public class DynamoDbEventToQueueHandlerTest {
 
     public static final Context CONTEXT = mock(Context.class);
     public static final String DLQ_URL = "IndexDlq";
-    public static final String MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER_QUEUE = "candidateIdentifier";
     private DynamoDbEventToQueueHandler handler;
     private FakeSqsClient sqsClient;
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -50,6 +50,7 @@ import no.sikt.nva.nvi.events.model.NviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate.Creator;
 import no.sikt.nva.nvi.events.model.NviCandidate.PublicationDate;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
+import no.sikt.nva.nvi.test.FakeSqsClient;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
 import no.unit.nva.auth.uriretriever.BackendClientCredentials;
 import no.unit.nva.auth.uriretriever.UriRetriever;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithCristinDataTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithCristinDataTest.java
@@ -29,6 +29,7 @@ import no.sikt.nva.nvi.events.evaluator.client.OrganizationRetriever;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.NviCandidate;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
+import no.sikt.nva.nvi.test.FakeSqsClient;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
 import no.unit.nva.auth.uriretriever.BackendClientCredentials;
 import no.unit.nva.auth.uriretriever.UriRetriever;

--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -55,4 +55,5 @@ test {
     environment("CUSTOM_DOMAIN_BASE_PATH", "scientific-index")
     environment("BACKEND_CLIENT_AUTH_URL", "My url")
     environment("BACKEND_CLIENT_SECRET_NAME", "My secret name")
+    environment("PERSISTED_INDEX_DOCUMENT_QUEUE_URL", "PersistedIndexDocumentQueue")
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -33,6 +33,7 @@ import org.slf4j.LoggerFactory;
 
 public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
 
+    public static final String FAILED_SENDING_EVENT_MESSAGE = "Failed to send message to queue: {}";
     private static final Logger LOGGER = LoggerFactory.getLogger(IndexDocumentHandler.class);
     private static final String EXPANDED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
     private static final String QUEUE_URL = "PERSISTED_INDEX_DOCUMENT_QUEUE_URL";
@@ -104,9 +105,9 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
     }
 
     private void sendEvent(URI uri) {
-        attempt(() -> sqsClient.sendMessage(new PersistedIndexDocumentMessage(uri).toJsonString(), queueUrl))
+        attempt(() -> sqsClient.sendMessage(new PersistedIndexDocumentMessage(uri).asJsonString(), queueUrl))
             .orElse(failure -> {
-                handleFailure(failure, "Failed to send message to queue", uri.toString());
+                handleFailure(failure, FAILED_SENDING_EVENT_MESSAGE, uri.toString());
                 return null;
             });
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/PersistedIndexDocumentMessage.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/PersistedIndexDocumentMessage.java
@@ -1,0 +1,13 @@
+package no.sikt.nva.nvi.index;
+
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.attempt.Try.attempt;
+import java.net.URI;
+
+public record PersistedIndexDocumentMessage(URI documentUri) {
+
+    public String toJsonString() {
+        return attempt(() -> dtoObjectMapper.writeValueAsString(this))
+                   .orElseThrow();
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/PersistedIndexDocumentMessage.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/PersistedIndexDocumentMessage.java
@@ -6,8 +6,7 @@ import java.net.URI;
 
 public record PersistedIndexDocumentMessage(URI documentUri) {
 
-    public String toJsonString() {
-        return attempt(() -> dtoObjectMapper.writeValueAsString(this))
-                   .orElseThrow();
+    public String asJsonString() {
+        return attempt(() -> dtoObjectMapper.writeValueAsString(this)).orElseThrow();
     }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -61,6 +61,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 
 public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
+    public static final Environment ENVIRONMENT = new Environment();
     private static final String BODY = "body";
     private static final String NVI_CANDIDATES_FOLDER = "nvi-candidates";
     private static final String GZIP_ENDING = ".gz";
@@ -69,7 +70,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     private static final String HARD_CODED_PART_OF = "https://example.org/organization/hardCodedPartOf";
     private static final String EXPANDED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
     private static final Context CONTEXT = mock(Context.class);
-    private static final String BUCKET_NAME = new Environment().readEnv(EXPANDED_RESOURCES_BUCKET);
+    private static final String BUCKET_NAME = ENVIRONMENT.readEnv(EXPANDED_RESOURCES_BUCKET);
     private final S3Client s3Client = new FakeS3Client();
     private IndexDocumentHandler handler;
     private CandidateRepository candidateRepository;
@@ -87,11 +88,12 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         candidateRepository = new CandidateRepository(localDynamoDbClient);
         periodRepository = new PeriodRepository(localDynamoDbClient);
         uriRetriever = mock(UriRetriever.class);
-        var sqsClient = new FakeSqsClient();
+        sqsClient = new FakeSqsClient();
         handler = new IndexDocumentHandler(new S3StorageReader(s3Client, BUCKET_NAME),
                                            new S3StorageWriter(s3Client, BUCKET_NAME),
                                            sqsClient,
-                                           candidateRepository, periodRepository, uriRetriever);
+                                           candidateRepository, periodRepository, uriRetriever,
+                                           ENVIRONMENT);
     }
 
     @Test
@@ -167,7 +169,8 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         var s3Writer = mockS3WriterFailingForOneCandidate(candidateToSucceed, candidateToFail
         );
         var handler = new IndexDocumentHandler(new S3StorageReader(s3Client, BUCKET_NAME),
-                                               s3Writer, sqsClient, candidateRepository, periodRepository, uriRetriever);
+                                               s3Writer, sqsClient, candidateRepository, periodRepository, uriRetriever,
+                                               ENVIRONMENT);
         assertDoesNotThrow(() -> handler.handleRequest(event, CONTEXT));
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -87,8 +87,10 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         candidateRepository = new CandidateRepository(localDynamoDbClient);
         periodRepository = new PeriodRepository(localDynamoDbClient);
         uriRetriever = mock(UriRetriever.class);
+        var sqsClient = new FakeSqsClient();
         handler = new IndexDocumentHandler(new S3StorageReader(s3Client, BUCKET_NAME),
                                            new S3StorageWriter(s3Client, BUCKET_NAME),
+                                           sqsClient,
                                            candidateRepository, periodRepository, uriRetriever);
     }
 
@@ -165,7 +167,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         var s3Writer = mockS3WriterFailingForOneCandidate(candidateToSucceed, candidateToFail
         );
         var handler = new IndexDocumentHandler(new S3StorageReader(s3Client, BUCKET_NAME),
-                                               s3Writer, candidateRepository, periodRepository, uriRetriever);
+                                               s3Writer, sqsClient, candidateRepository, periodRepository, uriRetriever);
         assertDoesNotThrow(() -> handler.handleRequest(event, CONTEXT));
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -179,15 +179,15 @@ public class SearchNviCandidatesHandlerTest {
         var paginatedSearchResult = response.getBodyObject(PaginatedSearchResult.class);
 
         var actualId = paginatedSearchResult.getId().toString();
-        var expectedInstitutionQuery = QUERY_PARAM_AFFILIATIONS
-                                       + "=" + randomInstitutions.get(0)
-                                       + "," + randomInstitutions.get(1);
-        var expectedExcludeQuery = QUERY_PARAM_EXCLUDE_SUB_UNITS + "=true";
 
         assertThat(actualId, containsString(QUERY_PARAM_FILTER + "=" + randomFilter));
         assertThat(actualId, containsString(QUERY_PARAM_CATEGORY + "=" + randomCategory));
         assertThat(actualId, containsString(QUERY_PARAM_TITLE + "=" + randomTitle));
         assertThat(actualId, containsString(QUERY_PARAM_SEARCH_TERM + "=" + randomSearchTerm));
+        var expectedInstitutionQuery = QUERY_PARAM_AFFILIATIONS
+                                       + "=" + randomInstitutions.get(0)
+                                       + "," + randomInstitutions.get(1);
+        var expectedExcludeQuery = QUERY_PARAM_EXCLUDE_SUB_UNITS + "=true";
         assertThat(actualId, containsString(expectedInstitutionQuery));
         assertThat(actualId, containsString(expectedExcludeQuery));
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
@@ -277,6 +277,16 @@ class UpdateIndexHandlerTest extends LocalDynamoTest {
         return approvals.get(institutionId);
     }
 
+    private static List<ApprovalStatusDao> getApproval(Candidate persistedCandidate) {
+        var approval = persistedCandidate.getApprovals().get(INSTITUTION_ID_FROM_EVENT);
+        return List.of(ApprovalStatusDao.builder()
+                           .approvalStatus(DbApprovalStatus.builder()
+                                               .institutionId(approval.getInstitutionId())
+                                               .status(DbStatus.PENDING)
+                                               .build())
+                           .build());
+    }
+
     private static ApprovalStatus getStatus(Map<URI, Approval> approvals, URI approval) {
         return ApprovalStatus.fromValue(
             getApproval(approvals, approval)
@@ -389,16 +399,6 @@ class UpdateIndexHandlerTest extends LocalDynamoTest {
                                   .totalPoints(candidate.getTotalPoints())
                                   .build())
                    .build();
-    }
-
-    private List<ApprovalStatusDao> getApproval(Candidate persistedCandidate) {
-        var approval = persistedCandidate.getApprovals().get(INSTITUTION_ID_FROM_EVENT);
-        return List.of(ApprovalStatusDao.builder()
-                           .approvalStatus(DbApprovalStatus.builder()
-                                               .institutionId(approval.getInstitutionId())
-                                               .status(DbStatus.PENDING)
-                                               .build())
-                           .build());
     }
 
     private Candidate randomApplicableCandidate() {

--- a/nvi-test/build.gradle
+++ b/nvi-test/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation libs.jackson.databind
     implementation libs.aws.sdk2.dynamodb
     implementation libs.aws.sdk2.dynamodbenhanced
+    implementation libs.aws.sdk2.sqs
     implementation libs.aws.lambda.events
 
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/FakeSqsClient.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/FakeSqsClient.java
@@ -1,6 +1,5 @@
-package no.sikt.nva.nvi.events.evaluator;
+package no.sikt.nva.nvi.test;
 
-import static no.sikt.nva.nvi.events.db.DynamoDbEventToQueueHandlerTest.MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER_QUEUE;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -21,6 +20,8 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 
 @JacocoGenerated
 public class FakeSqsClient implements QueueClient<NviSendMessageResponse, NviSendMessageBatchResponse> {
+
+    public static final String MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER_QUEUE = "candidateIdentifier";
 
     private final List<SendMessageRequest> sentMessages = new ArrayList<>();
 
@@ -92,8 +93,9 @@ public class FakeSqsClient implements QueueClient<NviSendMessageResponse, NviSen
     private SendMessageRequest createRequest(String body, String queueUrl, UUID candidateIdentifier) {
         return SendMessageRequest.builder()
                    .queueUrl(queueUrl)
-                   .messageAttributes(Map.of(MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER_QUEUE,
-                                             MessageAttributeValue.builder()
+                   .messageAttributes(Map.of(
+                       MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER_QUEUE,
+                       MessageAttributeValue.builder()
                                                  .stringValue(candidateIdentifier.toString())
                                                  .build()))
                    .messageBody(body)


### PR DESCRIPTION
The plan was to listen to S3 events, but this is not possible when the bucket is in another stack. Therefore, added new functionality in IndexDocumentHandler:
- send event with s3 uri when document is persisted