### PR TITLE
Fix attribute value bug

### DIFF
--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     implementation libs.bundles.logging
     implementation libs.bundles.jena
     testImplementation project(':nvi-test')
+    testImplementation libs.jackson.datatype.jsr310
 
     testImplementation libs.nva.testutils
     testImplementation(group: 'com.amazonaws', name: 'DynamoDBLocal', version: '1.19.0') {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandler.java
@@ -85,7 +85,7 @@ public class DataEntryUpdateHandler implements RequestHandler<SQSEvent, Void> {
         });
     }
 
-    private NviPublishMessageResponse extractDaoAndPublish(DynamodbStreamRecord streamRecord) throws Exception {
+    private NviPublishMessageResponse extractDaoAndPublish(DynamodbStreamRecord streamRecord) {
         var operationType = OperationType.fromValue(streamRecord.getEventName());
         var dao = extractDao(streamRecord);
         if (isNotCandidateOrApproval(dao) || isUnknownOperationType(operationType)) {
@@ -105,13 +105,9 @@ public class DataEntryUpdateHandler implements RequestHandler<SQSEvent, Void> {
         return response;
     }
 
-    private Dao extractDao(DynamodbStreamRecord streamRecord) throws Exception {
-        var image = getImage(streamRecord);
-        return attempt(() -> DynamoEntryWithRangeKey.parseAttributeValuesMap(image, Dao.class))
-                   .orElseThrow(daoFailure -> {
-                       LOGGER.error("Failed to parse image: {}", image.toString());
-                       return daoFailure.getException();
-                   });
+    private Dao extractDao(DynamodbStreamRecord streamRecord) {
+        return attempt(() -> DynamoEntryWithRangeKey.parseAttributeValuesMap(getImage(streamRecord), Dao.class))
+                   .orElseThrow();
     }
 
     private String writeAsString(DynamodbStreamRecord streamRecord) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DynamoDbUtils.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/db/DynamoDbUtils.java
@@ -55,11 +55,16 @@ public final class DynamoDbUtils {
     private static AttributeValue mapToDynamoDbValue(
         com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue value)
         throws JsonProcessingException {
-        if (value.isNULL()) {
+        if (isNullValue(value)) {
             return AttributeValue.builder().nul(true).build();
         }
         var json = writeAsString(value);
         return dynamoObjectMapper.readValue(json, AttributeValue.serializableBuilderClass()).build();
+    }
+
+    private static boolean isNullValue(
+        com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue value) {
+        return nonNull(value.isNULL()) && value.isNULL();
     }
 
     private static String writeAsString(

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -12,6 +12,7 @@ import static no.sikt.nva.nvi.test.TestUtils.randomUsername;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -22,6 +23,8 @@ import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao;
+import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
+import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateUniquenessEntryDao;
 import no.sikt.nva.nvi.common.db.Dao;
@@ -70,7 +73,7 @@ public class DataEntryUpdateHandlerTest {
                                       OperationType.MODIFY),
                          Arguments.of(nonApplicableCandidate, null,
                                       CANDIDATE_REMOVED_TOPIC, OperationType.REMOVE),
-                         Arguments.of(null, randomApproval, APPROVAL_INSERT_TOPIC, OperationType.INSERT),
+                         Arguments.of(null, generatePendingApproval(), APPROVAL_INSERT_TOPIC, OperationType.INSERT),
                          Arguments.of(randomApproval, randomApproval, APPROVAL_UPDATE_TOPIC, OperationType.MODIFY),
                          Arguments.of(randomApproval, null, APPROVAL_REMOVE_TOPIC, OperationType.REMOVE));
     }
@@ -190,5 +193,16 @@ public class DataEntryUpdateHandlerTest {
 
     private static CandidateDao nonApplicableCandidateDao() {
         return new CandidateDao(UUID.randomUUID(), randomCandidateBuilder(false).build(), UUID.randomUUID().toString());
+    }
+
+    private static ApprovalStatusDao generatePendingApproval() {
+        return new ApprovalStatusDao(UUID.randomUUID(),
+                                     new DbApprovalStatus(randomUri(),
+                                                          DbStatus.PENDING,
+                                                          null,
+                                                          null,
+                                                          null,
+                                                          null),
+                                     UUID.randomUUID().toString());
     }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbUtilsTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbUtilsTest.java
@@ -20,10 +20,8 @@ class DynamoDbUtilsTest {
     }
 
     private static DynamodbStreamRecord setUpStreamRecordWithFieldWithNullValue() {
-        return (DynamodbStreamRecord) new DynamodbStreamRecord()
-                                          .withDynamodb(new StreamRecord().withNewImage(
-                                              Map.of(SOME_FIELD_NAME,
-                                                     new com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue().withNULL(
-                                                         true))));
+        return (DynamodbStreamRecord) new DynamodbStreamRecord().withDynamodb(new StreamRecord().withNewImage(
+            Map.of(SOME_FIELD_NAME,
+                   new com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue().withNULL(true))));
     }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbUtilsTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbUtilsTest.java
@@ -15,7 +15,7 @@ class DynamoDbUtilsTest {
     void shouldParseNullValuesWhenGettingImage() {
         var streamRecordWithNullValue = setUpStreamRecordWithFieldWithNullValue();
         var attributeValueMap = DynamoDbUtils.getImage(streamRecordWithNullValue);
-        AttributeValue expectedAttributeValue = AttributeValue.builder().nul(true).build();
+        var expectedAttributeValue = AttributeValue.builder().nul(true).build();
         assertEquals(expectedAttributeValue, attributeValueMap.get(SOME_FIELD_NAME));
     }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbUtilsTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DynamoDbUtilsTest.java
@@ -1,0 +1,29 @@
+package no.sikt.nva.nvi.events.db;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
+import com.amazonaws.services.lambda.runtime.events.models.dynamodb.StreamRecord;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
+
+class DynamoDbUtilsTest {
+
+    public static final String SOME_FIELD_NAME = "fieldWithNullValue";
+
+    @Test
+    void shouldParseNullValuesWhenGettingImage() {
+        var streamRecordWithNullValue = setUpStreamRecordWithFieldWithNullValue();
+        var attributeValueMap = DynamoDbUtils.getImage(streamRecordWithNullValue);
+        AttributeValue expectedAttributeValue = AttributeValue.builder().nul(true).build();
+        assertEquals(expectedAttributeValue, attributeValueMap.get(SOME_FIELD_NAME));
+    }
+
+    private static DynamodbStreamRecord setUpStreamRecordWithFieldWithNullValue() {
+        return (DynamodbStreamRecord) new DynamodbStreamRecord()
+                                          .withDynamodb(new StreamRecord().withNewImage(
+                                              Map.of(SOME_FIELD_NAME,
+                                                     new com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue().withNULL(
+                                                         true))));
+    }
+}


### PR DESCRIPTION
Jira bug: [Candidate modifications/approvals are not getting indexed](https://unit.atlassian.net/browse/NP-45929)

Reason: `AttributeValue`s with null-values where not parsed correctly with `dynamoDbMapper` (ObjectMapper) in `DynamoDbUtils`, causing failures in `DynamoEntryWithRangeKey.parseAttributeValuesMap()`.

Not a fan of this solution, its very aws dynamoDb model-specific. Feel free to suggest better ways to handle this issue.