### PR TITLE
Adding year to imported candidate

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
@@ -53,8 +53,8 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
     }
 
     private void createAndPersist(CristinNviReport cristinNviReport) {
-        repository.importCandidate(CristinMapper.toDbCandidate(cristinNviReport),
-                                   CristinMapper.toApprovals(cristinNviReport),
-                                   String.valueOf(cristinNviReport.yearReported()));
+        repository.create(CristinMapper.toDbCandidate(cristinNviReport),
+                          CristinMapper.toApprovals(cristinNviReport),
+                          String.valueOf(cristinNviReport.yearReported()));
     }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
@@ -53,6 +53,8 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
     }
 
     private void createAndPersist(CristinNviReport cristinNviReport) {
-        repository.create(CristinMapper.toDbCandidate(cristinNviReport), CristinMapper.toApprovals(cristinNviReport));
+        repository.importCandidate(CristinMapper.toDbCandidate(cristinNviReport),
+                                   CristinMapper.toApprovals(cristinNviReport),
+                                   String.valueOf(cristinNviReport.yearReported()));
     }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -9,6 +9,7 @@ import static no.sikt.nva.nvi.test.TestUtils.randomApproval;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
 import static no.sikt.nva.nvi.test.TestUtils.randomUsername;
+import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInstant;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -193,7 +194,7 @@ public class DataEntryUpdateHandlerTest {
     }
 
     private static CandidateDao randomCandidateDao() {
-        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString(), randomString());
+        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString(), randomYear());
     }
 
     private static CandidateDao nonApplicableCandidateDao() {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -193,11 +193,12 @@ public class DataEntryUpdateHandlerTest {
     }
 
     private static CandidateDao randomCandidateDao() {
-        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString());
+        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString(), randomString());
     }
 
     private static CandidateDao nonApplicableCandidateDao() {
-        return new CandidateDao(UUID.randomUUID(), randomCandidateBuilder(false).build(), UUID.randomUUID().toString());
+        return new CandidateDao(UUID.randomUUID(), randomCandidateBuilder(false).build(),
+                                UUID.randomUUID().toString(), randomString());
     }
 
     private static ApprovalStatusDao generatePendingApproval() {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -289,6 +289,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                    .withStatus(Status.OPEN_PERIOD)
                    .withStartDate(period.startDate().toString())
                    .withReportingDate(period.reportingDate().toString())
+                   .withYear(period.publishingYear())
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/DeletePersistedIndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/DeletePersistedIndexDocumentHandlerTest.java
@@ -7,6 +7,7 @@ import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEvent;
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEventWithDynamodbRecords;
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEventWithOneInvalidRecord;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -119,7 +120,7 @@ public class DeletePersistedIndexDocumentHandlerTest {
     }
 
     private static CandidateDao randomCandidateDao() {
-        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString());
+        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString(), randomString());
     }
 
     private static DeleteObjectRequest getDeleteObjectRequest(UUID identifier) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/RemoveIndexDocumentHandlerTest.java
@@ -4,6 +4,7 @@ import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEvent;
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEventWithDynamoEventMissingIdentifier;
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEventWithOneInvalidRecord;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -63,7 +64,7 @@ class RemoveIndexDocumentHandlerTest {
     }
 
     private static CandidateDao randomCandidateDao() {
-        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString());
+        return new CandidateDao(UUID.randomUUID(), randomCandidate(), UUID.randomUUID().toString(), randomString());
     }
 
     private void mockOpenSearchFailure(CandidateDao candidateToFail) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -25,7 +25,6 @@ import java.util.Objects;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateDao.Builder;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
-import no.sikt.nva.nvi.common.db.model.InstanceType;
 import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
