### PR TITLE
Np 46085 index document contributors nvi info

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Affiliation.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Affiliation.java
@@ -13,7 +13,8 @@ import java.util.List;
     property = "type")
 @JsonTypeName("Organization")
 public record Affiliation(String id,
-                          List<String> partOf) {
+                          List<String> partOf,
+                          boolean isNviAffiliation) {
 
     public static Builder builder() {
         return new Builder();
@@ -23,6 +24,10 @@ public record Affiliation(String id,
 
         private String id;
         private List<String> partOf;
+        private boolean isNviAffiliation;
+
+        private Builder() {
+        }
 
         public Builder withId(String id) {
             this.id = id;
@@ -34,8 +39,13 @@ public record Affiliation(String id,
             return this;
         }
 
+        public Builder withIsNviAffiliation(boolean isNviAffiliation) {
+            this.isNviAffiliation = isNviAffiliation;
+            return this;
+        }
+
         public Affiliation build() {
-            return new Affiliation(id, partOf);
+            return new Affiliation(id, partOf, isNviAffiliation);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
@@ -31,7 +31,6 @@ public record Contributor(@JsonProperty("id") String id,
         private String orcid;
         private String role;
         private List<Affiliation> affiliations;
-        private boolean isNviContributor;
 
         private Builder() {
         }
@@ -58,11 +57,6 @@ public record Contributor(@JsonProperty("id") String id,
 
         public Builder withAffiliations(List<Affiliation> affiliations) {
             this.affiliations = affiliations;
-            return this;
-        }
-
-        public Builder withIsNviContributor(boolean isNviContributor) {
-            this.isNviContributor = isNviContributor;
             return this;
         }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
@@ -2,19 +2,24 @@ package no.sikt.nva.nvi.index.model;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 import java.util.Objects;
+import nva.commons.core.JacocoGenerated;
 
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
 @JsonSerialize
 @JsonTypeInfo(
     use = Id.NAME,
     property = "type")
-@JsonTypeName("Contributor")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = NviContributor.class, name = "NviContributor")
+})
 public class Contributor {
 
     private final String id;
@@ -22,16 +27,18 @@ public class Contributor {
     private final String orcid;
     private final String role;
     private final List<Affiliation> affiliations;
-    private final boolean isNviContributor;
 
-    public Contributor(String id, String name, String orcid, String role, List<Affiliation> affiliations,
-                       boolean isNviContributor) {
+    @JsonCreator
+    public Contributor(@JsonProperty("id") String id,
+                       @JsonProperty("name") String name,
+                       @JsonProperty("orcid") String orcid,
+                       @JsonProperty("role") String role,
+                       @JsonProperty("affiliations") List<Affiliation> affiliations) {
         this.id = id;
         this.name = name;
         this.orcid = orcid;
         this.role = role;
         this.affiliations = affiliations;
-        this.isNviContributor = isNviContributor;
     }
 
     public static Builder builder() {
@@ -58,41 +65,27 @@ public class Contributor {
         return affiliations;
     }
 
-    public boolean isNviContributor() {
-        return isNviContributor;
-    }
-
     @Override
+    @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(id, name, orcid, role, affiliations, isNviContributor);
+        return Objects.hash(id, name, orcid, role, affiliations);
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == this) {
+    @JacocoGenerated
+    public boolean equals(Object o) {
+        if (this == o) {
             return true;
         }
-        if (obj == null || obj.getClass() != this.getClass()) {
+        if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        var that = (Contributor) obj;
-        return Objects.equals(this.id, that.id) &&
-               Objects.equals(this.name, that.name) &&
-               Objects.equals(this.orcid, that.orcid) &&
-               Objects.equals(this.role, that.role) &&
-               Objects.equals(this.affiliations, that.affiliations) &&
-               this.isNviContributor == that.isNviContributor;
-    }
-
-    @Override
-    public String toString() {
-        return "Contributor[" +
-               "id=" + id + ", " +
-               "name=" + name + ", " +
-               "orcid=" + orcid + ", " +
-               "role=" + role + ", " +
-               "affiliations=" + affiliations + ", " +
-               "isNviContributor=" + isNviContributor + ']';
+        Contributor that = (Contributor) o;
+        return Objects.equals(id, that.id)
+               && Objects.equals(name, that.name)
+               && Objects.equals(orcid, that.orcid)
+               && Objects.equals(role, that.role)
+               && Objects.equals(affiliations, that.affiliations);
     }
 
     public static final class Builder {
@@ -138,7 +131,7 @@ public class Contributor {
         }
 
         public Contributor build() {
-            return new Contributor(id, name, orcid, role, affiliations, isNviContributor);
+            return new Contributor(id, name, orcid, role, affiliations);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
@@ -1,26 +1,98 @@
 package no.sikt.nva.nvi.index.model;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import java.util.Objects;
 
-@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonAutoDetect(fieldVisibility = Visibility.ANY)
 @JsonSerialize
 @JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
+    use = Id.NAME,
     property = "type")
 @JsonTypeName("Contributor")
-public record Contributor(String id,
-                          String name,
-                          String orcid,
-                          String role,
-                          List<Affiliation> affiliations,
-                          boolean isNviContributor) {
+public class Contributor {
+
+    private final String id;
+    private final String name;
+    private final String orcid;
+    private final String role;
+    private final List<Affiliation> affiliations;
+    private final boolean isNviContributor;
+
+    public Contributor(String id, String name, String orcid, String role, List<Affiliation> affiliations,
+                       boolean isNviContributor) {
+        this.id = id;
+        this.name = name;
+        this.orcid = orcid;
+        this.role = role;
+        this.affiliations = affiliations;
+        this.isNviContributor = isNviContributor;
+    }
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String orcid() {
+        return orcid;
+    }
+
+    public String role() {
+        return role;
+    }
+
+    public List<Affiliation> affiliations() {
+        return affiliations;
+    }
+
+    public boolean isNviContributor() {
+        return isNviContributor;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, name, orcid, role, affiliations, isNviContributor);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == this) {
+            return true;
+        }
+        if (obj == null || obj.getClass() != this.getClass()) {
+            return false;
+        }
+        var that = (Contributor) obj;
+        return Objects.equals(this.id, that.id) &&
+               Objects.equals(this.name, that.name) &&
+               Objects.equals(this.orcid, that.orcid) &&
+               Objects.equals(this.role, that.role) &&
+               Objects.equals(this.affiliations, that.affiliations) &&
+               this.isNviContributor == that.isNviContributor;
+    }
+
+    @Override
+    public String toString() {
+        return "Contributor[" +
+               "id=" + id + ", " +
+               "name=" + name + ", " +
+               "orcid=" + orcid + ", " +
+               "role=" + role + ", " +
+               "affiliations=" + affiliations + ", " +
+               "isNviContributor=" + isNviContributor + ']';
     }
 
     public static final class Builder {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
@@ -17,7 +17,7 @@ public record Contributor(@JsonProperty("id") String id,
                           @JsonProperty("name") String name,
                           @JsonProperty("orcid") String orcid,
                           @JsonProperty("role") String role,
-                          @JsonProperty("affiliations") List<Affiliation> affiliations)
+                          @JsonProperty("affiliations") List<OrganizationType> affiliations)
     implements ContributorType {
 
     public static Builder builder() {
@@ -30,7 +30,7 @@ public record Contributor(@JsonProperty("id") String id,
         private String name;
         private String orcid;
         private String role;
-        private List<Affiliation> affiliations;
+        private List<OrganizationType> affiliations;
 
         private Builder() {
         }
@@ -55,7 +55,7 @@ public record Contributor(@JsonProperty("id") String id,
             return this;
         }
 
-        public Builder withAffiliations(List<Affiliation> affiliations) {
+        public Builder withAffiliations(List<OrganizationType> affiliations) {
             this.affiliations = affiliations;
             return this;
         }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
@@ -16,7 +16,8 @@ public record Contributor(String id,
                           String name,
                           String orcid,
                           String role,
-                          List<Affiliation> affiliations) {
+                          List<Affiliation> affiliations,
+                          boolean isNviContributor) {
 
     public static Builder builder() {
         return new Builder();
@@ -29,6 +30,10 @@ public record Contributor(String id,
         private String orcid;
         private String role;
         private List<Affiliation> affiliations;
+        private boolean isNviContributor;
+
+        private Builder() {
+        }
 
         public Builder withId(String id) {
             this.id = id;
@@ -55,8 +60,13 @@ public record Contributor(String id,
             return this;
         }
 
+        public Builder withIsNviContributor(boolean isNviContributor) {
+            this.isNviContributor = isNviContributor;
+            return this;
+        }
+
         public Contributor build() {
-            return new Contributor(id, name, orcid, role, affiliations);
+            return new Contributor(id, name, orcid, role, affiliations, isNviContributor);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Contributor.java
@@ -2,90 +2,26 @@ package no.sikt.nva.nvi.index.model;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
-import java.util.Objects;
-import nva.commons.core.JacocoGenerated;
 
 @JsonAutoDetect(fieldVisibility = Visibility.ANY)
 @JsonSerialize
 @JsonTypeInfo(
     use = Id.NAME,
     property = "type")
-@JsonSubTypes({
-    @JsonSubTypes.Type(value = NviContributor.class, name = "NviContributor")
-})
-public class Contributor {
-
-    private final String id;
-    private final String name;
-    private final String orcid;
-    private final String role;
-    private final List<Affiliation> affiliations;
-
-    @JsonCreator
-    public Contributor(@JsonProperty("id") String id,
-                       @JsonProperty("name") String name,
-                       @JsonProperty("orcid") String orcid,
-                       @JsonProperty("role") String role,
-                       @JsonProperty("affiliations") List<Affiliation> affiliations) {
-        this.id = id;
-        this.name = name;
-        this.orcid = orcid;
-        this.role = role;
-        this.affiliations = affiliations;
-    }
+public record Contributor(@JsonProperty("id") String id,
+                          @JsonProperty("name") String name,
+                          @JsonProperty("orcid") String orcid,
+                          @JsonProperty("role") String role,
+                          @JsonProperty("affiliations") List<Affiliation> affiliations)
+    implements ContributorType {
 
     public static Builder builder() {
         return new Builder();
-    }
-
-    public String id() {
-        return id;
-    }
-
-    public String name() {
-        return name;
-    }
-
-    public String orcid() {
-        return orcid;
-    }
-
-    public String role() {
-        return role;
-    }
-
-    public List<Affiliation> affiliations() {
-        return affiliations;
-    }
-
-    @Override
-    @JacocoGenerated
-    public int hashCode() {
-        return Objects.hash(id, name, orcid, role, affiliations);
-    }
-
-    @Override
-    @JacocoGenerated
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-        Contributor that = (Contributor) o;
-        return Objects.equals(id, that.id)
-               && Objects.equals(name, that.name)
-               && Objects.equals(orcid, that.orcid)
-               && Objects.equals(role, that.role)
-               && Objects.equals(affiliations, that.affiliations);
     }
 
     public static final class Builder {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/ContributorType.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/ContributorType.java
@@ -1,0 +1,25 @@
+package no.sikt.nva.nvi.index.model;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+
+@JsonSerialize
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = NviContributor.class, name = "NviContributor"),
+    @JsonSubTypes.Type(value = Contributor.class, name = "Contributor")
+})
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+public sealed interface ContributorType permits NviContributor, Contributor {
+
+    String id();
+
+    String name();
+
+    String orcid();
+
+    String role();
+
+    List<Affiliation> affiliations();
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/ContributorType.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/ContributorType.java
@@ -21,5 +21,5 @@ public sealed interface ContributorType permits NviContributor, Contributor {
 
     String role();
 
-    List<Affiliation> affiliations();
+    List<OrganizationType> affiliations();
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviContributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviContributor.java
@@ -11,7 +11,7 @@ public record NviContributor(@JsonProperty("id") String id,
                              @JsonProperty("name") String name,
                              @JsonProperty("orcid") String orcid,
                              @JsonProperty("role") String role,
-                             @JsonProperty("affiliations") List<Affiliation> affiliations) implements ContributorType {
+                             @JsonProperty("affiliations") List<OrganizationType> affiliations) implements ContributorType {
 
     public static Builder builder() {
         return new Builder();
@@ -23,7 +23,7 @@ public record NviContributor(@JsonProperty("id") String id,
         private String name;
         private String orcid;
         private String role;
-        private List<Affiliation> affiliations;
+        private List<OrganizationType> affiliations;
 
         private Builder() {
         }
@@ -48,7 +48,7 @@ public record NviContributor(@JsonProperty("id") String id,
             return this;
         }
 
-        public Builder withAffiliations(List<Affiliation> affiliations) {
+        public Builder withAffiliations(List<OrganizationType> affiliations) {
             this.affiliations = affiliations;
             return this;
         }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviContributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviContributor.java
@@ -1,15 +1,60 @@
 package no.sikt.nva.nvi.index.model;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 
 @JsonSerialize
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-@JsonTypeName("NviContributor")
-public class NviContributor extends Contributor {
-    public NviContributor(String id, String name, String orcid, String role, List<Affiliation> affiliations) {
-        super(id, name, orcid, role, affiliations);
+public record NviContributor(@JsonProperty("id") String id,
+                             @JsonProperty("name") String name,
+                             @JsonProperty("orcid") String orcid,
+                             @JsonProperty("role") String role,
+                             @JsonProperty("affiliations") List<Affiliation> affiliations) implements ContributorType {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String id;
+        private String name;
+        private String orcid;
+        private String role;
+        private List<Affiliation> affiliations;
+
+        private Builder() {
+        }
+
+        public Builder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withName(String name) {
+            this.name = name;
+            return this;
+        }
+
+        public Builder withOrcid(String orcid) {
+            this.orcid = orcid;
+            return this;
+        }
+
+        public Builder withRole(String role) {
+            this.role = role;
+            return this;
+        }
+
+        public Builder withAffiliations(List<Affiliation> affiliations) {
+            this.affiliations = affiliations;
+            return this;
+        }
+
+        public NviContributor build() {
+            return new NviContributor(id, name, orcid, role, affiliations);
+        }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviContributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviContributor.java
@@ -1,0 +1,11 @@
+package no.sikt.nva.nvi.index.model;
+
+import java.util.List;
+
+public class NviContributor extends Contributor {
+
+    public NviContributor(String id, String name, String orcid, String role, List<Affiliation> affiliations,
+                          boolean isNviContributor) {
+        super(id, name, orcid, role, affiliations, isNviContributor);
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviContributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviContributor.java
@@ -1,11 +1,15 @@
 package no.sikt.nva.nvi.index.model;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 
+@JsonSerialize
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeName("NviContributor")
 public class NviContributor extends Contributor {
-
-    public NviContributor(String id, String name, String orcid, String role, List<Affiliation> affiliations,
-                          boolean isNviContributor) {
-        super(id, name, orcid, role, affiliations, isNviContributor);
+    public NviContributor(String id, String name, String orcid, String role, List<Affiliation> affiliations) {
+        super(id, name, orcid, role, affiliations);
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviOrganization.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviOrganization.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.index.model;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -8,13 +9,10 @@ import java.util.List;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
-@JsonTypeInfo(
-    use = JsonTypeInfo.Id.NAME,
-    property = "type")
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonTypeName("Organization")
-public record Affiliation(String id,
-                          List<String> partOf,
-                          boolean isNviAffiliation) {
+public record NviOrganization(@JsonProperty("id") String id,
+                              @JsonProperty("partOf") List<String> partOf) implements OrganizationType {
 
     public static Builder builder() {
         return new Builder();
@@ -24,7 +22,6 @@ public record Affiliation(String id,
 
         private String id;
         private List<String> partOf;
-        private boolean isNviAffiliation;
 
         private Builder() {
         }
@@ -39,13 +36,8 @@ public record Affiliation(String id,
             return this;
         }
 
-        public Builder withIsNviAffiliation(boolean isNviAffiliation) {
-            this.isNviAffiliation = isNviAffiliation;
-            return this;
-        }
-
-        public Affiliation build() {
-            return new Affiliation(id, partOf, isNviAffiliation);
+        public NviOrganization build() {
+            return new NviOrganization(id, partOf);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Organization.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Organization.java
@@ -1,0 +1,42 @@
+package no.sikt.nva.nvi.index.model;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonSerialize
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonTypeName("Organization")
+public record Organization(String id,
+                           List<String> partOf) implements OrganizationType {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private String id;
+        private List<String> partOf;
+
+        private Builder() {
+        }
+
+        public Builder withId(String id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withPartOf(List<String> partOf) {
+            this.partOf = partOf;
+            return this;
+        }
+
+        public Organization build() {
+            return new Organization(id, partOf);
+        }
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/OrganizationType.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/OrganizationType.java
@@ -1,0 +1,21 @@
+package no.sikt.nva.nvi.index.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
+
+@JsonSerialize
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Organization.class, name = "Organization"),
+    @JsonSubTypes.Type(value = NviOrganization.class, name = "NviOrganization")
+})
+public sealed interface OrganizationType permits Organization, NviOrganization {
+
+   String id();
+
+   List<String> partOf();
+
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/OrganizationType.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/OrganizationType.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.index.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -14,8 +13,7 @@ import java.util.List;
 })
 public sealed interface OrganizationType permits Organization, NviOrganization {
 
-   String id();
+    String id();
 
-   List<String> partOf();
-
+    List<String> partOf();
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/PublicationDetails.java
@@ -1,13 +1,17 @@
 package no.sikt.nva.nvi.index.model;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
-public record PublicationDetails(String id, String type, String title, PublicationDate publicationDate,
-                                 List<Contributor> contributors) {
+public record PublicationDetails(@JsonProperty("id") String id,
+                                 @JsonProperty("type") String type,
+                                 @JsonProperty("title") String title,
+                                 @JsonProperty("publicationDate") PublicationDate publicationDate,
+                                 @JsonProperty("contributors") List<ContributorType> contributors) {
 
     public static Builder builder() {
         return new Builder();
@@ -19,7 +23,7 @@ public record PublicationDetails(String id, String type, String title, Publicati
         private String type;
         private String title;
         private PublicationDate publicationDate;
-        private List<Contributor> contributors;
+        private List<ContributorType> contributors;
 
         private Builder() {
         }
@@ -44,7 +48,7 @@ public record PublicationDetails(String id, String type, String title, Publicati
             return this;
         }
 
-        public Builder withContributors(List<Contributor> contributors) {
+        public Builder withContributors(List<ContributorType> contributors) {
             this.contributors = contributors;
             return this;
         }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -41,6 +41,7 @@ import no.sikt.nva.nvi.common.service.model.Username;
 import no.sikt.nva.nvi.index.model.Affiliation;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.Contributor;
+import no.sikt.nva.nvi.index.model.ContributorType;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.PublicationDate;
 import no.sikt.nva.nvi.index.model.PublicationDetails;
@@ -149,7 +150,7 @@ public final class NviCandidateIndexDocumentGenerator {
                    .build();
     }
 
-    private List<Contributor> expandContributors(JsonNode resource, Candidate candidate) {
+    private List<ContributorType> expandContributors(JsonNode resource, Candidate candidate) {
         return getJsonNodeStream(resource, JSON_PTR_CONTRIBUTOR).map(
             contributor -> createContributor(contributor, candidate)).toList();
     }
@@ -169,7 +170,7 @@ public final class NviCandidateIndexDocumentGenerator {
                    .findFirst();
     }
 
-    private Contributor createContributor(JsonNode contributor, Candidate candidate) {
+    private ContributorType createContributor(JsonNode contributor, Candidate candidate) {
         var identity = contributor.at(JSON_PTR_IDENTITY);
         return Contributor.builder()
                    .withId(extractId(identity))

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -192,7 +192,7 @@ public final class NviCandidateIndexDocumentGenerator {
         var id = extractJsonNodeTextValue(affiliation, JSON_PTR_ID);
 
         if (isNull(id)) {
-            LOGGER.info("Skipping extraction of affiliation because of missing institutionId: {}", affiliation);
+            LOGGER.info("Skipping expansion of affiliation because of missing institutionId: {}", affiliation);
             return null;
         }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -167,6 +167,7 @@ public final class NviCandidateIndexDocumentGenerator {
                    .withName(extractJsonNodeTextValue(identity, JSON_PTR_NAME))
                    .withOrcid(extractJsonNodeTextValue(identity, JSON_PTR_ORCID))
                    .withRole(extractRoleType(contributor))
+                   .withIsNviContributor(isNviCreator)
                    .withAffiliations(expandAffiliations(contributor, isNviCreator))
                    .build();
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -162,7 +162,8 @@ public final class NviCandidateIndexDocumentGenerator {
 
     private Contributor createContributor(JsonNode contributor, boolean isNviCreator) {
         var identity = contributor.at(JSON_PTR_IDENTITY);
-        return new Contributor.Builder().withId(extractId(identity))
+        return Contributor.builder()
+                   .withId(extractId(identity))
                    .withName(extractJsonNodeTextValue(identity, JSON_PTR_NAME))
                    .withOrcid(extractJsonNodeTextValue(identity, JSON_PTR_ORCID))
                    .withRole(extractRoleType(contributor))

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -169,8 +169,8 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, CONTEXT);
         var actualIndexDocument = dtoObjectMapper.readTree(s3Writer.getFile(createPath(candidate))).at(JSON_PTR_BODY);
         assertEquals("NviCandidate", actualIndexDocument.at(JSON_PTR_TYPE).textValue());
-        assertEquals("Contributor", actualIndexDocument.at(JSON_PTR_CONTRIBUTOR).get(0).at(JSON_PTR_TYPE).textValue());
-        assertEquals("Organization",
+        assertEquals("NviContributor", actualIndexDocument.at(JSON_PTR_CONTRIBUTOR).get(0).at(JSON_PTR_TYPE).textValue());
+        assertEquals("NviOrganization",
                      actualIndexDocument.at(JSON_PTR_CONTRIBUTOR)
                          .get(0)
                          .at(JSON_PTR_AFFILIATIONS)

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -44,7 +44,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.index.aws.OpenSearchClient;
-import no.sikt.nva.nvi.index.model.Affiliation;
+import no.sikt.nva.nvi.index.model.Organization;
 import no.sikt.nva.nvi.index.model.Approval;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.CandidateSearchParameters;
@@ -501,7 +501,7 @@ public class OpenSearchClientTest {
                                   ? PublicationDate.builder().withYear(year).build()
                                   : PublicationDate.builder().withYear(YEAR).build();
         var contributorBuilder = Contributor.builder().withRole("Creator")
-                                     .withAffiliations(List.of(Affiliation.builder().withId(affiliation).build()));
+                                     .withAffiliations(List.of(Organization.builder().withId(affiliation).build()));
         if (contributor != null) {
             contributorBuilder.withName(contributor);
         }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -501,7 +501,7 @@ public class OpenSearchClientTest {
                                   ? PublicationDate.builder().withYear(year).build()
                                   : PublicationDate.builder().withYear(YEAR).build();
         var contributorBuilder = Contributor.builder().withRole("Creator")
-                                     .withAffiliations(List.of(new Affiliation(affiliation, List.of())));
+                                     .withAffiliations(List.of(Affiliation.builder().withId(affiliation).build()));
         if (contributor != null) {
             contributorBuilder.withName(contributor);
         }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -500,7 +500,7 @@ public class OpenSearchClientTest {
         var publicationDate = year != null
                                   ? PublicationDate.builder().withYear(year).build()
                                   : PublicationDate.builder().withYear(YEAR).build();
-        var contributorBuilder = new Contributor.Builder().withRole("Creator")
+        var contributorBuilder = Contributor.builder().withRole("Creator")
                                      .withAffiliations(List.of(new Affiliation(affiliation, List.of())));
         if (contributor != null) {
             contributorBuilder.withName(contributor);

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -85,9 +85,7 @@ public final class IndexDocumentTestUtils {
 
     private static List<Contributor> mapToContributors(ArrayNode contributorNodes, Candidate candidate) {
         return JsonUtils.streamNode(contributorNodes)
-                   .map(contributorNode -> toContributorWithExpandedAffiliation(contributorNode,
-                                                                                isNviCreator(contributorNode,
-                                                                                             candidate)))
+                   .map(contributorNode -> toContributorWithExpandedAffiliation(contributorNode, candidate))
                    .toList();
     }
 
@@ -99,8 +97,9 @@ public final class IndexDocumentTestUtils {
                        creator -> creator.id().toString().equals(ExpandedResourceGenerator.extractId(contributorNode)));
     }
 
-    private static Contributor toContributorWithExpandedAffiliation(JsonNode contributorNode, boolean isNviCreator) {
+    private static Contributor toContributorWithExpandedAffiliation(JsonNode contributorNode, Candidate candidate) {
         var affiliations = extractAffiliations(contributorNode);
+        var isNviCreator = isNviCreator(contributorNode, candidate);
         return Contributor.builder()
                    .withId(ExpandedResourceGenerator.extractId(contributorNode))
                    .withName(ExpandedResourceGenerator.extractName(contributorNode))
@@ -108,6 +107,7 @@ public final class IndexDocumentTestUtils {
                    .withRole(ExpandedResourceGenerator.extractRole(contributorNode))
                    .withAffiliations(isNviCreator ? expandAffiliationsWithPartOf(affiliations)
                                          : expandAffiliations(affiliations))
+                   .withIsNviContributor(isNviCreator)
                    .build();
     }
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -18,11 +18,13 @@ import no.sikt.nva.nvi.common.service.model.Approval;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.Creator;
 import no.sikt.nva.nvi.common.utils.JsonUtils;
-import no.sikt.nva.nvi.index.model.Affiliation;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.Contributor;
 import no.sikt.nva.nvi.index.model.ContributorType;
 import no.sikt.nva.nvi.index.model.NviContributor;
+import no.sikt.nva.nvi.index.model.NviOrganization;
+import no.sikt.nva.nvi.index.model.Organization;
+import no.sikt.nva.nvi.index.model.OrganizationType;
 import no.sikt.nva.nvi.index.model.PublicationDate;
 import no.sikt.nva.nvi.index.model.PublicationDetails;
 import nva.commons.core.paths.UnixPath;
@@ -125,17 +127,18 @@ public final class IndexDocumentTestUtils {
         return candidate.getPublicationDetails()
                    .creators()
                    .stream()
-                   .filter(creator -> creator.id().toString().equals(ExpandedResourceGenerator.extractId(contributorNode)))
+                   .filter(
+                       creator -> creator.id().toString().equals(ExpandedResourceGenerator.extractId(contributorNode)))
                    .findFirst();
     }
 
-    private static List<Affiliation> expandAffiliations(List<URI> uris) {
-        return uris.stream().map(uri -> Affiliation.builder()
-                                            .withId(uri.toString())
-                                            .build()).toList();
+    private static List<OrganizationType> expandAffiliations(List<URI> uris) {
+        return uris.stream()
+                   .map(IndexDocumentTestUtils::generateOrganization)
+                   .toList();
     }
 
-    private static List<Affiliation> expandAffiliationsWithPartOf(Creator creator, List<URI> uris) {
+    private static List<OrganizationType> expandAffiliationsWithPartOf(Creator creator, List<URI> uris) {
         return uris.stream()
                    .map(uri -> toAffiliationWithPartOf(uri, isNviAffiliation(creator, uri)))
                    .toList();
@@ -147,11 +150,22 @@ public final class IndexDocumentTestUtils {
                    .anyMatch(affiliation -> affiliation.equals(uri));
     }
 
-    private static Affiliation toAffiliationWithPartOf(URI uri, boolean isNviAffiliation) {
-        return Affiliation.builder()
+    private static OrganizationType toAffiliationWithPartOf(URI uri, boolean isNviAffiliation) {
+        return isNviAffiliation ? generateNviOrganization(uri)
+                   : generateOrganization(uri);
+    }
+
+    private static OrganizationType generateOrganization(URI uri) {
+        return Organization.builder()
                    .withId(uri.toString())
                    .withPartOf(List.of(HARD_CODED_PART_OF))
-                   .withIsNviAffiliation(isNviAffiliation)
+                   .build();
+    }
+
+    private static OrganizationType generateNviOrganization(URI uri) {
+        return NviOrganization.builder()
+                   .withId(uri.toString())
+                   .withPartOf(List.of(HARD_CODED_PART_OF))
                    .build();
     }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -96,7 +96,7 @@ public final class IndexDocumentTestUtils {
     private static ContributorType toContributorWithExpandedAffiliation(JsonNode contributorNode, Candidate candidate) {
         var affiliations = extractAffiliations(contributorNode);
         var creator = getNviCreatorIfPresent(candidate, contributorNode);
-        return creator.map(value -> genereateNviContributor(contributorNode, value, affiliations))
+        return creator.map(value -> generateNviContributor(contributorNode, value, affiliations))
                    .orElseGet(() -> generateContributor(contributorNode, affiliations));
     }
 
@@ -110,8 +110,8 @@ public final class IndexDocumentTestUtils {
                    .build();
     }
 
-    private static ContributorType genereateNviContributor(JsonNode contributorNode, Creator value,
-                                                           List<URI> affiliations) {
+    private static ContributorType generateNviContributor(JsonNode contributorNode, Creator value,
+                                                          List<URI> affiliations) {
         return NviContributor.builder()
                    .withId(ExpandedResourceGenerator.extractId(contributorNode))
                    .withName(ExpandedResourceGenerator.extractName(contributorNode))

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -21,6 +21,7 @@ import no.sikt.nva.nvi.common.utils.JsonUtils;
 import no.sikt.nva.nvi.index.model.Affiliation;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.Contributor;
+import no.sikt.nva.nvi.index.model.ContributorType;
 import no.sikt.nva.nvi.index.model.NviContributor;
 import no.sikt.nva.nvi.index.model.PublicationDate;
 import no.sikt.nva.nvi.index.model.PublicationDetails;
@@ -86,13 +87,13 @@ public final class IndexDocumentTestUtils {
         return new PublicationDate(publicationDate.year(), publicationDate.month(), publicationDate.day());
     }
 
-    private static List<Contributor> mapToContributors(ArrayNode contributorNodes, Candidate candidate) {
+    private static List<ContributorType> mapToContributors(ArrayNode contributorNodes, Candidate candidate) {
         return JsonUtils.streamNode(contributorNodes)
                    .map(contributorNode -> toContributorWithExpandedAffiliation(contributorNode, candidate))
                    .toList();
     }
 
-    private static Contributor toContributorWithExpandedAffiliation(JsonNode contributorNode, Candidate candidate) {
+    private static ContributorType toContributorWithExpandedAffiliation(JsonNode contributorNode, Candidate candidate) {
         var affiliations = extractAffiliations(contributorNode);
         var creator = getNviCreatorIfPresent(candidate, contributorNode);
         return creator.map(value -> genereateNviContributor(contributorNode, value, affiliations))
@@ -109,8 +110,8 @@ public final class IndexDocumentTestUtils {
                    .build();
     }
 
-    private static Contributor genereateNviContributor(JsonNode contributorNode, Creator value,
-                                                       List<URI> affiliations) {
+    private static ContributorType genereateNviContributor(JsonNode contributorNode, Creator value,
+                                                           List<URI> affiliations) {
         return NviContributor.builder()
                    .withId(ExpandedResourceGenerator.extractId(contributorNode))
                    .withName(ExpandedResourceGenerator.extractName(contributorNode))

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -92,14 +92,6 @@ public final class IndexDocumentTestUtils {
                    .toList();
     }
 
-    private static boolean isNviCreator(JsonNode contributorNode, Candidate candidate) {
-        return candidate.getPublicationDetails()
-                   .creators()
-                   .stream()
-                   .anyMatch(
-                       creator -> creator.id().toString().equals(ExpandedResourceGenerator.extractId(contributorNode)));
-    }
-
     private static Contributor toContributorWithExpandedAffiliation(JsonNode contributorNode, Candidate candidate) {
         var affiliations = extractAffiliations(contributorNode);
         var creator = getNviCreatorIfPresent(candidate, contributorNode);
@@ -132,8 +124,7 @@ public final class IndexDocumentTestUtils {
         return candidate.getPublicationDetails()
                    .creators()
                    .stream()
-                   .filter(
-                       creator -> creator.id().toString().equals(ExpandedResourceGenerator.extractId(contributorNode)))
+                   .filter(creator -> creator.id().toString().equals(ExpandedResourceGenerator.extractId(contributorNode)))
                    .findFirst();
     }
 


### PR DESCRIPTION
Today, all contributors (regardless of whether they are nvi contributors or not) with affiliations are presented under `publicationDetails` on the index document. 
It is necessary to know which of these contributors are nvi contributors, and which of these contributor affiliations are nvi affiliations in data export.
Therefore, added types `NviContributor` and `NviOrganization`, and creating these during "expansion" of contributors and affiliations.