### PR TITLE
InstanceType from Enum to String

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
@@ -11,8 +11,6 @@ import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
-import no.sikt.nva.nvi.common.db.model.InstanceType;
-
 import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
 
@@ -34,7 +32,6 @@ public final class CristinMapper {
                    .publicationBucketUri(constructPublicationBucketUri(cristinNviReport.publicationIdentifier()))
                    .publicationDate(constructPublicationDate(cristinNviReport))
                    .applicable(true)
-                   .instanceType(InstanceType.IMPORTED_CANDIDATE)
                    .level(DbLevel.NON_CANDIDATE)
                    .build();
     }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
@@ -273,7 +273,7 @@ public class RequeueDlqHandlerTest {
                                           .institutionId(randomUri())
                                           .points(BigDecimal.valueOf(1))
                                           .build()))
-                                  .instanceType(InstanceType.ACADEMIC_ARTICLE)
+                                  .instanceType(InstanceType.ACADEMIC_ARTICLE.getValue())
                                   .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))))
                                   .level(DbLevel.LEVEL_ONE)
                                   .channelType(ChannelType.JOURNAL)

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.events.persist;
 
-import static no.sikt.nva.nvi.common.db.model.InstanceType.IMPORTED_CANDIDATE;
 import static no.sikt.nva.nvi.common.db.model.InstanceType.NON_CANDIDATE;
 import static no.sikt.nva.nvi.common.utils.DecimalUtils.adjustScaleAndRoundingMode;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
@@ -135,7 +134,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
         var institutionId = randomUri();
         var identifier = UUID.randomUUID();
         var creators = List.of(new Creator(randomUri(), List.of(institutionId)));
-        var instanceType = randomInstanceTypeExcluding(NON_CANDIDATE);
+        var instanceType = randomInstanceTypeExcluding(NON_CANDIDATE.getValue());
         var randomLevel = randomElement(DbLevel.values());
         var publicationDate = randomPublicationDate();
         var institutionPoints = Map.of(institutionId, randomBigDecimal());
