### PR TITLE
Change modifiedDate type to string in index document

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -3,6 +3,7 @@ package no.sikt.nva.nvi.index.model;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
@@ -12,6 +13,7 @@ import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+@JsonSerialize
 public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         URI id,
                                         String type,

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -3,10 +3,8 @@ package no.sikt.nva.nvi.index.model;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.math.BigDecimal;
 import java.net.URI;
-import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.service.model.Candidate;
@@ -14,7 +12,6 @@ import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
-@JsonSerialize
 public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         URI id,
                                         String type,
@@ -23,7 +20,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         List<Approval> approvals,
                                         int numberOfApprovals,
                                         BigDecimal points,
-                                        Instant modifiedDate) {
+                                        String modifiedDate) {
 
     private static final String CONTEXT = "@context";
     private static final String NVI_CANDIDATE = "NviCandidate";
@@ -48,7 +45,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         private List<Approval> approvals;
         private int numberOfApprovals;
         private BigDecimal points;
-        private Instant modifiedDate;
+        private String modifiedDate;
 
         private Builder() {
         }
@@ -88,7 +85,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
             return this;
         }
 
-        public Builder withModifiedDate(Instant modifiedDate) {
+        public Builder withModifiedDate(String modifiedDate) {
             this.modifiedDate = modifiedDate;
             return this;
         }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -85,7 +85,7 @@ public final class NviCandidateIndexDocumentGenerator {
                    .withPublicationDetails(extractPublicationDetails(resource, candidate))
                    .withNumberOfApprovals(approvals.size())
                    .withPoints(candidate.getTotalPoints())
-                   .withModifiedDate(candidate.getModifiedDate())
+                   .withModifiedDate(candidate.getModifiedDate().toString())
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -472,7 +472,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
                    .withPoints(candidate.getTotalPoints())
                    .withPublicationDetails(expandPublicationDetails(candidate, expandedResource))
                    .withNumberOfApprovals(candidate.getApprovals().size())
-                   .withModifiedDate(candidate.getModifiedDate())
+                   .withModifiedDate(candidate.getModifiedDate().toString())
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -45,12 +45,12 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.index.aws.OpenSearchClient;
-import no.sikt.nva.nvi.index.model.Organization;
 import no.sikt.nva.nvi.index.model.Approval;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.Contributor;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
+import no.sikt.nva.nvi.index.model.Organization;
 import no.sikt.nva.nvi.index.model.PublicationDate;
 import no.sikt.nva.nvi.index.model.PublicationDetails;
 import no.unit.nva.auth.CachedJwtProvider;
@@ -515,6 +515,7 @@ public class OpenSearchClientTest {
                    .withApprovals(List.of(randomApprovalWithCustomerAndAssignee(customer, assignee)))
                    .withNumberOfApprovals(1)
                    .withPoints(randomBigDecimal())
+                   .withModifiedDate(Instant.now().toString())
                    .build();
     }
 


### PR DESCRIPTION
`UpdateIndexHandler` is failing due to openSearch serialisation error. Change data type for `modifiedDate` in index document to String