@@ -40,28 +39,28 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortK
 public final class CandidateDao extends Dao {
 
     public static final String TYPE = "CANDIDATE";
-    public static final String YEAR_FIELD = "year";
+    public static final String PERIOD_FIELD = "period";
     @JsonProperty(IDENTIFIER_FIELD)
     private final UUID identifier;
     @JsonProperty(DATA_FIELD)
     private final DbCandidate candidate;
     @JsonProperty(VERSION_FIELD)
     private final String version;
-    @JsonProperty(YEAR_FIELD)
-    private final String year;
+    @JsonProperty(PERIOD_FIELD)
+    private final String period;
 
     @JsonCreator
     public CandidateDao(
         @JsonProperty(IDENTIFIER_FIELD) UUID identifier,
         @JsonProperty(DATA_FIELD) DbCandidate candidate,
         @JsonProperty(VERSION_FIELD) String version,
-        @JsonProperty(YEAR_FIELD) String year
+        @JsonProperty(PERIOD_FIELD) String period
     ) {
         super();
         this.identifier = identifier;
         this.candidate = candidate;
         this.version = version;
-        this.year = year;
+        this.period = period;
     }
 
     @DynamoDbIgnore
@@ -95,7 +94,7 @@ public final class CandidateDao extends Dao {
     }
 
     public String year() {
-        return year;
+        return period;
     }
 
     @Override
@@ -126,7 +125,7 @@ public final class CandidateDao extends Dao {
     @DynamoDbAttribute(SECONDARY_INDEX_YEAR_HASH_KEY)
     @JsonProperty(SECONDARY_INDEX_YEAR_HASH_KEY)
     public String searchByYearHashKey() {
-        return year;
+        return period;
     }
 
     @JacocoGenerated
@@ -156,7 +155,7 @@ public final class CandidateDao extends Dao {
     @Override
     @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(identifier, candidate, version, year);
+        return Objects.hash(identifier, candidate, version, period);
     }
 
     @Override
@@ -172,7 +171,7 @@ public final class CandidateDao extends Dao {
         return Objects.equals(this.identifier, that.identifier)
                && Objects.equals(this.candidate, that.candidate)
                && Objects.equals(this.version, that.version)
-               && Objects.equals(this.year, that.year);
+               && Objects.equals(this.period, that.period);
     }
 
     @Override
@@ -305,20 +304,6 @@ public final class CandidateDao extends Dao {
             return new Builder();
         }
 
-        @Deprecated
-        //TODO: Should be removed once we have migrated instanceType to String
-        public String instanceType() {
-            var enums = Arrays.stream(InstanceType.values()).toList();
-            var instanceTypeEnum = enums.stream()
-                                       .filter(value -> value.toString().equals(instanceType))
-                                       .findFirst();
-            if (instanceTypeEnum.isPresent()) {
-                return instanceTypeEnum.get().getValue();
-            } else {
-                return instanceType;
-            }
-        }
-
         @DynamoDbIgnore
         public Builder copy() {
             return builder()
@@ -423,15 +408,7 @@ public final class CandidateDao extends Dao {
 
             //TODO: Should be removed once we have migrated instanceType to String
             public Builder instanceType(String instanceType) {
-                var enums = Arrays.stream(InstanceType.values()).toList();
-                var instanceTypeEnum = enums.stream()
-                                           .filter(value -> value.toString().equals(instanceType))
-                                           .findFirst();
-                if (instanceTypeEnum.isPresent()) {
-                    this.builderInstanceType = instanceTypeEnum.get().getValue();
-                } else {
-                    this.builderInstanceType = instanceType;
-                }
+                this.builderInstanceType = instanceType;
                 return this;
             }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -12,6 +12,7 @@ import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_HASH
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_RANGE_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SORT_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.VERSION_FIELD;
+import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.math.BigDecimal;
@@ -25,6 +26,7 @@ import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateDao.Builder;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.db.model.InstanceType;
+import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbAttribute;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbIgnore;
@@ -38,23 +40,28 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortK
 public final class CandidateDao extends Dao {
 
     public static final String TYPE = "CANDIDATE";
+    public static final String YEAR_FIELD = "year";
     @JsonProperty(IDENTIFIER_FIELD)
     private final UUID identifier;
     @JsonProperty(DATA_FIELD)
     private final DbCandidate candidate;
     @JsonProperty(VERSION_FIELD)
     private final String version;
+    @JsonProperty(YEAR_FIELD)
+    private final String year;
 
     @JsonCreator
     public CandidateDao(
         @JsonProperty(IDENTIFIER_FIELD) UUID identifier,
         @JsonProperty(DATA_FIELD) DbCandidate candidate,
-        @JsonProperty(VERSION_FIELD) String version
+        @JsonProperty(VERSION_FIELD) String version,
+        @JsonProperty(YEAR_FIELD) String year
     ) {
         super();
         this.identifier = identifier;
         this.candidate = candidate;
         this.version = version;
+        this.year = year;
     }
 
     @DynamoDbIgnore
@@ -87,6 +94,10 @@ public final class CandidateDao extends Dao {
         return version;
     }
 
+    public String year() {
+        return year;
+    }
+
     @Override
     @JacocoGenerated
     @DynamoDbAttribute(TYPE_FIELD)
@@ -115,7 +126,7 @@ public final class CandidateDao extends Dao {
     @DynamoDbAttribute(SECONDARY_INDEX_YEAR_HASH_KEY)
     @JsonProperty(SECONDARY_INDEX_YEAR_HASH_KEY)
     public String searchByYearHashKey() {
-        return nonNull(candidate.publicationDate()) ? candidate.publicationDate().year() : null;
+        return year;
     }
 
     @JacocoGenerated
@@ -145,7 +156,7 @@ public final class CandidateDao extends Dao {
     @Override
     @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(identifier, candidate, version);
+        return Objects.hash(identifier, candidate, version, year);
     }
 
     @Override
@@ -160,16 +171,14 @@ public final class CandidateDao extends Dao {
         var that = (CandidateDao) obj;
         return Objects.equals(this.identifier, that.identifier)
                && Objects.equals(this.candidate, that.candidate)
-               && Objects.equals(this.version, that.version);
+               && Objects.equals(this.version, that.version)
+               && Objects.equals(this.year, that.year);
     }
 
     @Override
     @JacocoGenerated
     public String toString() {
-        return "CandidateDao["
-               + "identifier=" + identifier + ", "
-               + "candidate=" + candidate + ", "
-               + "version=" + version + ']';
+        return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
     }
 
     public enum DbLevel {
@@ -205,6 +214,7 @@ public final class CandidateDao extends Dao {
         private UUID builderIdentifier;
         private DbCandidate builderCandidate;
         private String builderVersion;
+        private String builderYear;
 
         private Builder() {
 
@@ -260,8 +270,13 @@ public final class CandidateDao extends Dao {
             return this;
         }
 
+        public Builder year(String year) {
+            this.builderYear = year;
+            return this;
+        }
+
         public CandidateDao build() {
-            return new CandidateDao(builderIdentifier, builderCandidate, builderVersion);
+            return new CandidateDao(builderIdentifier, builderCandidate, builderVersion, builderYear);
         }
     }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -39,28 +39,28 @@ import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSortK
 public final class CandidateDao extends Dao {
 
     public static final String TYPE = "CANDIDATE";
-    public static final String PERIOD_FIELD = "period";
+    public static final String PERIOD_YEAR_FIELD = "periodYear";
     @JsonProperty(IDENTIFIER_FIELD)
     private final UUID identifier;
     @JsonProperty(DATA_FIELD)
     private final DbCandidate candidate;
     @JsonProperty(VERSION_FIELD)
     private final String version;
-    @JsonProperty(PERIOD_FIELD)
-    private final String period;
+    @JsonProperty(PERIOD_YEAR_FIELD)
+    private final String periodYear;
 
     @JsonCreator
     public CandidateDao(
         @JsonProperty(IDENTIFIER_FIELD) UUID identifier,
         @JsonProperty(DATA_FIELD) DbCandidate candidate,
         @JsonProperty(VERSION_FIELD) String version,
-        @JsonProperty(PERIOD_FIELD) String period
+        @JsonProperty(PERIOD_YEAR_FIELD) String periodYear
     ) {
         super();
         this.identifier = identifier;
         this.candidate = candidate;
         this.version = version;
-        this.period = period;
+        this.periodYear = periodYear;
     }
 
     @DynamoDbIgnore
@@ -93,10 +93,6 @@ public final class CandidateDao extends Dao {
         return version;
     }
 
-    public String year() {
-        return period;
-    }
-
     @Override
     @JacocoGenerated
     @DynamoDbAttribute(TYPE_FIELD)
@@ -125,7 +121,7 @@ public final class CandidateDao extends Dao {
     @DynamoDbAttribute(SECONDARY_INDEX_YEAR_HASH_KEY)
     @JsonProperty(SECONDARY_INDEX_YEAR_HASH_KEY)
     public String searchByYearHashKey() {
-        return period;
+        return periodYear;
     }
 
     @JacocoGenerated
@@ -155,7 +151,7 @@ public final class CandidateDao extends Dao {
     @Override
     @JacocoGenerated
     public int hashCode() {
-        return Objects.hash(identifier, candidate, version, period);
+        return Objects.hash(identifier, candidate, version, periodYear);
     }
 
     @Override
@@ -171,13 +167,17 @@ public final class CandidateDao extends Dao {
         return Objects.equals(this.identifier, that.identifier)
                && Objects.equals(this.candidate, that.candidate)
                && Objects.equals(this.version, that.version)
-               && Objects.equals(this.period, that.period);
+               && Objects.equals(this.periodYear, that.periodYear);
     }
 
     @Override
     @JacocoGenerated
     public String toString() {
         return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
+    }
+
+    public String periodYear() {
+        return periodYear;
     }
 
     public enum DbLevel {
@@ -213,7 +213,7 @@ public final class CandidateDao extends Dao {
         private UUID builderIdentifier;
         private DbCandidate builderCandidate;
         private String builderVersion;
-        private String builderYear;
+        private String builderPeriodYear;
 
         private Builder() {
 
@@ -269,13 +269,13 @@ public final class CandidateDao extends Dao {
             return this;
         }
 
-        public Builder year(String year) {
-            this.builderYear = year;
+        public Builder periodYear(String periodYear) {
+            this.builderPeriodYear = periodYear;
             return this;
         }
 
         public CandidateDao build() {
-            return new CandidateDao(builderIdentifier, builderCandidate, builderVersion, builderYear);
+            return new CandidateDao(builderIdentifier, builderCandidate, builderVersion, builderPeriodYear);
         }
     }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -112,7 +112,7 @@ public class CandidateRepository extends DynamoRepository {
         var candidate = CandidateDao.builder()
                                    .identifier(identifier)
                                    .candidate(dbCandidate)
-                                   .year(year)
+                                   .periodYear(year)
                                    .build();
         var uniqueness = new CandidateUniquenessEntryDao(dbCandidate.publicationId().toString());
         var transactionBuilder = buildTransaction(approvalStatuses, candidate, identifier, uniqueness);

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -104,16 +104,10 @@ public class CandidateRepository extends DynamoRepository {
     }
 
     public CandidateDao create(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses) {
-        var identifier = randomUUID();
-        var candidate = constructCandidate(identifier, dbCandidate);
-        var uniqueness = new CandidateUniquenessEntryDao(dbCandidate.publicationId().toString());
-        var transactionBuilder = buildTransaction(approvalStatuses, candidate, identifier, uniqueness);
-
-        this.client.transactWriteItems(transactionBuilder.build());
-        return candidateTable.getItem(candidate);
+        return create(dbCandidate, approvalStatuses, dbCandidate.publicationDate().year());
     }
 
-    public CandidateDao importCandidate(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses, String year) {
+    public CandidateDao create(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses, String year) {
         var identifier = randomUUID();
         var candidate = CandidateDao.builder()
                                    .identifier(identifier)
@@ -234,14 +228,6 @@ public class CandidateRepository extends DynamoRepository {
                                   .partitionValue(CandidateDao.createPartitionKey(identifier.toString()))
                                   .sortValue(ApprovalStatusDao.TYPE)
                                   .build());
-    }
-
-    private static CandidateDao constructCandidate(UUID identifier, DbCandidate dbCandidate) {
-        return CandidateDao.builder()
-                   .identifier(identifier)
-                   .candidate(dbCandidate)
-                   .year(dbCandidate.publicationDate().year())
-                   .build();
     }
 
     private static NoteDao newNoteDao(UUID candidateIdentifier, DbNote dbNote) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -27,6 +27,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
 import no.sikt.nva.nvi.common.db.NoteDao.DbNote;
 import no.sikt.nva.nvi.common.model.ListingResult;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
@@ -104,7 +105,8 @@ public class CandidateRepository extends DynamoRepository {
     }
 
     public CandidateDao create(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses) {
-        return create(dbCandidate, approvalStatuses, dbCandidate.publicationDate().year());
+        return create(dbCandidate, approvalStatuses,
+                      Optional.ofNullable(dbCandidate.publicationDate()).map(DbPublicationDate::year).orElse(null));
     }
 
     public CandidateDao create(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses, String year) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/PeriodStatus.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/PeriodStatus.java
@@ -11,7 +11,7 @@ import nva.commons.core.JacocoGenerated;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
-public record PeriodStatus(Instant startDate, Instant reportingDate, Status status) implements JsonSerializable {
+public record PeriodStatus(Instant startDate, Instant reportingDate, Status status, String year) implements JsonSerializable {
 
     public static Builder builder() {
         return new Builder();
@@ -40,6 +40,7 @@ public record PeriodStatus(Instant startDate, Instant reportingDate, Status stat
                    .withStartDate(period.startDate())
                    .withReportingDate(period.reportingDate())
                    .withStatus(Status.UNOPENED_PERIOD)
+                   .withYear(period.publishingYear())
                    .build();
     }
 
@@ -56,6 +57,7 @@ public record PeriodStatus(Instant startDate, Instant reportingDate, Status stat
                    .withStartDate(period.startDate())
                    .withReportingDate(period.reportingDate())
                    .withStatus(Status.OPEN_PERIOD)
+                   .withYear(period.publishingYear())
                    .build();
     }
 
@@ -64,6 +66,7 @@ public record PeriodStatus(Instant startDate, Instant reportingDate, Status stat
                    .withStartDate(period.startDate())
                    .withReportingDate(period.reportingDate())
                    .withStatus(Status.CLOSED_PERIOD)
+                   .withYear(period.publishingYear())
                    .build();
     }
 
@@ -89,6 +92,7 @@ public record PeriodStatus(Instant startDate, Instant reportingDate, Status stat
         private Instant reportingDate;
         private Instant startDate;
         private Status status;
+        private String year;
 
         private Builder() {
         }
@@ -108,8 +112,14 @@ public record PeriodStatus(Instant startDate, Instant reportingDate, Status stat
             return this;
         }
 
-        public PeriodStatus build() {
-            return new PeriodStatus(startDate, reportingDate, status);
+        public Builder withYear(String year) {
+            this.year = year;
+            return this;
         }
+
+        public PeriodStatus build() {
+            return new PeriodStatus(startDate, reportingDate, status, year);
+        }
+
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/dto/PeriodStatusDto.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/dto/PeriodStatusDto.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Optional;
 import nva.commons.core.JacocoGenerated;
 
-public record PeriodStatusDto(Status status, String startDate, String reportingDate) {
+public record PeriodStatusDto(Status status, String startDate, String reportingDate, String year) {
 
     public static Builder builder() {
         return new Builder();
@@ -15,6 +15,7 @@ public record PeriodStatusDto(Status status, String startDate, String reportingD
         return builder().withStatus(Status.parse(periodStatus.status().getValue()))
                    .withStartDate(toStartDate(periodStatus))
                    .withReportingDate(toReportingDate(periodStatus))
+                   .withYear(periodStatus.year())
                    .build();
     }
 
@@ -61,6 +62,7 @@ public record PeriodStatusDto(Status status, String startDate, String reportingD
         private Status status;
         private String startDate;
         private String closedDate;
+        private String year;
 
         private Builder() {
         }
@@ -80,8 +82,13 @@ public record PeriodStatusDto(Status status, String startDate, String reportingD
             return this;
         }
 
+        public Builder withYear(String year) {
+            this.year = year;
+            return this;
+        }
+
         public PeriodStatusDto build() {
-            return new PeriodStatusDto(status, startDate, closedDate);
+            return new PeriodStatusDto(status, startDate, closedDate, year);
         }
 
     }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -114,7 +114,7 @@ public final class Candidate {
                                .orElseThrow(CandidateNotFoundException::new);
         var approvalDaoList = repository.fetchApprovals(candidateDao.identifier());
         var noteDaoList = repository.getNotes(candidateDao.identifier());
-        var periodStatus = findPeriodStatus(periodRepository, candidateDao.candidate().publicationDate().year());
+        var periodStatus = findPeriodStatus(periodRepository, candidateDao.year());
         return new Candidate(repository, candidateDao, approvalDaoList, noteDaoList, periodStatus);
     }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -114,7 +114,7 @@ public final class Candidate {
                                .orElseThrow(CandidateNotFoundException::new);
         var approvalDaoList = repository.fetchApprovals(candidateDao.identifier());
         var noteDaoList = repository.getNotes(candidateDao.identifier());
-        var periodStatus = findPeriodStatus(periodRepository, candidateDao.year());
+        var periodStatus = findPeriodStatus(periodRepository, candidateDao.periodYear());
         return new Candidate(repository, candidateDao, approvalDaoList, noteDaoList, periodStatus);
     }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateDaoTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateDaoTest.java
@@ -15,7 +15,7 @@ class CandidateDaoTest {
         var dao = CandidateDao.builder()
                       .candidate(randomCandidate())
                       .identifier(UUID.randomUUID())
-                      .year(randomString())
+                      .periodYear(randomString())
                       .version(randomString())
                       .build();
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateDaoTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateDaoTest.java
@@ -1,0 +1,27 @@
+package no.sikt.nva.nvi.common.db;
+
+import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.UUID;
+import no.unit.nva.commons.json.JsonUtils;
+import org.junit.jupiter.api.Test;
+
+class CandidateDaoTest {
+
+    @Test
+    void shouldRoundTripCandidateDaoWithoutLossOfData() throws JsonProcessingException {
+        var dao = CandidateDao.builder()
+                      .candidate(randomCandidate())
+                      .identifier(UUID.randomUUID())
+                      .year(randomString())
+                      .version(randomString())
+                      .build();
+
+        var json = dao.toString();
+        var roundTrippedDao = JsonUtils.dtoObjectMapper.readValue(json, CandidateDao.class);
+
+        assertEquals(dao, roundTrippedDao);
+    }
+}

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/PeriodStatusTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/PeriodStatusTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.common.db;
 
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
@@ -42,15 +43,18 @@ public class PeriodStatusTest {
                                .withStartDate(startDate)
                                .withReportingDate(reportingDate)
                                .withStatus(status)
+                               .withYear(randomString())
                                .build();
         var expectedDto = PeriodStatusDto.builder()
                               .withStatus(PeriodStatusDto.Status.parse(status.getValue()))
                               .withStartDate(startDate.toString())
                               .withReportingDate(reportingDate.toString())
+                              .withYear(periodStatus.year())
                               .build();
         var actualDto = PeriodStatusDto.fromPeriodStatus(periodStatus);
         assertThat(actualDto, is(equalTo(expectedDto)));
         assertThat(actualDto.startDate(), is(equalTo(expectedDto.startDate())));
+        assertThat(actualDto.year(), is(equalTo(expectedDto.year())));
     }
 
     @ParameterizedTest()

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -487,6 +487,24 @@ class CandidateTest extends LocalDynamoTest {
         assertThat(persistedCandidate.instanceType(), is(equalTo(instanceType.getValue())));
     }
 
+    @Test
+    void shouldImportCandidate() {
+        var instanceType = InstanceType.ACADEMIC_CHAPTER;
+        var request = createUpsertCandidateRequest(randomUri(), randomUri(), true,
+                                                   instanceType.toString(),
+                                                   1, randomBigDecimal(),
+                                                   randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
+                                                   Integer.parseInt(randomYear()),
+                                                   randomUri());
+        var candidateIdentifier = Candidate.upsert(request, candidateRepository, periodRepository)
+                                      .orElseThrow()
+                                      .getIdentifier();
+        var persistedCandidate = candidateRepository.findCandidateById(candidateIdentifier)
+                                     .orElseThrow()
+                                     .candidate();
+        assertThat(persistedCandidate.instanceType(), is(equalTo(instanceType.getValue())));
+    }
+
     private static UpsertCandidateRequest createUpsertRequestWithDecimalScale(int scale, URI institutionId) {
         var creators = IntStream.of(1)
                            .mapToObj(i -> randomUri())
@@ -599,7 +617,7 @@ class CandidateTest extends LocalDynamoTest {
                                     .points(mapToDbInstitutionPoints(request.institutionPoints()))
                                     .totalPoints(setScaleAndRoundingMode(request.totalPoints()))
                                     .createdDate(candidate.getCreatedDate())
-                                    .build(), randomString()).candidate();
+                                    .build(), randomString(), randomString()).candidate();
     }
 
     private DbPublicationDate mapToDbPublicationDate(PublicationDate publicationDate) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -11,7 +11,6 @@ import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeri
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomInstanceTypeExcluding;
 import static no.sikt.nva.nvi.test.TestUtils.randomLevelExcluding;
-import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
@@ -467,42 +466,6 @@ class CandidateTest extends LocalDynamoTest {
     void shouldReturnContextUri() {
         var contextUri = Candidate.getContextUri();
         assertThat(contextUri, is(equalTo(CONTEXT_URI)));
-    }
-
-    @Test
-    void shouldMigrateInstanceTypeToEnumValue() {
-        var instanceType = InstanceType.ACADEMIC_CHAPTER;
-        var request = createUpsertCandidateRequest(randomUri(), randomUri(), true,
-                                                   instanceType.toString(),
-                                                   1, randomBigDecimal(),
-                                                   randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
-                                                   Integer.parseInt(randomYear()),
-                                                   randomUri());
-        var candidateIdentifier = Candidate.upsert(request, candidateRepository, periodRepository)
-                                      .orElseThrow()
-                                      .getIdentifier();
-        var persistedCandidate = candidateRepository.findCandidateById(candidateIdentifier)
-                                     .orElseThrow()
-                                     .candidate();
-        assertThat(persistedCandidate.instanceType(), is(equalTo(instanceType.getValue())));
-    }
-
-    @Test
-    void shouldImportCandidate() {
-        var instanceType = InstanceType.ACADEMIC_CHAPTER;
-        var request = createUpsertCandidateRequest(randomUri(), randomUri(), true,
-                                                   instanceType.toString(),
-                                                   1, randomBigDecimal(),
-                                                   randomLevelExcluding(DbLevel.NON_CANDIDATE).getVersionOneValue(),
-                                                   Integer.parseInt(randomYear()),
-                                                   randomUri());
-        var candidateIdentifier = Candidate.upsert(request, candidateRepository, periodRepository)
-                                      .orElseThrow()
-                                      .getIdentifier();
-        var persistedCandidate = candidateRepository.findCandidateById(candidateIdentifier)
-                                     .orElseThrow()
-                                     .candidate();
-        assertThat(persistedCandidate.instanceType(), is(equalTo(instanceType.getValue())));
     }
 
     private static UpsertCandidateRequest createUpsertRequestWithDecimalScale(int scale, URI institutionId) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -91,6 +91,8 @@ public final class TestUtils {
                    .publicationDate(new DbPublicationDate(randomString(), randomString(), randomString()))
                    .internationalCollaboration(randomBoolean())
                    .creatorCount(randomInteger())
+                   .createdDate(Instant.now())
+                   .modifiedDate(Instant.now())
                    .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))));
     }
 


### PR DESCRIPTION
Task: Store reportedYear/ reportedPeriod for NviCandidate. 

Problem:

Not possible to add `:PERIOD#somePeriod` to hashKey or rangeKey, cause they must be equal to be able to run dynamo.getItem(UniqueKey), otherwise we have to use dynamo.query() for fetching single item which is not a good idea.

Solution:

Today we store publicationDate.year as secondary index key in dynamo. This year will also be reportedYear/period since our periods are years, like 2023. This key will be set as publicationDate.year for nvi candidates created from NVA, but set to given value for imported nvi candidates from Cristin. 

Alternative solution is to create one more secondary index, but this is not a good idea, because given implementation we have now, this new secondary index will contain the same data as existing byYear index. 

For future "report candidates" functionality it will be enough to add for example `isReported` boolean or enum and iterate through all candidates for period/year and set isReported value. 