@@ -174,7 +173,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
         var identifier = UUID.randomUUID();
         var publicationId = generatePublicationId(identifier);
         var dto = Candidate.upsert(
-            createUpsertCandidateRequest(publicationId, randomUri(), true, InstanceType.ACADEMIC_ARTICLE, 1,
+            createUpsertCandidateRequest(publicationId, randomUri(), true, InstanceType.ACADEMIC_ARTICLE.getValue(), 1,
                                          randomBigDecimal(),
                                          randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
                                          TestUtils.CURRENT_YEAR,
@@ -211,7 +210,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                    .withCandidateType(NviCandidate.builder()
                                           .withPublicationId(generatePublicationId(identifier))
                                           .withPublicationBucketUri(generateS3BucketUri(identifier))
-                                          .withInstanceType(randomInstanceTypeExcluding(NON_CANDIDATE).getValue())
+                                          .withInstanceType(randomInstanceTypeExcluding(NON_CANDIDATE.getValue()))
                                           .withLevel(randomElement(DbLevel.values()).getVersionOneValue())
                                           .withTotalPoints(randomBigDecimal())
                                           .withBasePoints(randomBigDecimal())
@@ -260,7 +259,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
     }
 
     private static CandidateEvaluatedMessage createEvalMessage(List<Creator> verifiedCreators,
-                                                               InstanceType instanceType, DbLevel level,
+                                                               String instanceType, DbLevel level,
                                                                PublicationDate publicationDate,
                                                                Map<URI, BigDecimal> institutionPoints,
                                                                URI publicationId, URI publicationBucketUri,
@@ -269,7 +268,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                    .withCandidateType(NviCandidate.builder()
                                           .withPublicationId(publicationId)
                                           .withPublicationBucketUri(publicationBucketUri)
-                                          .withInstanceType(instanceType.getValue())
+                                          .withInstanceType(instanceType)
                                           .withChannelType(randomElement(ChannelType.values()).getValue())
                                           .withPublicationChannelId(randomUri())
                                           .withLevel(level.getVersionOneValue())
@@ -361,7 +360,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
     private SQSEvent createEvent(URI keep, URI publicationId, URI publicationBucketUri) {
         var institutionId = randomUri();
         var creators = List.of(new Creator(randomUri(), List.of(institutionId, keep)));
-        var instanceType = randomInstanceTypeExcluding(NON_CANDIDATE);
+        var instanceType = randomInstanceTypeExcluding(NON_CANDIDATE.getValue());
         var randomLevel = randomElement(DbLevel.values());
         var publicationDate = randomPublicationDate();
         var institutionPoints = Map.of(institutionId, randomBigDecimal(), keep, randomBigDecimal());
@@ -370,7 +369,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                            publicationBucketUri, randomBigDecimal());
     }
 
-    private SQSEvent createEvent(List<Creator> verifiedCreators, InstanceType instanceType, DbLevel randomLevel,
+    private SQSEvent createEvent(List<Creator> verifiedCreators, String instanceType, DbLevel randomLevel,
                                  PublicationDate publicationDate, Map<URI, BigDecimal> institutionPoints,
                                  URI publicationId, URI publicationBucketUri, BigDecimal totalPoints) {
         return createEvent(

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -268,7 +268,7 @@ public final class CandidateDao extends Dao {
     public record DbCandidate(URI publicationId,
                               URI publicationBucketUri,
                               boolean applicable,
-                              InstanceType instanceType,
+                              String instanceType,
                               ChannelType channelType,
                               URI channelId,
                               DbLevel level,
@@ -313,7 +313,7 @@ public final class CandidateDao extends Dao {
             private URI builderPublicationId;
             private URI builderPublicationBucketUri;
             private boolean builderApplicable;
-            private InstanceType builderInstanceType;
+            private String builderInstanceType;
             private ChannelType builderChannelType;
             private URI builderChannelId;
             private DbLevel builderLevel;
@@ -345,8 +345,17 @@ public final class CandidateDao extends Dao {
                 return this;
             }
 
-            public Builder instanceType(InstanceType instanceType) {
-                this.builderInstanceType = instanceType;
+            //TODO: Should be removed once we have migrated instanceType to String
+            public Builder instanceType(String instanceType) {
+                var enums = Arrays.stream(InstanceType.values()).toList();
+                var instanceTypeEnum = enums.stream()
+                                           .filter(value -> value.toString().equals(instanceType))
+                                           .findFirst();
+                if (instanceTypeEnum.isPresent()) {
+                    this.builderInstanceType = instanceTypeEnum.get().getValue();
+                } else {
+                    this.builderInstanceType = instanceType;
+                }
                 return this;
             }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/InstanceType.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/InstanceType.java
@@ -16,14 +16,6 @@ public enum InstanceType {
         this.value = value;
     }
 
-    @JacocoGenerated
-    public static InstanceType parse(String value) {
-        return Arrays.stream(InstanceType.values())
-                   .filter(type -> type.getValue().equalsIgnoreCase(value))
-                   .findFirst()
-                   .orElse(NON_CANDIDATE);
-    }
-
     @JsonCreator
     @JacocoGenerated
     public String getValue() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -356,7 +356,7 @@ public final class Candidate {
     }
 
     private static boolean instanceTypeIsUpdated(UpsertCandidateRequest request, CandidateDao existingCandidateDao) {
-        return !Objects.equals(request.instanceType(), existingCandidateDao.candidate().instanceType().getValue());
+        return !Objects.equals(request.instanceType(), existingCandidateDao.candidate().instanceType());
     }
 
     private static boolean levelIsUpdated(UpsertCandidateRequest request, CandidateDao existingCandidateDao) {
@@ -450,7 +450,7 @@ public final class Candidate {
                    .channelType(ChannelType.parse(request.channelType()))
                    .channelId(request.publicationChannelId())
                    .level(DbLevel.parse(request.level()))
-                   .instanceType(InstanceType.parse(request.instanceType()))
+                   .instanceType(request.instanceType())
                    .publicationDate(mapToPublicationDate(request.publicationDate()))
                    .internationalCollaboration(request.isInternationalCollaboration())
                    .collaborationFactor(adjustScaleAndRoundingMode(request.collaborationFactor()))
@@ -471,7 +471,7 @@ public final class Candidate {
                                   .channelType(ChannelType.parse(request.channelType()))
                                   .channelId(request.publicationChannelId())
                                   .level(DbLevel.parse(request.level()))
-                                  .instanceType(InstanceType.parse(request.instanceType()))
+                                  .instanceType(request.instanceType())
                                   .publicationDate(mapToPublicationDate(request.publicationDate()))
                                   .internationalCollaboration(request.isInternationalCollaboration())
                                   .collaborationFactor(adjustScaleAndRoundingMode(request.collaborationFactor()))
@@ -530,7 +530,7 @@ public final class Candidate {
     private PublicationDetails mapToPublicationDetails(CandidateDao candidateDao) {
         return new PublicationDetails(candidateDao.candidate().publicationId(),
                                       candidateDao.candidate().publicationBucketUri(),
-                                      candidateDao.candidate().instanceType().getValue(),
+                                      candidateDao.candidate().instanceType(),
                                       mapToPublicationDate(candidateDao.candidate().publicationDate()),
                                       mapToCreators(candidateDao.candidate().creators()),
                                       candidateDao.candidate().channelType(),

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateTest.java
@@ -34,7 +34,7 @@ public class CandidateTest {
         return DbCandidate.builder()
                    .publicationId(randomUri())
                    .creatorCount(randomInteger())
-                   .instanceType(randomInstanceType())
+                   .instanceType(randomInstanceType().getValue())
                    .level(DbLevel.LEVEL_ONE)
                    .applicable(true)
                    .internationalCollaboration(true)

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalDtoTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalDtoTest.java
@@ -143,7 +143,8 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         var candidate = Candidate.upsert(upsertCandidateRequest, candidateRepository, periodRepository)
                             .orElseThrow();
         var updateRequest = createUpsertCandidateRequest(candidate.toDto().publicationId(),
-                                                         randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH.getValue(), 2,
+                                                         randomUri(), true,
+                                                         InstanceType.ACADEMIC_MONOGRAPH.getValue(), 2,
                                                          randomBigDecimal(),
                                                          randomLevelExcluding(DbLevel.NON_CANDIDATE)
                                                              .getVersionOneValue(), TestUtils.CURRENT_YEAR,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalDtoTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalDtoTest.java
@@ -100,7 +100,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
     void shouldResetApprovalWhenChangingToPending(ApprovalStatus oldStatus) {
         var institutionId = randomUri();
         var upsertCandidateRequest = createUpsertCandidateRequest(randomUri(), randomUri(), true,
-                                                                  InstanceType.ACADEMIC_MONOGRAPH, 1,
+                                                                  InstanceType.ACADEMIC_MONOGRAPH.getValue(), 1,
                                                                   randomBigDecimal(),
                                                                   randomLevelExcluding(
                                                                       DbLevel.NON_CANDIDATE).getVersionOneValue(),
@@ -143,7 +143,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         var candidate = Candidate.upsert(upsertCandidateRequest, candidateRepository, periodRepository)
                             .orElseThrow();
         var updateRequest = createUpsertCandidateRequest(candidate.toDto().publicationId(),
-                                                         randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH, 2,
+                                                         randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH.getValue(), 2,
                                                          randomBigDecimal(),
                                                          randomLevelExcluding(DbLevel.NON_CANDIDATE)
                                                              .getVersionOneValue(), TestUtils.CURRENT_YEAR,
@@ -162,7 +162,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         var createCandidateRequest = createUpsertCandidateRequest(keepInstitutionId, deleteInstitutionId, randomUri());
         Candidate.upsert(createCandidateRequest, candidateRepository, periodRepository);
         var updateRequest = createUpsertCandidateRequest(
-            createCandidateRequest.publicationId(), randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH, 2,
+            createCandidateRequest.publicationId(), randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH.getValue(), 2,
             randomBigDecimal(), randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
             TestUtils.CURRENT_YEAR,
             keepInstitutionId,
@@ -197,7 +197,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         var candidateBO = Candidate.upsert(upsertCandidateRequest, candidateRepository, periodRepository)
                               .orElseThrow();
         var updateRequest = createUpsertCandidateRequest(candidateBO.toDto().publicationId(),
-                                                         randomUri(), true, InstanceType.NON_CANDIDATE, 2,
+                                                         randomUri(), true, InstanceType.NON_CANDIDATE.getValue(), 2,
                                                          randomBigDecimal(),
                                                          randomLevelExcluding(DbLevel.NON_CANDIDATE)
                                                              .getVersionOneValue(), TestUtils.CURRENT_YEAR,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -313,7 +313,8 @@ class CandidateTest extends LocalDynamoTest {
                                 .orElseThrow();
         var updateRequest = createUpsertCandidateRequest(tempCandidate.getPublicationDetails().publicationId(),
                                                          randomUri(), false,
-                                                         InstanceType.ACADEMIC_MONOGRAPH.getValue(), 4, randomBigDecimal(),
+                                                         InstanceType.ACADEMIC_MONOGRAPH.getValue(), 4,
+                                                         randomBigDecimal(),
                                                          randomLevelExcluding(DbLevel.NON_CANDIDATE)
                                                              .getVersionOneValue(), CURRENT_YEAR,
                                                          randomUri(), randomUri(),
@@ -425,7 +426,8 @@ class CandidateTest extends LocalDynamoTest {
                                                             randomUri(), true,
                                                             new PublicationDate(String.valueOf(CURRENT_YEAR),
                                                                                 null, null),
-                                                            getCreators(arguments.institutionIds()), arguments.type().getValue(),
+                                                            getCreators(arguments.institutionIds()),
+                                                            arguments.type().getValue(),
                                                             randomString(), randomUri(),
                                                             arguments.level().getVersionOneValue(),
                                                             getPointsOriginal(arguments.institutionIds()),

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -100,7 +100,8 @@ public final class TestUtils {
     }
 
     public static String randomInstanceTypeExcluding(String instanceType) {
-        var instanceTypes = Arrays.stream(InstanceType.values()).filter(type -> !type.getValue().equals(instanceType)).toList();
+        var instanceTypes = Arrays.stream(InstanceType.values())
+                                .filter(type -> !type.getValue().equals(instanceType)).toList();
         return instanceTypes.get(RANDOM.nextInt(instanceTypes.size())).getValue();
     }
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -85,7 +85,7 @@ public final class TestUtils {
                    .publicationId(randomUri())
                    .publicationBucketUri(randomUri())
                    .applicable(applicable)
-                   .instanceType(randomInstanceTypeExcluding(NON_CANDIDATE))
+                   .instanceType(randomInstanceTypeExcluding(NON_CANDIDATE.getValue()))
                    .points(List.of(new DbInstitutionPoints(randomUri(), randomBigDecimal())))
                    .level(randomElement(DbLevel.values()))
                    .publicationDate(new DbPublicationDate(randomString(), randomString(), randomString()))
@@ -99,9 +99,9 @@ public final class TestUtils {
         return instanceTypes.get(RANDOM.nextInt(instanceTypes.size()));
     }
 
-    public static InstanceType randomInstanceTypeExcluding(InstanceType instanceType) {
-        var instanceTypes = Arrays.stream(InstanceType.values()).filter(type -> !type.equals(instanceType)).toList();
-        return instanceTypes.get(RANDOM.nextInt(instanceTypes.size()));
+    public static String randomInstanceTypeExcluding(String instanceType) {
+        var instanceTypes = Arrays.stream(InstanceType.values()).filter(type -> !type.getValue().equals(instanceType)).toList();
+        return instanceTypes.get(RANDOM.nextInt(instanceTypes.size())).getValue();
     }
 
     public static DbLevel randomLevelExcluding(DbLevel level) {
@@ -237,13 +237,13 @@ public final class TestUtils {
 
     public static UpsertCandidateRequest createUpsertCandidateRequestWithLevel(String level, URI... institutions) {
         return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceTypeExcluding(
-                                                NON_CANDIDATE),
+                                                NON_CANDIDATE.getValue()),
                                             1, randomBigDecimal(), level, CURRENT_YEAR, institutions);
     }
 
     public static UpsertCandidateRequest createUpsertCandidateRequest(int year) {
         return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceTypeExcluding(
-                                                NON_CANDIDATE),
+                                                NON_CANDIDATE.getValue()),
                                             1, randomBigDecimal(),
                                             randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
                                             year,
@@ -252,7 +252,7 @@ public final class TestUtils {
 
     public static UpsertCandidateRequest createUpsertCandidateRequest(URI... institutions) {
         return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceTypeExcluding(
-                                                NON_CANDIDATE),
+                                                NON_CANDIDATE.getValue()),
                                             1, randomBigDecimal(),
                                             randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
                                             CURRENT_YEAR,
@@ -262,7 +262,7 @@ public final class TestUtils {
     public static UpsertCandidateRequest createUpsertCandidateRequest(URI publicationId,
                                                                       URI publicationBucketUri,
                                                                       boolean isApplicable,
-                                                                      InstanceType instanceType,
+                                                                      String instanceType,
                                                                       int creatorCount,
                                                                       BigDecimal totalPoints,
                                                                       String level, int year,
@@ -288,7 +288,7 @@ public final class TestUtils {
                                                                       boolean isApplicable,
                                                                       final PublicationDate publicationDate,
                                                                       Map<URI, List<URI>> creators,
-                                                                      InstanceType instanceType,
+                                                                      String instanceType,
                                                                       String channelType, URI channelId,
                                                                       String level,
                                                                       Map<URI, BigDecimal> points,
@@ -342,7 +342,7 @@ public final class TestUtils {
 
             @Override
             public String instanceType() {
-                return instanceType.getValue();
+                return instanceType;
             }
 
             @Override


### PR DESCRIPTION
I think we want to keep `InstanceType` enum when validating candidacy, so InstanceType will still be used inn `nvi-eveluator`, but it will never be stored as enum in database. 