### PR TITLE
Persist non applicable candidates in persisted resources.

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -178,7 +178,7 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
     private IndexDocumentWithConsumptionAttributes generateIndexDocumentWithConsumptionAttributes(
         DynamodbStreamRecord record) {
         var candidate = fetchCandidate(record);
-        return candidate.isApplicable() ? generateIndexDocumentWithConsumptionAttributes(candidate) : null;
+        return generateIndexDocumentWithConsumptionAttributes(candidate);
     }
 
     private IndexDocumentWithConsumptionAttributes generateIndexDocumentWithConsumptionAttributes(

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -16,6 +16,7 @@ import no.unit.nva.auth.uriretriever.UriRetriever;
 @JsonSerialize
 public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         URI id,
+                                        boolean isApplicable,
                                         String type,
                                         UUID identifier,
                                         PublicationDetails publicationDetails,
@@ -42,6 +43,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
 
         private URI context;
         private URI id;
+        private boolean isApplicable;
         private UUID identifier;
         private PublicationDetails publicationDetails;
         private List<Approval> approvals;
@@ -51,7 +53,6 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
 
         private Builder() {
         }
-
         public Builder withContext(URI context) {
             this.context = context;
             return this;
@@ -59,6 +60,11 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
 
         public Builder withId(URI id) {
             this.id = id;
+            return this;
+        }
+
+        public Builder withIsApplicable(boolean isApplicable) {
+            this.isApplicable = isApplicable;
             return this;
         }
 
@@ -93,8 +99,8 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         }
 
         public NviCandidateIndexDocument build() {
-            return new NviCandidateIndexDocument(context, id, TYPE, identifier, publicationDetails, approvals,
-                                                 numberOfApprovals, points, modifiedDate);
+            return new NviCandidateIndexDocument(context, id, isApplicable, TYPE, identifier, publicationDetails,
+                                                 approvals, numberOfApprovals, points, modifiedDate);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -80,6 +80,7 @@ public final class NviCandidateIndexDocumentGenerator {
         return NviCandidateIndexDocument.builder()
                    .withId(candidate.getId())
                    .withContext(Candidate.getContextUri())
+                   .withIsApplicable(candidate.isApplicable())
                    .withIdentifier(candidate.getIdentifier())
                    .withApprovals(approvals)
                    .withPublicationDetails(extractPublicationDetails(resource, candidate))

--- a/template.yaml
+++ b/template.yaml
@@ -158,15 +158,15 @@ Resources:
       TopicArn: !Ref NviDataEntryUpdateCandidateApplicableUpdateTopic
       RawMessageDelivery: true
 
-  NviDataEntryUpdateCandidateNotApplicableUpdateSubscription:
+  NviDataEntryUpdateCandidateNotApplicableRemoveFromIndexSubscription:
     Type: AWS::SNS::Subscription
     Properties:
       Protocol: sqs
-      Endpoint: !GetAtt GenerateIndexDocumentQueue.Arn
+      Endpoint: !GetAtt RemoveDocumentFromIndexQueue.Arn
       TopicArn: !Ref NviDataEntryUpdateCandidateNotApplicableUpdateTopic
       RawMessageDelivery: true
 
-  NviDataEntryUpdateCandidateRemoveSubscription:
+  NviDataEntryUpdateCandidateRemoveFromIndexSubscription:
     Type: AWS::SNS::Subscription
     Properties:
       Protocol: sqs
@@ -174,11 +174,11 @@ Resources:
       TopicArn: !Ref NviDataEntryUpdateCandidateRemoveTopic
       RawMessageDelivery: true
 
-  NviDataEntryUpdateCandidateNotApplicableUpdateDeleteDocumentSubscription:
+  NviDataEntryUpdateCandidateNotApplicableUpdateSubscription:
     Type: AWS::SNS::Subscription
     Properties:
       Protocol: sqs
-      Endpoint: !GetAtt DeletePersistedIndexDocumentQueue.Arn
+      Endpoint: !GetAtt GenerateIndexDocumentQueue.Arn
       TopicArn: !Ref NviDataEntryUpdateCandidateNotApplicableUpdateTopic
       RawMessageDelivery: true
 

--- a/template.yaml
+++ b/template.yaml
@@ -162,7 +162,7 @@ Resources:
     Type: AWS::SNS::Subscription
     Properties:
       Protocol: sqs
-      Endpoint: !GetAtt RemoveDocumentFromIndexQueue.Arn
+      Endpoint: !GetAtt GenerateIndexDocumentQueue.Arn
       TopicArn: !Ref NviDataEntryUpdateCandidateNotApplicableUpdateTopic
       RawMessageDelivery: true
 


### PR DESCRIPTION
- Renamed subscription `NviDataEntryUpdateCandidateNotApplicableUpdateDeleteDocumentSubscription` to `NviDataEntryUpdateCandidateNotApplicableUpdateSubscription` and changed endpoint to `GenerateIndexDocumentQueue` (previously `DeletePersistedIndexDocumentQueue`)
- Create index documents also for not applicable candidates
- Add boolean `applicable` to `NviCandidateIndexDocument`

Note: Non applicable candidates will still be removed from OpenSearch due to subscription `NviDataEntryUpdateCandidateNotApplicableRemoveFromIndexSubscription`