### PR TITLE
Index document: Rename reportedPeriod to reported and change data type to boolean

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -29,7 +29,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         int creatorShareCount,
                                         BigDecimal internationalCollaborationFactor,
                                         ReportingPeriod reportingPeriod,
-                                        String reportedPeriod,
+                                        boolean reported,
                                         String modifiedDate) {
 
     private static final String CONTEXT = "@context";
@@ -61,7 +61,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         private int creatorShareCount;
         private BigDecimal internationalCollaborationFactor;
         private ReportingPeriod reportingPeriod;
-        private String reportedPeriod;
+        private boolean reported;
         private String modifiedDate;
 
         private Builder() {
@@ -132,8 +132,8 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
             return this;
         }
 
-        public Builder withReportedPeriod(String reportedPeriod) {
-            this.reportedPeriod = reportedPeriod;
+        public Builder withReported(boolean reported) {
+            this.reported = reported;
             return this;
         }
 
@@ -147,7 +147,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                                  approvals, numberOfApprovals, points,
                                                  publicationTypeChannelLevelPoints, globalApprovalStatus,
                                                  creatorShareCount, internationalCollaborationFactor, reportingPeriod,
-                                                 reportedPeriod, modifiedDate);
+                                                 reported, modifiedDate);
         }
     }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -480,7 +480,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
                    .withPublicationDetails(expandPublicationDetails(candidate, expandedResource))
                    .withNumberOfApprovals(candidate.getApprovals().size())
                    .withCreatorShareCount(candidate.getCreatorShareCount())
-                   .withReportedPeriod(candidate.isReported() ? candidate.getPeriod().year() : null)
+                   .withReported(candidate.isReported())
                    .withGlobalApprovalStatus(candidate.getGlobalApprovalStatus())
                    .withPublicationTypeChannelLevelPoints(candidate.getBasePoints())
                    .withInternationalCollaborationFactor(candidate.getCollaborationFactor())


### PR DESCRIPTION
- Since I implemented `reportingPeriod` in [previous PR](https://github.com/BIBSYSDEV/nva-nvi/pull/267), the year the candidate was reported is provided here
- Renamed `reportedPeriod` to `reported` and changed data type to boolean

This change will require re-indexing
(`reportedPeriod` is only consumed in data-report, I will follow up required changes here)