### PR TITLE
Fix type info bug

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandler.java
@@ -38,6 +38,11 @@ public class SearchNviCandidatesHandler
     public static final String QUERY_PARAM_EXCLUDE_SUB_UNITS = "excludeSubUnits";
     public static final String QUERY_PARAM_FILTER = "filter";
     public static final String QUERY_PARAM_TITLE = "title";
+    private static final String DEFAULT_STRING = StringUtils.EMPTY_STRING;
+    private static final String QUERY_SIZE_PARAM = "size";
+    private static final String QUERY_OFFSET_PARAM = "offset";
+    private static final int DEFAULT_QUERY_SIZE = 10;
+    private static final int DEFAULT_OFFSET_SIZE = 0;
     public static final String QUERY_PARAM_SEARCH_TERM = "query";
     public static final String QUERY_PARAM_YEAR = "year";
     public static final String QUERY_PARAM_CATEGORY = "category";
@@ -46,11 +51,6 @@ public class SearchNviCandidatesHandler
     public static final String USER_IS_NOT_ALLOWED_TO_SEARCH_FOR_AFFILIATIONS_S
         = "User is not allowed to search for affiliations: %s";
     public static final String COMMA_AND_SPACE = ", ";
-    private static final String DEFAULT_STRING = StringUtils.EMPTY_STRING;
-    private static final String QUERY_SIZE_PARAM = "size";
-    private static final String QUERY_OFFSET_PARAM = "offset";
-    private static final int DEFAULT_QUERY_SIZE = 10;
-    private static final int DEFAULT_OFFSET_SIZE = 0;
     private final SearchClient<NviCandidateIndexDocument> openSearchClient;
     private final AuthorizedBackendUriRetriever uriRetriever;
 
@@ -77,8 +77,61 @@ public class SearchNviCandidatesHandler
                                                 candidateSearchParameters.customer());
 
         return attempt(() -> openSearchClient.search(candidateSearchParameters))
-                   .map(searchResponse -> toPaginatedResult(searchResponse, candidateSearchParameters))
-                   .orElseThrow();
+            .map(searchResponse -> toPaginatedResult(searchResponse, candidateSearchParameters))
+            .orElseThrow();
+    }
+
+    private CandidateSearchParameters getCandidateSearchParameters(RequestInfo requestInfo)
+        throws UnauthorizedException {
+        var offset = extractQueryParamOffsetOrDefault(requestInfo);
+        var size = extractQueryParamSizeOrDefault(requestInfo);
+        var filter = extractQueryParamFilterOrDefault(requestInfo);
+        var excludeSubUnits = extractQueryParamExcludeSubUnitsOrDefault(requestInfo);
+        var topLevelOrg = requestInfo.getTopLevelOrgCristinId().orElseThrow();
+        var affiliations = Optional.ofNullable(extractQueryParamAffiliations(requestInfo))
+            .orElse(List.of(topLevelOrg));
+        var username = requestInfo.getUserName();
+        var searchTerm = extractQueryParamSearchTermOrDefault(requestInfo);
+        var year = extractQueryParamPublicationDateOrDefault(requestInfo);
+        var category = extractQueryParamCategoryOrDefault(requestInfo);
+        var title = extractQueryParamTitle(requestInfo);
+        var contributor = extractQueryParamContributor(requestInfo);
+        var assignee = extractQueryParamAssignee(requestInfo);
+
+        assertUserIsAllowedToSearchAffiliations(affiliations, topLevelOrg);
+
+        var candidateSearchParameters = new CandidateSearchParameters(searchTerm, affiliations, excludeSubUnits,
+                                                                      filter, username,
+                                                                      year, category, title, contributor,
+                                                                      assignee, topLevelOrg, offset, size);
+        return candidateSearchParameters;
+    }
+
+    private void assertUserIsAllowedToSearchAffiliations(List<URI> affiliations, URI topLevelOrg)
+        throws UnauthorizedException {
+        var allowed = attempt(() -> this.uriRetriever.getRawContent(topLevelOrg, APPLICATION_JSON)).map(
+                Optional::orElseThrow)
+            .map(str -> createModel(dtoObjectMapper.readTree(str)))
+            .map(model -> model.listObjectsOfProperty(model.createProperty(HAS_PART_PROPERTY)))
+            .map(node -> node.toList().stream().map(RDFNode::toString))
+            .map(s -> Stream.concat(s, Stream.of(topLevelOrg.toString())))
+            .orElseThrow()
+            .collect(Collectors.toSet());
+
+        var illegal = Sets.difference(new HashSet<>(affiliations.stream().map(URI::toString)
+                                                        .collect(Collectors.toSet())), allowed);
+
+        if (!illegal.isEmpty()) {
+            throw new UnauthorizedException(
+                String.format(USER_IS_NOT_ALLOWED_TO_SEARCH_FOR_AFFILIATIONS_S,
+                              String.join(COMMA_AND_SPACE, illegal))
+            );
+        }
+    }
+
+    private String extractQueryParamPublicationDateOrDefault(RequestInfo requestInfo) {
+        return requestInfo.getQueryParameters()
+            .getOrDefault(QUERY_PARAM_YEAR, String.valueOf(ZonedDateTime.now().getYear()));
     }
 
     @Override
