### PR TITLE
Fix: DataEntryUpdateHandler handle candidateUniquenessEntryDao

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -23,6 +23,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao;
 import no.sikt.nva.nvi.common.db.CandidateDao;
+import no.sikt.nva.nvi.common.db.CandidateUniquenessEntryDao;
 import no.sikt.nva.nvi.common.db.Dao;
 import no.sikt.nva.nvi.common.db.NoteDao;
 import no.sikt.nva.nvi.common.db.NoteDao.DbNote;
@@ -76,7 +77,8 @@ public class DataEntryUpdateHandlerTest {
 
     public static Stream<Arguments> otherDaoTypesProvider() {
         return Stream.of(Arguments.of(randomPeriodDao()),
-                         Arguments.of(randomNoteDao()));
+                         Arguments.of(randomNoteDao()),
+                         Arguments.of(candidateUniquenessEntryDao()));
     }
 
     @BeforeEach
@@ -147,6 +149,10 @@ public class DataEntryUpdateHandlerTest {
             List.of(createMessage(dao, dao, OperationType.INSERT), createMessage(UUID.randomUUID())));
         handler.handleRequest(eventWithOneInvalidRecord, CONTEXT);
         assertEquals(1, snsClient.getPublishedMessages().size());
+    }
+
+    private static CandidateUniquenessEntryDao candidateUniquenessEntryDao() {
+        return new CandidateUniquenessEntryDao(UUID.randomUUID().toString());
     }
 
     private static NoteDao randomNoteDao() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateUniquenessEntryDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateUniquenessEntryDao.java
@@ -90,18 +90,18 @@ public final class CandidateUniquenessEntryDao extends Dao {
             return false;
         }
         var that = (CandidateUniquenessEntryDao) obj;
-        return Objects.equals(this.partitionKey, that.partitionKey) &&
-               Objects.equals(this.sortKey, that.sortKey) &&
-               Objects.equals(this.version, that.version);
+        return Objects.equals(this.partitionKey, that.partitionKey)
+               && Objects.equals(this.sortKey, that.sortKey)
+               && Objects.equals(this.version, that.version);
     }
 
     @Override
     @JacocoGenerated
     public String toString() {
-        return "CandidateUniquenessEntryDao[" +
-               "partitionKey=" + partitionKey + ", " +
-               "sortKey=" + sortKey + ", " +
-               "version=" + version + ']';
+        return "CandidateUniquenessEntryDao["
+               + "partitionKey=" + partitionKey + ", "
+               + "sortKey=" + sortKey + ", "
+               + "version=" + version + ']';
     }
 
     @DynamoDbIgnore

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateUniquenessEntryDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateUniquenessEntryDao.java
@@ -24,6 +24,7 @@ public final class CandidateUniquenessEntryDao extends Dao {
         String sortKey,
         String version
     ) {
+        super();
         this.partitionKey = partitionKey;
         this.sortKey = sortKey;
         this.version = version;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateUniquenessEntryDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateUniquenessEntryDao.java
@@ -2,6 +2,8 @@ package no.sikt.nva.nvi.common.db;
 
 import static no.sikt.nva.nvi.common.DatabaseConstants.HASH_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SORT_KEY;
+import java.util.Objects;
+import no.sikt.nva.nvi.common.db.CandidateUniquenessEntryDao.Builder;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbIgnore;
@@ -9,14 +11,23 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbImmut
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortKey;
 
-@DynamoDbImmutable(builder = CandidateUniquenessEntryDao.Builder.class)
-public record CandidateUniquenessEntryDao(
-    String partitionKey,
-    String sortKey,
-    String version
-) implements DynamoEntryWithRangeKey {
+@DynamoDbImmutable(builder = Builder.class)
+public final class CandidateUniquenessEntryDao extends Dao {
 
     public static final String TYPE = "CandidateUniquenessEntry";
+    private final String partitionKey;
+    private final String sortKey;
+    private final String version;
+
+    public CandidateUniquenessEntryDao(
+        String partitionKey,
+        String sortKey,
+        String version
+    ) {
+        this.partitionKey = partitionKey;
+        this.sortKey = sortKey;
+        this.version = version;
+    }
 
     public CandidateUniquenessEntryDao(String identifier) {
         this(pk0(identifier), pk0(identifier), null);
@@ -43,11 +54,54 @@ public record CandidateUniquenessEntryDao(
         return sortKey;
     }
 
+    @Override
+    public String version() {
+        return version;
+    }
+
     @JacocoGenerated
     @Override
     @DynamoDbAttribute(TYPE_FIELD)
     public String type() {
         return TYPE;
+    }
+
+    public String partitionKey() {
+        return partitionKey;
+    }
+
+    public String sortKey() {
+        return sortKey;
+    }
+
+    @Override
+    @JacocoGenerated
+    public int hashCode() {
+        return Objects.hash(partitionKey, sortKey, version);
+    }
+
+    @Override
+    @JacocoGenerated
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        var that = (CandidateUniquenessEntryDao) obj;
+        return Objects.equals(this.partitionKey, that.partitionKey) &&
+               Objects.equals(this.sortKey, that.sortKey) &&
+               Objects.equals(this.version, that.version);
+    }
+
+    @Override
+    @JacocoGenerated
+    public String toString() {
+        return "CandidateUniquenessEntryDao[" +
+               "partitionKey=" + partitionKey + ", " +
+               "sortKey=" + sortKey + ", " +
+               "version=" + version + ']';
     }
 
     @DynamoDbIgnore


### PR DESCRIPTION
Fix: DataEntryUpdateHandler handle CandidateUniquenessEntryDao

Did not fix the three codacy issues because the fields are DynamoDbAttributes