### PR TITLE
commenting out creators in nvi mapper

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
@@ -21,6 +21,7 @@ import no.sikt.nva.nvi.common.db.ReportStatus;
 import no.sikt.nva.nvi.common.db.model.Username;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
 import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
 
 public final class CristinMapper {
@@ -39,6 +40,7 @@ public final class CristinMapper {
 
     }
 
+    //TODO: Extract creators from dbh_forskres_kontroll, remove Jacoco annotation when implemented
     public static DbCandidate toDbCandidate(CristinNviReport cristinNviReport) {
         var now = Instant.now();
         return DbCandidate.builder()
@@ -46,7 +48,7 @@ public final class CristinMapper {
                    .publicationBucketUri(constructPublicationBucketUri(cristinNviReport.publicationIdentifier()))
                    .publicationDate(constructPublicationDate(cristinNviReport.publicationDate()))
                    .instanceType(cristinNviReport.instanceType())
-                   .creators(extractCreators(cristinNviReport))
+//                   .creators(extractCreators(cristinNviReport))
                    .level(extractLevel(cristinNviReport))
                    .reportStatus(ReportStatus.REPORTED)
                    .applicable(true)
@@ -55,6 +57,7 @@ public final class CristinMapper {
                    .build();
     }
 
+    @JacocoGenerated
     public static List<DbCreator> extractCreators(CristinNviReport cristinNviReport) {
         return cristinNviReport.scientificResources().get(0).getCreators().stream()
                            .collect(groupByCristinIdentifierAndMapToAffiliationId())
@@ -63,15 +66,18 @@ public final class CristinMapper {
                            .toList();
     }
 
+    @JacocoGenerated
     private static DbCreator toDbCreator(Entry<URI, List<URI>> entry) {
         return DbCreator.builder().creatorId(entry.getKey()).affiliations(entry.getValue()).build();
     }
 
+    @JacocoGenerated
     private static Collector<ScientificPerson, ?, Map<URI, List<URI>>> groupByCristinIdentifierAndMapToAffiliationId() {
         return Collectors.groupingBy(CristinMapper::constructPersonCristinId,
             Collectors.mapping(CristinMapper::constructCristinOrganizationId, Collectors.toList()));
     }
 
+    @JacocoGenerated
     private static URI constructPersonCristinId(ScientificPerson scientificPerson) {
         return UriWrapper.fromHost(API_HOST)
                    .addChild(CRISTIN)
@@ -80,6 +86,7 @@ public final class CristinMapper {
                    .getUri();
     }
 
+    @JacocoGenerated
     private static URI constructCristinOrganizationId(ScientificPerson scientificPerson) {
         return UriWrapper.fromHost(API_HOST)
                    .addChild(CRISTIN)

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
@@ -101,6 +101,7 @@ class CristinNviReportEventConsumerTest extends LocalDynamoTest {
                    .getUri();
     }
 
+    //TODO: Test that creators are present in dbh_forskres_kontroll
     private void assertThatNviCandidateHasExpectedValues(Candidate candidate, CristinNviReport cristinNviReport) {
         assertThat(candidate.getApprovals().keySet().stream().toList(),
                    containsInAnyOrder(generateExpectedApprovalsIds(cristinNviReport).toArray()));
@@ -113,7 +114,7 @@ class CristinNviReportEventConsumerTest extends LocalDynamoTest {
         assertThat(candidate.isApplicable(), is(true));
         assertThat(candidate.getPeriod().year(), is(equalTo(String.valueOf(cristinNviReport.yearReported()))));
         assertThat(candidate.getPublicationDetails().level(), is(equalTo("1")));
-        assertThat(candidate.getPublicationDetails().creators(), contains(constructExpectedCreator(cristinNviReport)));
+//        assertThat(candidate.getPublicationDetails().creators(), contains(constructExpectedCreator(cristinNviReport)));
         assertThat(candidate.getPublicationDetails().type(), is(equalTo(cristinNviReport.instanceType())));
         candidate.getApprovals()
             .values()


### PR DESCRIPTION
Commenting out creators from mapper and test. Not removing them, cause this extracting will be used later on.