@@ -92,14 +145,14 @@ public class SearchNviCandidatesHandler
 
     private static Integer extractQueryParamOffsetOrDefault(RequestInfo requestInfo) {
         return requestInfo.getQueryParameterOpt(QUERY_OFFSET_PARAM)
-                   .map(Integer::parseInt)
-                   .orElse(DEFAULT_OFFSET_SIZE);
+            .map(Integer::parseInt)
+            .orElse(DEFAULT_OFFSET_SIZE);
     }
 
     private static List<URI> extractQueryParamAffiliations(RequestInfo requestInfo) {
         return requestInfo.getQueryParameterOpt(QUERY_PARAM_AFFILIATIONS)
-                   .map(SearchNviCandidatesHandler::splitStringToUris)
-                   .orElse(null);
+            .map(SearchNviCandidatesHandler::splitStringToUris)
+            .orElse(null);
     }
 
     private static List<URI> splitStringToUris(String s) {
@@ -108,12 +161,12 @@ public class SearchNviCandidatesHandler
 
     private static boolean extractQueryParamExcludeSubUnitsOrDefault(RequestInfo requestInfo) {
         return requestInfo.getQueryParameterOpt(QUERY_PARAM_EXCLUDE_SUB_UNITS)
-                   .map(Boolean::parseBoolean).orElse(false);
+            .map(Boolean::parseBoolean).orElse(false);
     }
 
     private static String extractQueryParamFilterOrDefault(RequestInfo requestInfo) {
         return requestInfo.getQueryParameters()
-                   .getOrDefault(QUERY_PARAM_FILTER, DEFAULT_STRING);
+            .getOrDefault(QUERY_PARAM_FILTER, DEFAULT_STRING);
     }
 
     private static String extractQueryParamSearchTermOrDefault(RequestInfo requestInfo) {
@@ -140,59 +193,6 @@ public class SearchNviCandidatesHandler
     private static AuthorizedBackendUriRetriever defaultUriRetriver() {
         return new AuthorizedBackendUriRetriever(new Environment().readEnv("BACKEND_CLIENT_AUTH_URL"),
                                                  new Environment().readEnv("BACKEND_CLIENT_SECRET_NAME"));
-    }
-
-    private CandidateSearchParameters getCandidateSearchParameters(RequestInfo requestInfo)
-        throws UnauthorizedException {
-        var offset = extractQueryParamOffsetOrDefault(requestInfo);
-        var size = extractQueryParamSizeOrDefault(requestInfo);
-        var filter = extractQueryParamFilterOrDefault(requestInfo);
-        var excludeSubUnits = extractQueryParamExcludeSubUnitsOrDefault(requestInfo);
-        var topLevelOrg = requestInfo.getTopLevelOrgCristinId().orElseThrow();
-        var affiliations = Optional.ofNullable(extractQueryParamAffiliations(requestInfo))
-                               .orElse(List.of(topLevelOrg));
-        var username = requestInfo.getUserName();
-        var searchTerm = extractQueryParamSearchTermOrDefault(requestInfo);
-        var year = extractQueryParamPublicationDateOrDefault(requestInfo);
-        var category = extractQueryParamCategoryOrDefault(requestInfo);
-        var title = extractQueryParamTitle(requestInfo);
-        var contributor = extractQueryParamContributor(requestInfo);
-        var assignee = extractQueryParamAssignee(requestInfo);
-
-        assertUserIsAllowedToSearchAffiliations(affiliations, topLevelOrg);
-
-        var candidateSearchParameters = new CandidateSearchParameters(searchTerm, affiliations, excludeSubUnits,
-                                                                      filter, username,
-                                                                      year, category, title, contributor,
-                                                                      assignee, topLevelOrg, offset, size);
-        return candidateSearchParameters;
-    }
-
-    private void assertUserIsAllowedToSearchAffiliations(List<URI> affiliations, URI topLevelOrg)
-        throws UnauthorizedException {
-        var allowed = attempt(() -> this.uriRetriever.getRawContent(topLevelOrg, APPLICATION_JSON)).map(
-                Optional::orElseThrow)
-                          .map(str -> createModel(dtoObjectMapper.readTree(str)))
-                          .map(model -> model.listObjectsOfProperty(model.createProperty(HAS_PART_PROPERTY)))
-                          .map(node -> node.toList().stream().map(RDFNode::toString))
-                          .map(s -> Stream.concat(s, Stream.of(topLevelOrg.toString())))
-                          .orElseThrow()
-                          .collect(Collectors.toSet());
-
-        var illegal = Sets.difference(new HashSet<>(affiliations.stream().map(URI::toString)
-                                                        .collect(Collectors.toSet())), allowed);
-
-        if (!illegal.isEmpty()) {
-            throw new UnauthorizedException(
-                String.format(USER_IS_NOT_ALLOWED_TO_SEARCH_FOR_AFFILIATIONS_S,
-                              String.join(COMMA_AND_SPACE, illegal))
-            );
-        }
-    }
-
-    private String extractQueryParamPublicationDateOrDefault(RequestInfo requestInfo) {
-        return requestInfo.getQueryParameters()
-                   .getOrDefault(QUERY_PARAM_YEAR, String.valueOf(ZonedDateTime.now().getYear()));
     }
 }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandler.java
@@ -31,17 +31,13 @@ import nva.commons.core.JacocoGenerated;
 import nva.commons.core.StringUtils;
 import org.apache.jena.rdf.model.RDFNode;
 
-public class SearchNviCandidatesHandler extends ApiGatewayHandler<Void, PaginatedSearchResult<String>> {
+public class SearchNviCandidatesHandler
+    extends ApiGatewayHandler<Void, PaginatedSearchResult<NviCandidateIndexDocument>> {
 
     public static final String QUERY_PARAM_AFFILIATIONS = "affiliations";
     public static final String QUERY_PARAM_EXCLUDE_SUB_UNITS = "excludeSubUnits";
     public static final String QUERY_PARAM_FILTER = "filter";
     public static final String QUERY_PARAM_TITLE = "title";
-    private static final String DEFAULT_STRING = StringUtils.EMPTY_STRING;
-    private static final String QUERY_SIZE_PARAM = "size";
-    private static final String QUERY_OFFSET_PARAM = "offset";
-    private static final int DEFAULT_QUERY_SIZE = 10;
-    private static final int DEFAULT_OFFSET_SIZE = 0;
     public static final String QUERY_PARAM_SEARCH_TERM = "query";
     public static final String QUERY_PARAM_YEAR = "year";
     public static final String QUERY_PARAM_CATEGORY = "category";
@@ -50,6 +46,11 @@ public class SearchNviCandidatesHandler extends ApiGatewayHandler<Void, Paginate
     public static final String USER_IS_NOT_ALLOWED_TO_SEARCH_FOR_AFFILIATIONS_S
         = "User is not allowed to search for affiliations: %s";
     public static final String COMMA_AND_SPACE = ", ";
+    private static final String DEFAULT_STRING = StringUtils.EMPTY_STRING;
+    private static final String QUERY_SIZE_PARAM = "size";
+    private static final String QUERY_OFFSET_PARAM = "offset";
+    private static final int DEFAULT_QUERY_SIZE = 10;
+    private static final int DEFAULT_OFFSET_SIZE = 0;
     private final SearchClient<NviCandidateIndexDocument> openSearchClient;
     private final AuthorizedBackendUriRetriever uriRetriever;
 
@@ -68,7 +69,7 @@ public class SearchNviCandidatesHandler extends ApiGatewayHandler<Void, Paginate
     }
 
     @Override
-    protected PaginatedSearchResult<String> processInput(Void input, RequestInfo requestInfo,
+    protected PaginatedSearchResult<NviCandidateIndexDocument> processInput(Void input, RequestInfo requestInfo,
                                                                             Context context)
         throws UnauthorizedException {
         var candidateSearchParameters = getCandidateSearchParameters(requestInfo);
@@ -76,65 +77,12 @@ public class SearchNviCandidatesHandler extends ApiGatewayHandler<Void, Paginate
                                                 candidateSearchParameters.customer());
 
         return attempt(() -> openSearchClient.search(candidateSearchParameters))
-            .map(searchResponse -> toPaginatedResult(searchResponse, candidateSearchParameters))
-            .orElseThrow();
-    }
-
-    private CandidateSearchParameters getCandidateSearchParameters(RequestInfo requestInfo)
-        throws UnauthorizedException {
-        var offset = extractQueryParamOffsetOrDefault(requestInfo);
-        var size = extractQueryParamSizeOrDefault(requestInfo);
-        var filter = extractQueryParamFilterOrDefault(requestInfo);
-        var excludeSubUnits = extractQueryParamExcludeSubUnitsOrDefault(requestInfo);
-        var topLevelOrg = requestInfo.getTopLevelOrgCristinId().orElseThrow();
-        var affiliations = Optional.ofNullable(extractQueryParamAffiliations(requestInfo))
-            .orElse(List.of(topLevelOrg));
-        var username = requestInfo.getUserName();
-        var searchTerm = extractQueryParamSearchTermOrDefault(requestInfo);
-        var year = extractQueryParamPublicationDateOrDefault(requestInfo);
-        var category = extractQueryParamCategoryOrDefault(requestInfo);
-        var title = extractQueryParamTitle(requestInfo);
-        var contributor = extractQueryParamContributor(requestInfo);
-        var assignee = extractQueryParamAssignee(requestInfo);
-
-        assertUserIsAllowedToSearchAffiliations(affiliations, topLevelOrg);
-
-        var candidateSearchParameters = new CandidateSearchParameters(searchTerm, affiliations, excludeSubUnits,
-                                                                      filter, username,
-                                                                      year, category, title, contributor,
-                                                                      assignee, topLevelOrg, offset, size);
-        return candidateSearchParameters;
-    }
-
-    private void assertUserIsAllowedToSearchAffiliations(List<URI> affiliations, URI topLevelOrg)
-        throws UnauthorizedException {
-        var allowed = attempt(() -> this.uriRetriever.getRawContent(topLevelOrg, APPLICATION_JSON)).map(
-                Optional::orElseThrow)
-            .map(str -> createModel(dtoObjectMapper.readTree(str)))
-            .map(model -> model.listObjectsOfProperty(model.createProperty(HAS_PART_PROPERTY)))
-            .map(node -> node.toList().stream().map(RDFNode::toString))
-            .map(s -> Stream.concat(s, Stream.of(topLevelOrg.toString())))
-            .orElseThrow()
-            .collect(Collectors.toSet());
-
-        var illegal = Sets.difference(new HashSet<>(affiliations.stream().map(URI::toString)
-                                                        .collect(Collectors.toSet())), allowed);
-
-        if (!illegal.isEmpty()) {
-            throw new UnauthorizedException(
-                String.format(USER_IS_NOT_ALLOWED_TO_SEARCH_FOR_AFFILIATIONS_S,
-                              String.join(COMMA_AND_SPACE, illegal))
-            );
-        }
-    }
-
-    private String extractQueryParamPublicationDateOrDefault(RequestInfo requestInfo) {
-        return requestInfo.getQueryParameters()
-            .getOrDefault(QUERY_PARAM_YEAR, String.valueOf(ZonedDateTime.now().getYear()));
+                   .map(searchResponse -> toPaginatedResult(searchResponse, candidateSearchParameters))
+                   .orElseThrow();
     }
 
     @Override
-    protected Integer getSuccessStatusCode(Void input, PaginatedSearchResult<String> output) {
+    protected Integer getSuccessStatusCode(Void input, PaginatedSearchResult<NviCandidateIndexDocument> output) {
         return HttpURLConnection.HTTP_OK;
     }
 
@@ -144,14 +92,14 @@ public class SearchNviCandidatesHandler extends ApiGatewayHandler<Void, Paginate
 
     private static Integer extractQueryParamOffsetOrDefault(RequestInfo requestInfo) {
         return requestInfo.getQueryParameterOpt(QUERY_OFFSET_PARAM)
-            .map(Integer::parseInt)
-            .orElse(DEFAULT_OFFSET_SIZE);
+                   .map(Integer::parseInt)
+                   .orElse(DEFAULT_OFFSET_SIZE);
     }
 
     private static List<URI> extractQueryParamAffiliations(RequestInfo requestInfo) {
         return requestInfo.getQueryParameterOpt(QUERY_PARAM_AFFILIATIONS)
-            .map(SearchNviCandidatesHandler::splitStringToUris)
-            .orElse(null);
+                   .map(SearchNviCandidatesHandler::splitStringToUris)
+                   .orElse(null);
     }
 
     private static List<URI> splitStringToUris(String s) {
@@ -160,12 +108,12 @@ public class SearchNviCandidatesHandler extends ApiGatewayHandler<Void, Paginate
 
     private static boolean extractQueryParamExcludeSubUnitsOrDefault(RequestInfo requestInfo) {
         return requestInfo.getQueryParameterOpt(QUERY_PARAM_EXCLUDE_SUB_UNITS)
-            .map(Boolean::parseBoolean).orElse(false);
+                   .map(Boolean::parseBoolean).orElse(false);
     }
 
     private static String extractQueryParamFilterOrDefault(RequestInfo requestInfo) {
         return requestInfo.getQueryParameters()
-            .getOrDefault(QUERY_PARAM_FILTER, DEFAULT_STRING);
+                   .getOrDefault(QUERY_PARAM_FILTER, DEFAULT_STRING);
     }
 
     private static String extractQueryParamSearchTermOrDefault(RequestInfo requestInfo) {
@@ -192,6 +140,59 @@ public class SearchNviCandidatesHandler extends ApiGatewayHandler<Void, Paginate
     private static AuthorizedBackendUriRetriever defaultUriRetriver() {
         return new AuthorizedBackendUriRetriever(new Environment().readEnv("BACKEND_CLIENT_AUTH_URL"),
                                                  new Environment().readEnv("BACKEND_CLIENT_SECRET_NAME"));
+    }
+
+    private CandidateSearchParameters getCandidateSearchParameters(RequestInfo requestInfo)
+        throws UnauthorizedException {
+        var offset = extractQueryParamOffsetOrDefault(requestInfo);
+        var size = extractQueryParamSizeOrDefault(requestInfo);
+        var filter = extractQueryParamFilterOrDefault(requestInfo);
+        var excludeSubUnits = extractQueryParamExcludeSubUnitsOrDefault(requestInfo);
+        var topLevelOrg = requestInfo.getTopLevelOrgCristinId().orElseThrow();
+        var affiliations = Optional.ofNullable(extractQueryParamAffiliations(requestInfo))
+                               .orElse(List.of(topLevelOrg));
+        var username = requestInfo.getUserName();
+        var searchTerm = extractQueryParamSearchTermOrDefault(requestInfo);
+        var year = extractQueryParamPublicationDateOrDefault(requestInfo);
+        var category = extractQueryParamCategoryOrDefault(requestInfo);
+        var title = extractQueryParamTitle(requestInfo);
+        var contributor = extractQueryParamContributor(requestInfo);
+        var assignee = extractQueryParamAssignee(requestInfo);
+
+        assertUserIsAllowedToSearchAffiliations(affiliations, topLevelOrg);
+
+        var candidateSearchParameters = new CandidateSearchParameters(searchTerm, affiliations, excludeSubUnits,
+                                                                      filter, username,
+                                                                      year, category, title, contributor,
+                                                                      assignee, topLevelOrg, offset, size);
+        return candidateSearchParameters;
+    }
+
+    private void assertUserIsAllowedToSearchAffiliations(List<URI> affiliations, URI topLevelOrg)
+        throws UnauthorizedException {
+        var allowed = attempt(() -> this.uriRetriever.getRawContent(topLevelOrg, APPLICATION_JSON)).map(
+                Optional::orElseThrow)
+                          .map(str -> createModel(dtoObjectMapper.readTree(str)))
+                          .map(model -> model.listObjectsOfProperty(model.createProperty(HAS_PART_PROPERTY)))
+                          .map(node -> node.toList().stream().map(RDFNode::toString))
+                          .map(s -> Stream.concat(s, Stream.of(topLevelOrg.toString())))
+                          .orElseThrow()
+                          .collect(Collectors.toSet());
+
+        var illegal = Sets.difference(new HashSet<>(affiliations.stream().map(URI::toString)
+                                                        .collect(Collectors.toSet())), allowed);
+
+        if (!illegal.isEmpty()) {
+            throw new UnauthorizedException(
+                String.format(USER_IS_NOT_ALLOWED_TO_SEARCH_FOR_AFFILIATIONS_S,
+                              String.join(COMMA_AND_SPACE, illegal))
+            );
+        }
+    }
+
+    private String extractQueryParamPublicationDateOrDefault(RequestInfo requestInfo) {
+        return requestInfo.getQueryParameters()
+                   .getOrDefault(QUERY_PARAM_YEAR, String.valueOf(ZonedDateTime.now().getYear()));
     }
 }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -1,11 +1,7 @@
 package no.sikt.nva.nvi.index.model;
 
-import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeName;
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.math.BigDecimal;
@@ -19,12 +15,9 @@ import no.unit.nva.auth.uriretriever.UriRetriever;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
-@JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    property = "type")
-@JsonTypeName("NviCandidate")
 public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         URI id,
+                                        String type,
                                         UUID identifier,
                                         PublicationDetails publicationDetails,
                                         List<Approval> approvals,
@@ -33,6 +26,8 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         Instant modifiedDate) {
 
     private static final String CONTEXT = "@context";
+    private static final String NVI_CANDIDATE = "NviCandidate";
+    private static final String TYPE = NVI_CANDIDATE;
 
     public static NviCandidateIndexDocument from(JsonNode expandedResource, Candidate candidate,
                                                  UriRetriever uriRetriever) {
@@ -42,10 +37,6 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
 
     public static Builder builder() {
         return new Builder();
-    }
-
-    public String toJsonString() throws JsonProcessingException {
-        return dtoObjectMapper.writeValueAsString(this);
     }
 
     public static final class Builder {
@@ -103,7 +94,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         }
 
         public NviCandidateIndexDocument build() {
-            return new NviCandidateIndexDocument(context, id, identifier, publicationDetails, approvals,
+            return new NviCandidateIndexDocument(context, id, TYPE, identifier, publicationDetails, approvals,
                                                  numberOfApprovals, points, modifiedDate);
         }
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
@@ -18,7 +18,6 @@ import java.net.URI;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import no.sikt.nva.nvi.index.model.CandidateSearchParameters;
@@ -51,7 +50,7 @@ public final class PaginatedResultConverter {
 
     }
 
-    public static PaginatedSearchResult<String> toPaginatedResult(
+    public static PaginatedSearchResult<NviCandidateIndexDocument> toPaginatedResult(
         SearchResponse<NviCandidateIndexDocument> searchResponse, CandidateSearchParameters candidateSearchParameters)
         throws UnprocessableContentException {
         var paginatedSearchResult = PaginatedSearchResult.create(
@@ -121,11 +120,10 @@ public final class PaginatedResultConverter {
         return (int) searchResponse.hits().total().value();
     }
 
-    private static List<String> extractsHits(SearchResponse<NviCandidateIndexDocument> searchResponse) {
+    private static List<NviCandidateIndexDocument> extractsHits(
+        SearchResponse<NviCandidateIndexDocument> searchResponse) {
         return searchResponse.hits().hits().stream()
                    .map(Hit::source)
-                   .filter(Objects::nonNull)
-                   .map(hit -> attempt(hit::toJsonString).orElseThrow())
                    .toList();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -21,7 +21,6 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -169,11 +168,16 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         mockUriRetrieverOrgResponse(candidate);
         handler.handleRequest(event, CONTEXT);
         var actualIndexDocument = dtoObjectMapper.readTree(s3Writer.getFile(createPath(candidate))).at(JSON_PTR_BODY);
-        assertNotNull(actualIndexDocument.at(JSON_PTR_TYPE));
-        assertNotNull(actualIndexDocument.at(JSON_PTR_CONTRIBUTOR).get(0).at(JSON_PTR_TYPE));
-        assertNotNull(
-            actualIndexDocument.at(JSON_PTR_CONTRIBUTOR).get(0).at(JSON_PTR_AFFILIATIONS).get(0).at(JSON_PTR_TYPE));
-        assertNotNull(actualIndexDocument.at(JSON_PTR_APPROVALS).get(0).at(JSON_PTR_TYPE));
+        assertEquals("NviCandidate", actualIndexDocument.at(JSON_PTR_TYPE).textValue());
+        assertEquals("Contributor", actualIndexDocument.at(JSON_PTR_CONTRIBUTOR).get(0).at(JSON_PTR_TYPE).textValue());
+        assertEquals("Organization",
+                     actualIndexDocument.at(JSON_PTR_CONTRIBUTOR)
+                         .get(0)
+                         .at(JSON_PTR_AFFILIATIONS)
+                         .get(0)
+                         .at(JSON_PTR_TYPE)
+                         .textValue());
+        assertEquals("Approval", actualIndexDocument.at(JSON_PTR_APPROVALS).get(0).at(JSON_PTR_TYPE).textValue());
     }
 
     @Test

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -15,6 +15,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
@@ -81,7 +82,7 @@ public class SearchNviCandidatesHandlerTest {
     private static final String QUERY_PARAM_SIZE = "size";
     private static final int DEFAULT_QUERY_SIZE = 10;
     private static final int DEFAULT_OFFSET_SIZE = 0;
-    private static final TypeReference<PaginatedSearchResult<String>> TYPE_REF =
+    private static final TypeReference<PaginatedSearchResult<NviCandidateIndexDocument>> TYPE_REF =
         new TypeReference<>() {
         };
     private static SearchClient<NviCandidateIndexDocument> openSearchClient;
@@ -102,15 +103,13 @@ public class SearchNviCandidatesHandlerTest {
 
     @Test
     void shouldReturnDocumentFromIndexWhenNoSearchIsSpecified() throws IOException {
-        when(openSearchClient.search(any()))
-            .thenReturn(createSearchResponse(singleNviCandidateIndexDocument()));
+        var expectedDocument = singleNviCandidateIndexDocument();
+        when(openSearchClient.search(any())).thenReturn(createSearchResponse(expectedDocument));
         handler.handleRequest(emptyRequest(), output, context);
-        var response =
-            GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
-        var paginatedResult =
-            objectMapper.readValue(response.getBody(), TYPE_REF);
-
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var paginatedResult = objectMapper.readValue(response.getBody(), TYPE_REF);
         assertThat(paginatedResult.getHits(), hasSize(1));
+        assertEquals(paginatedResult.getHits().get(0), expectedDocument);
     }
 
     @Test
@@ -233,8 +232,7 @@ public class SearchNviCandidatesHandlerTest {
         handler.handleRequest(request, output, context);
 
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
-        var paginatedResult =
-            objectMapper.readValue(response.getBody(), TYPE_REF);
+        var paginatedResult = objectMapper.readValue(response.getBody(), TYPE_REF);
 
         assertThat(paginatedResult.getHits(), hasSize(1));
     }


### PR DESCRIPTION
Fix bug introduced by: [Index document - add type info](https://github.com/BIBSYSDEV/nva-nvi/commit/2df96ccd14c6945bae8eaaa9893e0d7746f7ccf5)

- Change `PaginatedSearchResult` type back to `NviCandidateIndexDocument`
- Add type field with static value for `NviCandidateIndexDocument`