### PR TITLE
Remove deprecated field Approval id

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Approval.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Approval.java
@@ -13,8 +13,7 @@ import java.util.Map;
     use = JsonTypeInfo.Id.NAME,
     property = "type")
 @JsonTypeName("Approval")
-public record Approval(@Deprecated String id,
-                       String institutionId,
+public record Approval(String institutionId,
                        Map<String, String> labels,
                        ApprovalStatus approvalStatus,
                        BigDecimal points,
@@ -26,8 +25,6 @@ public record Approval(@Deprecated String id,
 
     public static final class Builder {
 
-        @Deprecated
-        private String id;
         private String institutionId;
         private Map<String, String> labels;
         private ApprovalStatus approvalStatus;
@@ -35,12 +32,6 @@ public record Approval(@Deprecated String id,
         private String assignee;
 
         private Builder() {
-        }
-
-        @Deprecated
-        public Builder withId(String id) {
-            this.id = id;
-            return this;
         }
 
         public Builder withInstitutionId(String institutionId) {
@@ -69,7 +60,7 @@ public record Approval(@Deprecated String id,
         }
 
         public Approval build() {
-            return new Approval(id, institutionId, labels, approvalStatus, points, assignee);
+            return new Approval(institutionId, labels, approvalStatus, points, assignee);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -115,7 +115,6 @@ public final class NviCandidateIndexDocumentGenerator {
 
     private no.sikt.nva.nvi.index.model.Approval toApproval(JsonNode resource, Approval approval, Candidate candidate) {
         return no.sikt.nva.nvi.index.model.Approval.builder()
-                   .withId(approval.getInstitutionId().toString())
                    .withInstitutionId(approval.getInstitutionId().toString())
                    .withLabels(extractLabels(resource, approval))
                    .withApprovalStatus(ApprovalStatus.fromValue(approval.getStatus().getValue()))

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -537,7 +537,7 @@ public class OpenSearchClientTest {
     }
 
     private static Approval randomApprovalWithCustomerAndAssignee(String affiliation, String assignee) {
-        return new Approval(affiliation, affiliation, Map.of(), randomStatus(), randomBigDecimal(SCALE), assignee);
+        return new Approval(affiliation, Map.of(), randomStatus(), randomBigDecimal(SCALE), assignee);
     }
 
     private static List<Approval> randomApprovalList() {
@@ -545,7 +545,7 @@ public class OpenSearchClientTest {
     }
 
     private static Approval randomApproval() {
-        return new Approval(randomString(), randomString(), Map.of(), randomStatus(), randomBigDecimal(SCALE), null);
+        return new Approval(randomString(), Map.of(), randomStatus(), randomBigDecimal(SCALE), null);
     }
 
     private static ApprovalStatus randomStatus() {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -66,7 +66,6 @@ public final class IndexDocumentTestUtils {
                                                                    Candidate candidate) {
         var assignee = approvalEntry.getValue().getAssignee();
         return no.sikt.nva.nvi.index.model.Approval.builder()
-                   .withId(approvalEntry.getKey().toString())
                    .withInstitutionId(approvalEntry.getKey().toString())
                    .withApprovalStatus(ApprovalStatus.fromValue(approvalEntry.getValue().getStatus().getValue()))
                    .withAssignee(Objects.nonNull(assignee) ? assignee.value() : null)


### PR DESCRIPTION
Remove deprecated field `Approval` `id` from index document. Frontend has migrated to new field `institutionId`.