### PR TITLE
Add dataType to messageAttribute

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -113,12 +113,12 @@ public class DataEntryUpdateHandlerTest {
 
     @Test
     void shouldSendMessageToDlqWhenFailingToPublishEvent() {
-        var failingUUID = UUID.randomUUID();
-        var eventWithOneInvalidRecord = createEventWithMessages(List.of(createMessage(failingUUID)));
+        var failingUuid = UUID.randomUUID();
+        var eventWithOneInvalidRecord = createEventWithMessages(List.of(createMessage(failingUuid)));
         handler.handleRequest(eventWithOneInvalidRecord, CONTEXT);
         assertEquals(1, queueClient.getSentMessages().size());
         var dlqSendMessageRequest = queueClient.getSentMessages().get(0);
-        assertEquals(failingUUID.toString(), dlqSendMessageRequest.messageAttributes().get(
+        assertEquals(failingUuid.toString(), dlqSendMessageRequest.messageAttributes().get(
             CANDIDATE_IDENTIFIER_MESSAGE_ATTRIBUTE).stringValue());
         assertEquals("String", dlqSendMessageRequest.messageAttributes().get(
             CANDIDATE_IDENTIFIER_MESSAGE_ATTRIBUTE).dataType());

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
@@ -30,6 +30,7 @@ public class NviQueueClient implements QueueClient {
     private static final int MAX_CONNECTIONS = 10_000;
     private static final int IDLE_TIME = 30;
     private static final int TIMEOUT_TIME = 30;
+    public static final String DATA_TYPE_STRING = "String";
     protected final SqsClient sqsClient;
 
     @JacocoGenerated
@@ -83,6 +84,7 @@ public class NviQueueClient implements QueueClient {
         return Map.of(CANDIDATE_IDENTIFIER,
                       MessageAttributeValue.builder()
                           .stringValue(candidateIdentifier.toString())
+                          .dataType(DATA_TYPE_STRING)
                           .build());
     }
 
@@ -163,13 +165,15 @@ public class NviQueueClient implements QueueClient {
         return new NviReceiveMessageResponse(receiveMessageResponse.messages()
                                                  .stream()
                                                  .map(m -> new NviReceiveMessage(m.body(),
-                                                         m.messageId(),
-                                                         m.messageAttributes().entrySet().stream()
-                                                             .collect(Collectors.toMap(
-                                                                 Entry::getKey,
-                                                                 e -> e.getValue().stringValue()
-                                                             )),
-                                                         m.receiptHandle()))
+                                                                                 m.messageId(),
+                                                                                 m.messageAttributes()
+                                                                                     .entrySet()
+                                                                                     .stream()
+                                                                                     .collect(Collectors.toMap(
+                                                                                         Entry::getKey,
+                                                                                         e -> e.getValue().stringValue()
+                                                                                     )),
+                                                                                 m.receiptHandle()))
                                                  .toList());
     }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/queue/NviQueueClientTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/queue/NviQueueClientTest.java
@@ -39,6 +39,7 @@ public class NviQueueClientTest {
     private static final String TEST_RECEIPT_HANDLE = "some_test_receipt_handle";
     public static final String MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER = "candidateIdentifier";
     public static final int MAX_NUMBER_OF_MESSAGES = 10;
+    public static final String DATA_TYPE_STRING = "String";
 
     @Test
     void shouldSendSqsMessageAndReturnId() {
@@ -154,6 +155,7 @@ public class NviQueueClientTest {
                    .messageAttributes(Map.of(MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER,
                                              MessageAttributeValue.builder()
                                                  .stringValue(candidateIdentifier.toString())
+                                                 .dataType(DATA_TYPE_STRING)
                                                  .build()))
                    .queueUrl(TEST_QUEUE_URL).build();
     }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/FakeSqsClient.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/FakeSqsClient.java
@@ -27,6 +27,7 @@ import software.amazon.awssdk.services.sqs.model.SendMessageResponse;
 public class FakeSqsClient implements QueueClient {
 
     public static final String MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER_QUEUE = "candidateIdentifier";
+    public static final String DATA_TYPE_STRING = "String";
 
     private final List<SendMessageRequest> sentMessages = new ArrayList<>();
 
@@ -121,6 +122,7 @@ public class FakeSqsClient implements QueueClient {
                        MESSAGE_ATTRIBUTE_CANDIDATE_IDENTIFIER_QUEUE,
                        MessageAttributeValue.builder()
                            .stringValue(candidateIdentifier.toString())
+                            .dataType(DATA_TYPE_STRING)
                            .build()))
                    .messageBody(body)
                    .build();


### PR DESCRIPTION
Fix `SqsException` that occurred when sending message to DLQ with `messageAttribute` `candidateIdentifier`. `messageAttribute` must contain `dataType`:
```
Message (user) attribute 'candidateIdentifier' must contain a non-empty attribute type. 
(Service: Sqs, Status Code: 400, Request ID: a7807667-a3f1-583f-a487-287657b4c0c2):software.amazon.awssdk.services.sqs.model.SqsException
software.amazon.awssdk.services.sqs.model.SqsException: Message (user) attribute 'candidateIdentifier' must contain a non-empty attribute type.
```