### PR TITLE
NP-46155 Persist sub unit affiliations in stead of top level affiliations for nvi contributors

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -23,7 +23,7 @@ import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.CandidateType;
 import no.sikt.nva.nvi.events.model.NonNviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate;
-import no.sikt.nva.nvi.events.model.NviCandidate.Creator;
+import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator;
 import no.sikt.nva.nvi.events.model.NviCandidate.PublicationDate;
 
 public class EvaluatorService {
@@ -76,10 +76,10 @@ public class EvaluatorService {
                    .build();
     }
 
-    private static List<Creator> mapToCreators(List<VerifiedNviCreator> nviCreators) {
+    private static List<NviCreator> mapToCreators(List<VerifiedNviCreator> nviCreators) {
         return nviCreators.stream()
-                   .map(creator -> new Creator(creator.id(),
-                                               creator.nviAffiliations()
+                   .map(creator -> new NviCreator(creator.id(),
+                                                  creator.nviAffiliations()
                                                    .stream()
                                                    .map(NviOrganization::id)
                                                    .toList()))

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -12,12 +12,13 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.net.URI;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import no.sikt.nva.nvi.common.StorageReader;
 import no.sikt.nva.nvi.events.evaluator.calculator.CandidateCalculator;
 import no.sikt.nva.nvi.events.evaluator.calculator.PointCalculator;
 import no.sikt.nva.nvi.events.evaluator.model.PointCalculation;
+import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
+import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator.NviOrganization;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.CandidateType;
 import no.sikt.nva.nvi.events.model.NonNviCandidate;
@@ -54,7 +55,7 @@ public class EvaluatorService {
     }
 
     private static NviCandidate constructNviCandidate(JsonNode jsonNode,
-                                                      Map<URI, List<URI>> verifiedCreatorsWithNviInstitutions,
+                                                      List<VerifiedNviCreator> nviCreators,
                                                       PointCalculation pointCalculation, URI publicationId,
                                                       URI publicationBucketUri) {
         return NviCandidate.builder()
@@ -70,16 +71,18 @@ public class EvaluatorService {
                    .withCollaborationFactor(pointCalculation.collaborationFactor())
                    .withCreatorShareCount(pointCalculation.creatorShareCount())
                    .withInstitutionPoints(pointCalculation.institutionPoints())
-                   .withVerifiedCreators(mapToCreators(verifiedCreatorsWithNviInstitutions))
+                   .withVerifiedCreators(mapToCreators(nviCreators))
                    .withTotalPoints(pointCalculation.totalPoints())
                    .build();
     }
 
-    private static List<Creator> mapToCreators(Map<URI, List<URI>> verifiedCreatorsWithNviInstitutions) {
-        return verifiedCreatorsWithNviInstitutions.entrySet()
-                   .stream()
-                   .map(entry -> new Creator(entry.getKey(),
-                                             entry.getValue()))
+    private static List<Creator> mapToCreators(List<VerifiedNviCreator> nviCreators) {
+        return nviCreators.stream()
+                   .map(creator -> new Creator(creator.id(),
+                                               creator.nviAffiliations()
+                                                   .stream()
+                                                   .map(NviOrganization::id)
+                                                   .toList()))
                    .toList();
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -78,12 +78,15 @@ public class EvaluatorService {
 
     private static List<NviCreator> mapToCreators(List<VerifiedNviCreator> nviCreators) {
         return nviCreators.stream()
-                   .map(creator -> new NviCreator(creator.id(),
-                                                  creator.nviAffiliations()
-                                                   .stream()
-                                                   .map(NviOrganization::id)
-                                                   .toList()))
+                   .map(EvaluatorService::toNviCreator)
                    .toList();
+    }
+
+    private static NviCreator toNviCreator(VerifiedNviCreator creator) {
+        return new NviCreator(creator.id(), creator.nviAffiliations()
+                                                .stream()
+                                                .map(NviOrganization::id)
+                                                .toList());
     }
 
     private static URI extractPublicationId(JsonNode publication) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/CandidateCalculator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/CandidateCalculator.java
@@ -67,8 +67,8 @@ public class CandidateCalculator {
                    : verifiedCreatorsWithNviInstitutions;
     }
 
-    private static boolean isNotAffiliatedWithNviOrganization(VerifiedNviCreator creator) {
-        return creator.nviAffiliations().isEmpty();
+    private static boolean isAffiliatedWithNviOrganization(VerifiedNviCreator creator) {
+        return !creator.nviAffiliations().isEmpty();
     }
 
     private static URI createCustomerApiUri(String institutionId) {
@@ -127,7 +127,7 @@ public class CandidateCalculator {
                    .filter(CandidateCalculator::isVerified)
                    .filter(CandidateCalculator::isCreator)
                    .map(this::toVerifiedNviCreator)
-                   .filter(CandidateCalculator::isNotAffiliatedWithNviOrganization)
+                   .filter(CandidateCalculator::isAffiliatedWithNviOrganization)
                    .toList();
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
@@ -162,9 +162,9 @@ public final class PointCalculator {
     }
 
     private static Long countCreators(URI institutionId, List<VerifiedNviCreator> nviCreators) {
-        return nviCreators.entrySet()
-                   .stream()
-                   .filter(creator -> creator.getValue().contains(institutionId))
+        return nviCreators.stream()
+                   .flatMap(creator -> creator.nviAffiliations().stream())
+                   .filter(affiliation -> affiliation.topLevelOrganization().id().equals(institutionId))
                    .count();
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.events.evaluator.model;
 
 import java.net.URI;
 import java.util.List;
+import java.util.Objects;
 
 public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations) {
 
@@ -34,6 +35,11 @@ public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations) 
     }
 
     public record NviOrganization(URI id, NviOrganization topLevelOrganization) {
+
+        @Override
+        public NviOrganization topLevelOrganization(){
+            return Objects.isNull(topLevelOrganization) ? this : topLevelOrganization;
+        }
 
         public static NviOrganization.Builder builder() {
             return new NviOrganization.Builder();

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
@@ -1,0 +1,66 @@
+package no.sikt.nva.nvi.events.evaluator.model;
+
+import java.net.URI;
+import java.util.List;
+
+public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+
+        private URI id;
+
+        private List<NviOrganization> nviAffiliations;
+
+        private Builder() {
+        }
+
+        public Builder withId(URI id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withNviAffiliations(List<NviOrganization> nviAffiliations) {
+            this.nviAffiliations = nviAffiliations;
+            return this;
+        }
+
+        public VerifiedNviCreator build() {
+            return new VerifiedNviCreator(id, nviAffiliations);
+        }
+    }
+
+    public record NviOrganization(URI id, NviOrganization topLevelOrganization) {
+
+        public static NviOrganization.Builder builder() {
+            return new NviOrganization.Builder();
+        }
+
+        public static final class Builder {
+
+            private URI id;
+
+            private VerifiedNviCreator.NviOrganization topLevelOrganization;
+
+            private Builder() {
+            }
+
+            public Builder withId(URI id) {
+                this.id = id;
+                return this;
+            }
+
+            public Builder withTopLevelOrganization(NviOrganization topLevelOrganization) {
+                this.topLevelOrganization = topLevelOrganization;
+                return this;
+            }
+            public NviOrganization build() {
+                return new NviOrganization(id, topLevelOrganization);
+            }
+        }
+
+    }
+}

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -63,7 +63,7 @@ public record NviCandidate(URI publicationId,
 
     @Override
     public Map<URI, List<URI>> creators() {
-        return verifiedCreators().stream().collect(Collectors.toMap(Creator::id, Creator::nviInstitutions));
+        return verifiedCreators().stream().collect(Collectors.toMap(Creator::id, Creator::nviAffiliation));
     }
 
     @Override
@@ -86,7 +86,7 @@ public record NviCandidate(URI publicationId,
                                                       publicationDate.day());
     }
 
-    public record Creator(URI id, List<URI> nviInstitutions) {
+    public record Creator(URI id, List<URI> nviAffiliation) {
 
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -18,7 +18,7 @@ public record NviCandidate(URI publicationId,
                            URI publicationBucketUri,
                            String instanceType,
                            @JsonProperty("publicationDate") PublicationDate date,
-                           List<Creator> verifiedCreators,
+                           List<NviCreator> nviCreators,
                            String channelType,
                            URI publicationChannelId,
                            String level,
@@ -42,7 +42,7 @@ public record NviCandidate(URI publicationId,
                    .withInstanceType(details.type())
                    .withDate(toPublicationDate(details.publicationDate()))
                    .withVerifiedCreators(details.creators().stream()
-                                             .map(creator -> new Creator(creator.id(), creator.affiliations()))
+                                             .map(creator -> new NviCreator(creator.id(), creator.affiliations()))
                                              .toList())
                    .withChannelType(details.channelType().getValue())
                    .withPublicationChannelId(details.publicationChannelId())
@@ -63,7 +63,7 @@ public record NviCandidate(URI publicationId,
 
     @Override
     public Map<URI, List<URI>> creators() {
-        return verifiedCreators().stream().collect(Collectors.toMap(Creator::id, Creator::nviAffiliation));
+        return nviCreators().stream().collect(Collectors.toMap(NviCreator::id, NviCreator::nviAffiliation));
     }
 
     @Override
@@ -86,7 +86,7 @@ public record NviCandidate(URI publicationId,
                                                       publicationDate.day());
     }
 
-    public record Creator(URI id, List<URI> nviAffiliation) {
+    public record NviCreator(URI id, List<URI> nviAffiliation) {
 
     }
 
@@ -100,7 +100,7 @@ public record NviCandidate(URI publicationId,
         private URI publicationBucketUri;
         private String instanceType;
         private PublicationDate date;
-        private List<Creator> verifiedCreators;
+        private List<NviCreator> nviCreators;
         private String channelType;
         private URI publicationChannelId;
         private String level;
@@ -134,8 +134,8 @@ public record NviCandidate(URI publicationId,
             return this;
         }
 
-        public Builder withVerifiedCreators(List<Creator> verifiedCreators) {
-            this.verifiedCreators = verifiedCreators;
+        public Builder withVerifiedCreators(List<NviCreator> nviCreators) {
+            this.nviCreators = nviCreators;
             return this;
         }
 
@@ -185,7 +185,7 @@ public record NviCandidate(URI publicationId,
         }
 
         public NviCandidate build() {
-            return new NviCandidate(publicationId, publicationBucketUri, instanceType, date, verifiedCreators,
+            return new NviCandidate(publicationId, publicationBucketUri, instanceType, date, nviCreators,
                                     channelType, publicationChannelId, level, basePoints, isInternationalCollaboration,
                                     collaborationFactor, creatorShareCount, institutionPoints, totalPoints);
         }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -562,7 +562,7 @@ class EvaluateNviCandidateHandlerTest {
                                                         PublicationChannel channelType, String level,
                                                         BigDecimal basePoints, BigDecimal totalPoints,
                                                         URI publicationBucketUri) {
-        var verifiedCreators = List.of(new Creator(HARDCODED_CREATOR_ID, List.of(CRISTIN_NVI_ORG_TOP_LEVEL_ID)));
+        var verifiedCreators = List.of(new Creator(HARDCODED_CREATOR_ID, List.of(CRISTIN_NVI_ORG_SUB_UNIT_ID)));
         return NviCandidate.builder()
                    .withPublicationId(HARDCODED_PUBLICATION_ID)
                    .withPublicationBucketUri(publicationBucketUri)
@@ -583,7 +583,7 @@ class EvaluateNviCandidateHandlerTest {
 
     private static int countCreatorShares(List<Creator> verifiedCreators) {
         return (int) verifiedCreators.stream()
-                         .mapToLong(creator -> creator.nviInstitutions().size())
+                         .mapToLong(creator -> creator.nviAffiliation().size())
                          .sum();
     }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -47,7 +47,7 @@ import no.sikt.nva.nvi.events.evaluator.model.PublicationChannel;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.NonNviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate;
-import no.sikt.nva.nvi.events.model.NviCandidate.Creator;
+import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator;
 import no.sikt.nva.nvi.events.model.NviCandidate.PublicationDate;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
 import no.sikt.nva.nvi.test.FakeSqsClient;
@@ -562,7 +562,7 @@ class EvaluateNviCandidateHandlerTest {
                                                         PublicationChannel channelType, String level,
                                                         BigDecimal basePoints, BigDecimal totalPoints,
                                                         URI publicationBucketUri) {
-        var verifiedCreators = List.of(new Creator(HARDCODED_CREATOR_ID, List.of(CRISTIN_NVI_ORG_SUB_UNIT_ID)));
+        var verifiedCreators = List.of(new NviCreator(HARDCODED_CREATOR_ID, List.of(CRISTIN_NVI_ORG_SUB_UNIT_ID)));
         return NviCandidate.builder()
                    .withPublicationId(HARDCODED_PUBLICATION_ID)
                    .withPublicationBucketUri(publicationBucketUri)
@@ -581,9 +581,9 @@ class EvaluateNviCandidateHandlerTest {
                    .build();
     }
 
-    private static int countCreatorShares(List<Creator> verifiedCreators) {
-        return (int) verifiedCreators.stream()
-                         .mapToLong(creator -> creator.nviAffiliation().size())
+    private static int countCreatorShares(List<NviCreator> nviCreators) {
+        return (int) nviCreators.stream()
+                         .mapToLong(nviCreator -> nviCreator.nviAffiliation().size())
                          .sum();
     }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculatorTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculatorTest.java
@@ -45,7 +45,7 @@ class PointCalculatorTest {
     private static final String ID = "id";
     private static final String LEVEL = "level";
     private static final JsonNode HARDCODED_JOURNAL_REFERENCE = createJournalReference("AcademicArticle", "1");
-    private static final String AFFILIATIONS = "affiliations";
+    private static final String AFFILIATIONS = "nviAffiliations";
     private static final String IDENTITY = "identity";
     private static final String VERIFICATION_STATUS = "verificationStatus";
     private static final String CONTRIBUTORS = "contributors";

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -62,7 +62,7 @@ import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.NonNviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate;
-import no.sikt.nva.nvi.events.model.NviCandidate.Creator;
+import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator;
 import no.sikt.nva.nvi.events.model.NviCandidate.PublicationDate;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.sikt.nva.nvi.test.TestUtils;
@@ -133,7 +133,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
     void shouldSaveNewNviCandidateWithPendingInstitutionApprovalsIfCandidateDoesNotExist() {
         var institutionId = randomUri();
         var identifier = UUID.randomUUID();
-        var creators = List.of(new Creator(randomUri(), List.of(institutionId)));
+        var creators = List.of(new NviCreator(randomUri(), List.of(institutionId)));
         var instanceType = randomInstanceTypeExcluding(NON_CANDIDATE.getValue());
         var randomLevel = randomElement(DbLevel.values());
         var publicationDate = randomPublicationDate();
@@ -254,11 +254,11 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
         return sqsEvent;
     }
 
-    private static Creator randomCreator() {
-        return new Creator(randomUri(), List.of(randomUri()));
+    private static NviCreator randomCreator() {
+        return new NviCreator(randomUri(), List.of(randomUri()));
     }
 
-    private static CandidateEvaluatedMessage createEvalMessage(List<Creator> verifiedCreators,
+    private static CandidateEvaluatedMessage createEvalMessage(List<NviCreator> nviCreators,
                                                                String instanceType, DbLevel level,
                                                                PublicationDate publicationDate,
                                                                Map<URI, BigDecimal> institutionPoints,
@@ -273,7 +273,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                                           .withPublicationChannelId(randomUri())
                                           .withLevel(level.getVersionOneValue())
                                           .withDate(publicationDate)
-                                          .withVerifiedCreators(verifiedCreators)
+                                          .withVerifiedCreators(nviCreators)
                                           .withIsInternationalCollaboration(randomBoolean())
                                           .withCollaborationFactor(randomBigDecimal())
                                           .withCreatorShareCount(randomInteger())
@@ -304,8 +304,8 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                        new PublicationDate(null, "3",
                                            Year.now().toString()))
                    .withVerifiedCreators(
-                       List.of(new Creator(creatorId,
-                                           List.of(institutionId))))
+                       List.of(new NviCreator(creatorId,
+                                              List.of(institutionId))))
                    .withInstitutionPoints(request.institutionPoints())
                    .withTotalPoints(randomBigDecimal())
                    .build();
@@ -359,7 +359,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
 
     private SQSEvent createEvent(URI keep, URI publicationId, URI publicationBucketUri) {
         var institutionId = randomUri();
-        var creators = List.of(new Creator(randomUri(), List.of(institutionId, keep)));
+        var creators = List.of(new NviCreator(randomUri(), List.of(institutionId, keep)));
         var instanceType = randomInstanceTypeExcluding(NON_CANDIDATE.getValue());
         var randomLevel = randomElement(DbLevel.values());
         var publicationDate = randomPublicationDate();
@@ -369,11 +369,11 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                            publicationBucketUri, randomBigDecimal());
     }
 
-    private SQSEvent createEvent(List<Creator> verifiedCreators, String instanceType, DbLevel randomLevel,
+    private SQSEvent createEvent(List<NviCreator> nviCreators, String instanceType, DbLevel randomLevel,
                                  PublicationDate publicationDate, Map<URI, BigDecimal> institutionPoints,
                                  URI publicationId, URI publicationBucketUri, BigDecimal totalPoints) {
         return createEvent(
-            createEvalMessage(verifiedCreators, instanceType, randomLevel, publicationDate, institutionPoints,
+            createEvalMessage(nviCreators, instanceType, randomLevel, publicationDate, institutionPoints,
                               publicationId, publicationBucketUri, totalPoints));
     }
 }


### PR DESCRIPTION
For data export, we need to know which contributor and affiliation (regardless of whether top level or sub unit) is part of the nvi reporting process for a given candidate.

Today, only the top level affiliation is peristed for nvi creators, and is not sufficient.

The nvi candidate containing nvi creators and affilitions that is persisted by `UpsertNviCandidateHandler` is constructed by `EvaluateNviCandidateHandler`.
Before:
`EvaluateNviCandidateHandler` sent creators with top level affiliations as creators of the `NviCandidate`
Changed this to:
`EvaluateNviCandidateHandler` sending creators with affiliations (regardless of whether top level or sub unit) as creators of the `NviCandidate`

(This change should not change any existing feature, only which data is persisted for creator affiliations)