### PR TITLE
Remove SQS queue names, use aws default names

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -43,63 +43,6 @@ Parameters:
   ResourcesBucket:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /NVA/Events/PersistedEntriesBucketName
-  PersistedResourceQueueName:
-    Type: String
-    Default: PersistedResourceQueue
-  PersistedResourceDLQName:
-    Type: String
-    Default: PersistedResourceDLQ
-  NewCandidateQueueName:
-    Type: String
-    Default: NewCandidateQueue
-  DbEventQueueName:
-    Type: String
-    Default: DbEventQueue
-  NewCandidateDLQName:
-    Type: String
-    Default: NewCandidateDLQ
-  BatchScanDLQName:
-    Type: String
-    Default: BatchScanDLQ
-  UpdateIndexDLQName:
-    Type: String
-    Default: UpdateIndexDLQ
-  UpsertCandidateDLQName:
-    Type: String
-    Default: UpsertCandidateDLQ
-  ReEvaluateDLQName:
-    Type: String
-    Default: ReEvaluateDLQ
-  GenerateIndexDocumentQueueName:
-    Type: String
-    Default: GenerateIndexDocumentQueue
-  RemoveDocumentFromIndexQueueName:
-    Type: String
-    Default: RemoveDocumentFromIndexQueue
-  RemoveDocumentFromIndexDLQName:
-    Type: String
-    Default: RemoveDocumentFromIndexDLQ
-  DeletePersistedIndexDocumentQueueName:
-    Type: String
-    Default: DeletePersistedIndexDocumentQueue
-  DeletePersistedIndexDocumentDLQName:
-    Type: String
-    Default: DeletePersistedIndexDocumentDLQ
-  PersistedIndexDocumentQueueName:
-    Type: String
-    Default: PersistedIndexDocumentQueue
-  IndexDLQName:
-    Type: String
-    Default: IndexDLQ
-  DynamoDbEventToQueueDLQName:
-    Type: String
-    Default: DynamoDbEventToQueueDLQ
-  DataEntryUpdateDLQName:
-    Type: String
-    Default: DataEntryUpdateDLQ
-  IndexDocumentDLQName:
-    Type: String
-    Default: IndexDocumentDLQ
   SearchInfrastructureApiHost:
     Type: String
     Description: Host of external search infrastructure API (SWS).
@@ -274,14 +217,12 @@ Resources:
   PersistedResourceQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref PersistedResourceQueueName
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt PersistedResourceDLQ.Arn
         maxReceiveCount: 5
   NewCandidateQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref NewCandidateQueueName
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt NewCandidateDLQ.Arn
         maxReceiveCount: 5
@@ -289,34 +230,28 @@ Resources:
   NewCandidateDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref NewCandidateDLQName
       MessageRetentionPeriod: 1209600 #14 days
   UpsertCandidateDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref UpsertCandidateDLQName
       MessageRetentionPeriod: 1209600 #14 days
   BatchScanDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref BatchScanDLQName
       MessageRetentionPeriod: 1209600 #14 days
   PersistedResourceDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref PersistedResourceDLQName
       MessageRetentionPeriod: 1209600 #14 days
   ReEvaluateDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref ReEvaluateDLQName
       MessageRetentionPeriod: 1209600 #14 days
 
   #=============================== For database events ============================================
   DbEventQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref DbEventQueueName
       VisibilityTimeout: 60
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DataEntryUpdateDLQ.Arn
@@ -325,18 +260,15 @@ Resources:
   DynamoDbEventToQueueDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref DynamoDbEventToQueueDLQName
       MessageRetentionPeriod: 1209600 #14 days
   DataEntryUpdateDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref DataEntryUpdateDLQName
       MessageRetentionPeriod: 1209600 #14 days
   #=============================== For index handling =============================================
   GenerateIndexDocumentQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref GenerateIndexDocumentQueueName
       VisibilityTimeout: 60
       RedrivePolicy:
           deadLetterTargetArn: !GetAtt IndexDocumentDLQ.Arn
@@ -344,21 +276,18 @@ Resources:
   RemoveDocumentFromIndexQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref RemoveDocumentFromIndexQueueName
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt RemoveDocumentFromIndexDLQ.Arn
         maxReceiveCount: 5
   PersistedIndexDocumentQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref PersistedIndexDocumentQueueName
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt UpdateIndexDLQ.Arn
         maxReceiveCount: 5
   DeletePersistedIndexDocumentQueue:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref DeletePersistedIndexDocumentQueueName
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt DeletePersistedIndexDocumentDLQ.Arn
         maxReceiveCount: 5
@@ -366,27 +295,22 @@ Resources:
   IndexDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref IndexDLQName
       MessageRetentionPeriod: 1209600 #14 days
   IndexDocumentDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref IndexDocumentDLQName
       MessageRetentionPeriod: 1209600 #14 days
   UpdateIndexDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref UpdateIndexDLQName
       MessageRetentionPeriod: 1209600 #14 days
   RemoveDocumentFromIndexDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref RemoveDocumentFromIndexDLQName
       MessageRetentionPeriod: 1209600 #14 days
   DeletePersistedIndexDocumentDLQ:
     Type: AWS::SQS::Queue
     Properties:
-      QueueName: !Ref DeletePersistedIndexDocumentDLQName
       MessageRetentionPeriod: 1209600 #14 days
 
   #============================= Permissions =======================================================


### PR DESCRIPTION
Noticed that nvi queues where missing prefixes with stack names in aws console compared to the other queues. These are provided as defaults if name is not specified.
Therefore: removing queue names from template