### PR TITLE
Add id to NviCandidateIndexDocument

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -12,13 +12,12 @@ import java.util.UUID;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.unit.nva.auth.uriretriever.UriRetriever;
-import nva.commons.core.JacocoGenerated;
 
-@JacocoGenerated
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
 @JsonTypeName("NviCandidate")
 public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
+                                        URI id,
                                         UUID identifier,
                                         PublicationDetails publicationDetails,
                                         List<Approval> approvals,
@@ -37,18 +36,26 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         return new Builder();
     }
 
-    @JacocoGenerated
-    public static class Builder {
+    public static final class Builder {
 
         private URI context;
+        private URI id;
         private UUID identifier;
         private PublicationDetails publicationDetails;
         private List<Approval> approvals;
         private int numberOfApprovals;
         private BigDecimal points;
 
+        private Builder() {
+        }
+
         public Builder withContext(URI context) {
             this.context = context;
+            return this;
+        }
+
+        public Builder withId(URI id) {
+            this.id = id;
             return this;
         }
 
@@ -78,8 +85,8 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         }
 
         public NviCandidateIndexDocument build() {
-            return new NviCandidateIndexDocument(context, identifier, publicationDetails,
-                                                 approvals, numberOfApprovals, points);
+            return new NviCandidateIndexDocument(context, id, identifier, publicationDetails, approvals,
+                                                 numberOfApprovals, points);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -72,7 +72,8 @@ public final class NviCandidateIndexDocumentGenerator {
 
     private NviCandidateIndexDocument createNviCandidateIndexDocument(JsonNode resource, Candidate candidate) {
         var approvals = createApprovals(resource, candidate);
-        return new NviCandidateIndexDocument.Builder()
+        return NviCandidateIndexDocument.builder()
+                   .withId(candidate.getId())
                    .withContext(Candidate.getContextUri())
                    .withIdentifier(candidate.getIdentifier())
                    .withApprovals(approvals)

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -440,6 +440,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     private NviCandidateIndexDocument createExpectedNviIndexDocument(JsonNode expandedResource, Candidate candidate) {
         return NviCandidateIndexDocument.builder()
                    .withContext(Candidate.getContextUri())
+                   .withId(candidate.getId())
                    .withIdentifier(candidate.getIdentifier())
                    .withApprovals(expandApprovals(candidate))
                    .withPoints(candidate.getTotalPoints())

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -470,8 +470,13 @@ public class OpenSearchClientTest {
 
     private static NviCandidateIndexDocument singleNviCandidateIndexDocument() {
         var approvals = randomApprovalList();
-        return new NviCandidateIndexDocument(randomUri(), UUID.randomUUID(), randomPublicationDetails(),
-                                             approvals, approvals.size(), randomBigDecimal());
+        return NviCandidateIndexDocument.builder()
+                   .withIdentifier(UUID.randomUUID())
+                   .withPublicationDetails(randomPublicationDetails())
+                   .withApprovals(approvals)
+                   .withNumberOfApprovals(approvals.size())
+                   .withPoints(randomBigDecimal())
+                   .build();
     }
 
     private static NviCandidateIndexDocument singleNviCandidateIndexDocumentWithCustomer(String customer,
@@ -479,10 +484,13 @@ public class OpenSearchClientTest {
                                                                                          String assignee,
                                                                                          String year,
                                                                                          String title) {
-        return new NviCandidateIndexDocument(randomUri(), UUID.randomUUID(),
-                                             randomPublicationDetailsWithCustomer(customer, contributor, year, title),
-                                             List.of(randomApprovalWithCustomerAndAssignee(customer, assignee)), 1,
-                                             randomBigDecimal());
+        return NviCandidateIndexDocument.builder()
+                   .withIdentifier(UUID.randomUUID())
+                   .withPublicationDetails(randomPublicationDetailsWithCustomer(customer, contributor, year, title))
+                   .withApprovals(List.of(randomApprovalWithCustomerAndAssignee(customer, assignee)))
+                   .withNumberOfApprovals(1)
+                   .withPoints(randomBigDecimal())
+                   .build();
     }
 
     private static PublicationDetails randomPublicationDetailsWithCustomer(String affiliation,

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -299,8 +299,13 @@ public class SearchNviCandidatesHandlerTest {
     }
 
     private static NviCandidateIndexDocument singleNviCandidateIndexDocument() {
-        return new NviCandidateIndexDocument(randomUri(), UUID.randomUUID(),
-                                             randomPublicationDetails(), List.of(), 0, TestUtils.randomBigDecimal());
+        return NviCandidateIndexDocument.builder()
+                   .withIdentifier(UUID.randomUUID())
+                   .withPublicationDetails(randomPublicationDetails())
+                   .withApprovals(List.of())
+                   .withNumberOfApprovals(0)
+                   .withPoints(TestUtils.randomBigDecimal())
+                   .build();
     }
 
     private static PublicationDetails randomPublicationDetails() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -162,6 +162,10 @@ public final class Candidate {
         return identifier;
     }
 
+    public URI getId() {
+        return new UriWrapper(HTTPS, API_DOMAIN).addChild(BASE_PATH, CANDIDATE_PATH, identifier.toString()).getUri();
+    }
+
     public boolean isApplicable() {
         return applicable;
     }
@@ -196,7 +200,7 @@ public final class Candidate {
 
     public CandidateDto toDto() {
         return CandidateDto.builder()
-                   .withId(constructId(identifier))
+                   .withId(getId())
                    .withContext(CONTEXT_URI)
                    .withIdentifier(identifier)
                    .withPublicationId(publicationDetails.publicationId())
@@ -403,9 +407,9 @@ public final class Candidate {
             return Collections.emptyMap();
         } else {
             return candidateDao.candidate()
-                .points()
-                .stream()
-                .collect(Collectors.toMap(DbInstitutionPoints::institutionId, DbInstitutionPoints::points));
+                       .points()
+                       .stream()
+                       .collect(Collectors.toMap(DbInstitutionPoints::institutionId, DbInstitutionPoints::points));
         }
     }
 
@@ -426,10 +430,6 @@ public final class Candidate {
         return periodRepository.findByPublishingYear(year)
                    .map(PeriodStatus::fromPeriod)
                    .orElse(PERIOD_STATUS_NO_PERIOD);
-    }
-
-    private static URI constructId(UUID identifier) {
-        return new UriWrapper(HTTPS, API_DOMAIN).addChild(BASE_PATH, CANDIDATE_PATH, identifier.toString()).getUri();
     }
 
     private static List<DbApprovalStatus> mapToApprovals(Map<URI, BigDecimal> points) {


### PR DESCRIPTION
In order to not get a blank node in a graph database, add `id` to `NviCandidateIndexDocument`