### PR TITLE
Template config - timeout and reserved concurrency

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -730,6 +730,7 @@ Resources:
       Role: !GetAtt NvaNviRole.Arn
       AutoPublishAlias: live
       Timeout: 60
+      ReservedConcurrentExecutions: 25
       Environment:
         Variables:
           EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
@@ -755,6 +756,7 @@ Resources:
       Role: !GetAtt NvaNviRole.Arn
       AutoPublishAlias: live
       Timeout: 30
+      ReservedConcurrentExecutions: 50
       Environment:
         Variables:
           EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
@@ -859,6 +861,7 @@ Resources:
       Handler: no.sikt.nva.nvi.events.batch.RequeueDlqHandler::handleRequest
       Role: !GetAtt NvaNviRole.Arn
       AutoPublishAlias: live
+      Timeout: 300
       Environment:
         Variables:
           DLQ_QUEUE_URL: !Ref IndexDLQ


### PR DESCRIPTION
- Timeout for NviRequeueDlqHandler adjusted to 5 minutes
- Reserved concurrency for `IndexDocumentHandler` set to 25 (due to cristin-proxy requests)
- Reserved concurrency for `UpdateIndexHandler` set to 50 (due to OpenSearch requests)

The reserved concurrencies are probable on the safer side, but can work as a default and be changed in aws if needed