### PR TITLE
Rename DbCreator to DbNviCreator

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
@@ -14,7 +14,7 @@ import java.util.stream.Collectors;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbNviCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
 import no.sikt.nva.nvi.common.db.ReportStatus;
@@ -46,7 +46,7 @@ public final class CristinMapper {
                    .publicationBucketUri(constructPublicationBucketUri(cristinNviReport.publicationIdentifier()))
                    .publicationDate(constructPublicationDate(cristinNviReport.publicationDate()))
                    .instanceType(cristinNviReport.instanceType())
-                   .creators(extractCreators(cristinNviReport))
+                   .nviCreators(extractCreators(cristinNviReport))
                    .level(extractLevel(cristinNviReport))
                    .reportStatus(ReportStatus.REPORTED)
                    .applicable(true)
@@ -55,7 +55,7 @@ public final class CristinMapper {
                    .build();
     }
 
-    public static List<DbCreator> extractCreators(CristinNviReport cristinNviReport) {
+    public static List<DbNviCreator> extractCreators(CristinNviReport cristinNviReport) {
         return cristinNviReport.scientificResources().get(0).getCreators().stream()
                            .collect(groupByCristinIdentifierAndMapToAffiliationId())
                            .entrySet().stream()
@@ -63,8 +63,8 @@ public final class CristinMapper {
                            .toList();
     }
 
-    private static DbCreator toDbCreator(Entry<URI, List<URI>> entry) {
-        return DbCreator.builder().creatorId(entry.getKey()).affiliations(entry.getValue()).build();
+    private static DbNviCreator toDbCreator(Entry<URI, List<URI>> entry) {
+        return DbNviCreator.builder().creatorId(entry.getKey()).nviAffiliations(entry.getValue()).build();
     }
 
     private static Collector<ScientificPerson, ?, Map<URI, List<URI>>> groupByCristinIdentifierAndMapToAffiliationId() {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbNviCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
@@ -274,7 +274,7 @@ public class RequeueDlqHandlerTest {
                                           .points(BigDecimal.valueOf(1))
                                           .build()))
                                   .instanceType(InstanceType.ACADEMIC_ARTICLE.getValue())
-                                  .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))))
+                                  .nviCreators(List.of(new DbNviCreator(randomUri(), List.of(randomUri()))))
                                   .level(DbLevel.LEVEL_ONE)
                                   .channelType(ChannelType.JOURNAL)
                                   .totalPoints(BigDecimal.valueOf(1))

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -331,6 +331,11 @@ public final class CandidateDao extends Dao {
             return migrateDate(createdDate);
         }
 
+        //TODO: Remove after migration
+        public List<DbNviCreator> creators() {
+            return nviCreators;
+        }
+
         @DynamoDbIgnore
         public Builder copy() {
             return builder()
@@ -393,7 +398,8 @@ public final class CandidateDao extends Dao {
             return Objects.hash(publicationId, publicationBucketUri, applicable, instanceType, channelType, channelId,
                                 level,
                                 publicationDate, internationalCollaboration, collaborationFactor, creatorCount,
-                                creatorShareCount, nviCreators, basePoints, points, totalPoints, createdDate, reportStatus);
+                                creatorShareCount, nviCreators, basePoints, points, totalPoints, createdDate,
+                                reportStatus);
         }
 
         @Deprecated
