### PR TITLE
Np 45429 index document reporting period

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -28,6 +28,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         ApprovalStatus globalApprovalStatus,
                                         int creatorShareCount,
                                         BigDecimal internationalCollaborationFactor,
+                                        ReportingPeriod reportingPeriod,
                                         String reportedPeriod,
                                         String modifiedDate) {
 
@@ -59,6 +60,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         private ApprovalStatus globalApprovalStatus;
         private int creatorShareCount;
         private BigDecimal internationalCollaborationFactor;
+        private ReportingPeriod reportingPeriod;
         private String reportedPeriod;
         private String modifiedDate;
 
@@ -125,6 +127,11 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
             return this;
         }
 
+        public Builder withReportingPeriod(ReportingPeriod reportingPeriod) {
+            this.reportingPeriod = reportingPeriod;
+            return this;
+        }
+
         public Builder withReportedPeriod(String reportedPeriod) {
             this.reportedPeriod = reportedPeriod;
             return this;
@@ -139,8 +146,8 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
             return new NviCandidateIndexDocument(context, id, isApplicable, TYPE, identifier, publicationDetails,
                                                  approvals, numberOfApprovals, points,
                                                  publicationTypeChannelLevelPoints, globalApprovalStatus,
-                                                 creatorShareCount, internationalCollaborationFactor, reportedPeriod,
-                                                 modifiedDate);
+                                                 creatorShareCount, internationalCollaborationFactor, reportingPeriod,
+                                                 reportedPeriod, modifiedDate);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/ReportingPeriod.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/ReportingPeriod.java
@@ -1,0 +1,12 @@
+package no.sikt.nva.nvi.index.model;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "type")
+public record ReportingPeriod(String year) {
+
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -48,6 +48,7 @@ import no.sikt.nva.nvi.index.model.Organization;
 import no.sikt.nva.nvi.index.model.OrganizationType;
 import no.sikt.nva.nvi.index.model.PublicationDate;
 import no.sikt.nva.nvi.index.model.PublicationDetails;
+import no.sikt.nva.nvi.index.model.ReportingPeriod;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import org.apache.jena.rdf.model.RDFNode;
 import org.slf4j.Logger;
@@ -92,6 +93,7 @@ public final class NviCandidateIndexDocumentGenerator {
                    .withContext(Candidate.getContextUri())
                    .withIsApplicable(candidate.isApplicable())
                    .withIdentifier(candidate.getIdentifier())
+                   .withReportingPeriod(new ReportingPeriod(candidate.getPeriod().year()))
                    .withApprovals(approvals)
                    .withPublicationDetails(extractPublicationDetails(resource, candidate))
                    .withNumberOfApprovals(approvals.size())

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -49,6 +49,7 @@ import no.sikt.nva.nvi.index.aws.S3StorageWriter;
 import no.sikt.nva.nvi.index.model.ConsumptionAttributes;
 import no.sikt.nva.nvi.index.model.IndexDocumentWithConsumptionAttributes;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
+import no.sikt.nva.nvi.index.model.ReportingPeriod;
 import no.sikt.nva.nvi.test.FakeSqsClient;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.unit.nva.auth.uriretriever.UriRetriever;
@@ -482,6 +483,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
                    .withPublicationTypeChannelLevelPoints(candidate.getBasePoints())
                    .withInternationalCollaborationFactor(candidate.getCollaborationFactor())
                    .withModifiedDate(candidate.getModifiedDate().toString())
+                   .withReportingPeriod(new ReportingPeriod(candidate.getPeriod().year()))
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -52,6 +52,7 @@ import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.ReportingPeriod;
 import no.sikt.nva.nvi.test.FakeSqsClient;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
@@ -65,6 +66,7 @@ import software.amazon.awssdk.services.sqs.model.SqsException;
 
 public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
+    public static final int SOME_REPORTING_YEAR = 2023;
     private static final String JSON_PTR_CONTRIBUTOR = "/publicationDetails/contributors";
     private static final String JSON_PTR_APPROVALS = "/approvals";
     private static final Environment ENVIRONMENT = new Environment();
@@ -92,7 +94,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         s3Writer = new S3Driver(s3Client, BUCKET_NAME);
         var localDynamoDbClient = initializeTestDatabase();
         candidateRepository = new CandidateRepository(localDynamoDbClient);
-        periodRepository = new PeriodRepository(localDynamoDbClient);
+        periodRepository = TestUtils.periodRepositoryReturningOpenedPeriod(SOME_REPORTING_YEAR);
         uriRetriever = mock(UriRetriever.class);
         sqsClient = new FakeSqsClient();
         handler = new IndexDocumentHandler(new S3StorageReader(s3Client, BUCKET_NAME),
@@ -488,7 +490,8 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     }
 
     private Candidate randomApplicableCandidate() {
-        return Candidate.upsert(createUpsertCandidateRequest(2023), candidateRepository, periodRepository)
+        return Candidate.upsert(createUpsertCandidateRequest(SOME_REPORTING_YEAR), candidateRepository,
+                                periodRepository)
                    .orElseThrow();
     }
 }


### PR DESCRIPTION
- Add `reportingPeriod` `year` in candidate index document

For data export, we need to know which reporting period the candidate belongs to in order to make a institution report for a given reporting year.
We could use the `publicationDate` `year` of the publication, but `reportingPeriod` `year` is more explicit. These will contain the same value in most cases.
Also, feel free to suggest better naming. Is `reportingPeriod` too similar to already implemented field `reportedPeriod`?