@@ -591,6 +597,11 @@ public final class CandidateDao extends Dao {
 
     @DynamoDbImmutable(builder = DbNviCreator.Builder.class)
     public record DbNviCreator(URI creatorId, List<URI> nviAffiliations) {
+
+        //TODO: Remove after migration
+        public List<URI> affiliations() {
+            return nviAffiliations;
+        }
 
         public static Builder builder() {
             return new Builder();

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -294,7 +294,7 @@ public final class CandidateDao extends Dao {
                               BigDecimal collaborationFactor,
                               int creatorCount,
                               int creatorShareCount,
-                              List<DbCreator> creators,
+                              List<DbNviCreator> nviCreators,
                               BigDecimal basePoints,
                               List<DbInstitutionPoints> points,
                               BigDecimal totalPoints,
@@ -346,7 +346,7 @@ public final class CandidateDao extends Dao {
                        .collaborationFactor(collaborationFactor)
                        .creatorCount(creatorCount)
                        .creatorShareCount(creatorShareCount)
-                       .creators(creators.stream().map(DbCreator::copy).toList())
+                       .nviCreators(nviCreators.stream().map(DbNviCreator::copy).toList())
                        .basePoints(basePoints)
                        .points(points.stream().map(DbInstitutionPoints::copy).toList())
                        .totalPoints(totalPoints)
@@ -378,7 +378,7 @@ public final class CandidateDao extends Dao {
                    && level == that.level
                    && Objects.equals(publicationDate, that.publicationDate)
                    && Objects.equals(collaborationFactor, that.collaborationFactor)
-                   && Objects.equals(creators, that.creators)
+                   && Objects.equals(nviCreators, that.nviCreators)
                    && Objects.equals(basePoints, that.basePoints)
                    && Objects.equals(points, that.points)
                    && Objects.equals(totalPoints, that.totalPoints)
@@ -393,7 +393,7 @@ public final class CandidateDao extends Dao {
             return Objects.hash(publicationId, publicationBucketUri, applicable, instanceType, channelType, channelId,
                                 level,
                                 publicationDate, internationalCollaboration, collaborationFactor, creatorCount,
-                                creatorShareCount, creators, basePoints, points, totalPoints, createdDate, reportStatus);
+                                creatorShareCount, nviCreators, basePoints, points, totalPoints, createdDate, reportStatus);
         }
 
         @Deprecated
@@ -419,7 +419,7 @@ public final class CandidateDao extends Dao {
             private BigDecimal builderCollaborationFactor;
             private int builderCreatorCount;
             private int builderCreatorShareCount;
-            private List<DbCreator> builderCreators;
+            private List<DbNviCreator> builderNviCreators;
             private BigDecimal builderBasePoints;
             private List<DbInstitutionPoints> builderPoints;
             private BigDecimal builderTotalPoints;
@@ -499,8 +499,8 @@ public final class CandidateDao extends Dao {
                 return this;
             }
 
-            public Builder creators(List<DbCreator> creators) {
-                this.builderCreators = creators;
+            public Builder nviCreators(List<DbNviCreator> nviCreators) {
+                this.builderNviCreators = nviCreators;
                 return this;
             }
 
@@ -539,7 +539,7 @@ public final class CandidateDao extends Dao {
                                        builderInstanceType, builderChannelType, builderChannelId, builderLevel,
                                        builderPublicationDate, builderInternationalCollaboration,
                                        builderCollaborationFactor,
-                                       builderCreatorCount, builderCreatorShareCount, builderCreators,
+                                       builderCreatorCount, builderCreatorShareCount, builderNviCreators,
                                        builderBasePoints,
                                        builderPoints, builderTotalPoints, builderCreatedDate, builderModifiedDate,
                                        builderReportStatus);
@@ -589,18 +589,18 @@ public final class CandidateDao extends Dao {
         }
     }
 
-    @DynamoDbImmutable(builder = DbCreator.Builder.class)
-    public record DbCreator(URI creatorId, List<URI> affiliations) {
+    @DynamoDbImmutable(builder = DbNviCreator.Builder.class)
+    public record DbNviCreator(URI creatorId, List<URI> nviAffiliations) {
 
         public static Builder builder() {
             return new Builder();
         }
 
         @DynamoDbIgnore
-        public DbCreator copy() {
+        public DbNviCreator copy() {
             return builder()
                        .creatorId(creatorId)
-                       .affiliations(new ArrayList<>(affiliations))
+                       .nviAffiliations(new ArrayList<>(nviAffiliations))
                        .build();
         }
 
@@ -617,13 +617,13 @@ public final class CandidateDao extends Dao {
                 return this;
             }
 
-            public Builder affiliations(List<URI> affiliations) {
-                this.builderAffiliations = affiliations;
+            public Builder nviAffiliations(List<URI> nviAffiliations) {
+                this.builderAffiliations = nviAffiliations;
                 return this;
             }
 
-            public DbCreator build() {
-                return new DbCreator(builderCreatorId, builderAffiliations);
+            public DbNviCreator build() {
+                return new DbNviCreator(builderCreatorId, builderAffiliations);
             }
         }
     }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -25,7 +25,7 @@ import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbNviCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
@@ -368,7 +368,7 @@ public final class Candidate {
     }
 
     private static boolean creatorsAreUpdated(UpsertCandidateRequest request, CandidateDao existingCandidateDao) {
-        return !Objects.equals(mapToCreators(request.creators()), existingCandidateDao.candidate().creators());
+        return !Objects.equals(mapToCreators(request.creators()), existingCandidateDao.candidate().nviCreators());
     }
 
     private static boolean instanceTypeIsUpdated(UpsertCandidateRequest request, CandidateDao existingCandidateDao) {
@@ -461,7 +461,7 @@ public final class Candidate {
                    .publicationId(request.publicationId())
                    .publicationBucketUri(request.publicationBucketUri())
                    .applicable(request.isApplicable())
-                   .creators(mapToCreators(request.creators()))
+                   .nviCreators(mapToCreators(request.creators()))
                    .creatorShareCount(request.creatorShareCount())
                    .channelType(ChannelType.parse(request.channelType()))
                    .channelId(request.publicationChannelId())
@@ -484,7 +484,7 @@ public final class Candidate {
                    .candidate(candidateDao.candidate()
                                   .copy()
                                   .applicable(request.isApplicable())
-                                  .creators(mapToCreators(request.creators()))
+                                  .nviCreators(mapToCreators(request.creators()))
                                   .creatorShareCount(request.creatorShareCount())
                                   .channelType(ChannelType.parse(request.channelType()))
                                   .channelId(request.publicationChannelId())
@@ -520,16 +520,16 @@ public final class Candidate {
         return new PublicationDate(date.year(), date.month(), date.day());
     }
 
-    private static List<DbCreator> mapToCreators(Map<URI, List<URI>> creators) {
-        return creators.entrySet().stream().map(e -> new DbCreator(e.getKey(), e.getValue())).toList();
+    private static List<DbNviCreator> mapToCreators(Map<URI, List<URI>> creators) {
+        return creators.entrySet().stream().map(e -> new DbNviCreator(e.getKey(), e.getValue())).toList();
     }
 
-    private static List<Creator> mapToCreators(List<DbCreator> creators) {
+    private static List<Creator> mapToCreators(List<DbNviCreator> creators) {
         return nonNull(creators) ? creators.stream().map(Candidate::mapToCreator).toList() : List.of();
     }
 
-    private static Creator mapToCreator(DbCreator dbCreator) {
-        return new Creator(dbCreator.creatorId(), dbCreator.affiliations());
+    private static Creator mapToCreator(DbNviCreator nviCreator) {
+        return new Creator(nviCreator.creatorId(), nviCreator.nviAffiliations());
     }
 
     private static boolean isExistingCandidate(URI publicationId, CandidateRepository repository) {
@@ -551,7 +551,7 @@ public final class Candidate {
                                       candidateDao.candidate().publicationBucketUri(),
                                       candidateDao.candidate().instanceType(),
                                       mapToPublicationDate(candidateDao.candidate().publicationDate()),
-                                      mapToCreators(candidateDao.candidate().creators()),
+                                      mapToCreators(candidateDao.candidate().nviCreators()),
                                       candidateDao.candidate().channelType(),
                                       candidateDao.candidate().channelId(),
                                       candidateDao.candidate().level()

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateTest.java
@@ -13,7 +13,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.IntStream;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbNviCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
@@ -39,7 +39,7 @@ public class CandidateTest {
                    .level(DbLevel.LEVEL_ONE)
                    .applicable(true)
                    .internationalCollaboration(true)
-                   .creators(randomVerifiedCreators())
+                   .nviCreators(randomVerifiedCreators())
                    .publicationDate(localDateNowAsPublicationDate())
                    .points(List.of(new DbInstitutionPoints(randomUri(), randomBigDecimal())))
                    .createdDate(Instant.now())
@@ -53,12 +53,12 @@ public class CandidateTest {
                                      String.valueOf(now.getDayOfMonth()));
     }
 
-    private List<DbCreator> randomVerifiedCreators() {
+    private List<DbNviCreator> randomVerifiedCreators() {
         return IntStream.range(1, 20).boxed().map(i -> randomVerifiedCreator()).toList();
     }
 
-    private DbCreator randomVerifiedCreator() {
-        return new DbCreator(randomUri(), randomAffiliations());
+    private DbNviCreator randomVerifiedCreator() {
+        return new DbNviCreator(randomUri(), randomAffiliations());
     }
 
     private List<URI> randomAffiliations() {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -50,7 +50,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbNviCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
@@ -608,7 +608,7 @@ class CandidateTest extends LocalDynamoTest {
                                     .basePoints(setScaleAndRoundingMode(request.basePoints()))
                                     .internationalCollaboration(request.isInternationalCollaboration())
                                     .collaborationFactor(setScaleAndRoundingMode(request.collaborationFactor()))
-                                    .creators(mapToDbCreators(request.creators()))
+                                    .nviCreators(mapToDbCreators(request.creators()))
                                     .creatorShareCount(request.creatorShareCount())
                                     .points(mapToDbInstitutionPoints(request.institutionPoints()))
                                     .totalPoints(setScaleAndRoundingMode(request.totalPoints()))
@@ -627,8 +627,8 @@ class CandidateTest extends LocalDynamoTest {
                    .toList();
     }
 
-    private List<DbCreator> mapToDbCreators(Map<URI, List<URI>> creators) {
-        return creators.entrySet().stream().map(entry -> new DbCreator(entry.getKey(), entry.getValue())).toList();
+    private List<DbNviCreator> mapToDbCreators(Map<URI, List<URI>> creators) {
+        return creators.entrySet().stream().map(entry -> new DbNviCreator(entry.getKey(), entry.getValue())).toList();
     }
 
     private UpsertCandidateRequest createNewUpsertRequestNotAffectingApprovals(UpsertCandidateRequest request) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -32,7 +32,7 @@ import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbNviCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
@@ -93,7 +93,7 @@ public final class TestUtils {
                    .creatorCount(randomInteger())
                    .createdDate(Instant.now())
                    .modifiedDate(Instant.now())
-                   .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))));
+                   .nviCreators(List.of(new DbNviCreator(randomUri(), List.of(randomUri()))));
     }
 
     public static InstanceType randomInstanceType() {


### PR DESCRIPTION
To make it explicit that only nvi creators are persisted for a candidate, rename `DbCreator` to `DbNviCreator`