### PR TITLE
Np 46381 batch scan for dao type

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanStartHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanStartHandler.java
@@ -31,7 +31,7 @@ public class BatchScanStartHandler implements RequestStreamHandler {
     @Override
     public void handleRequest(InputStream input, OutputStream output, Context context) {
 
-        new ScanDatabaseRequest.Builder()
+        ScanDatabaseRequest.builder()
             .fromInputStream(input)
             .withTopic(TOPIC)
             .build()

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandler.java
@@ -41,7 +41,7 @@ public class EventBasedBatchScanHandler extends EventHandler<ScanDatabaseRequest
                                               Context context) {
         logger.info("Query starting point: {}", input.startMarker());
 
-        var batchResult = nviService.migrateAndUpdateVersion(input.pageSize(), input.startMarker());
+        var batchResult = nviService.migrateAndUpdateVersion(input.pageSize(), input.startMarker(), input.types());
         logger.info("Batch result: {}", batchResult);
         if (batchResult.shouldContinueScan()) {
             sendEventToInvokeNewRefreshRowVersionExecution(input, context, batchResult);

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/KeyField.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/KeyField.java
@@ -1,0 +1,59 @@
+package no.sikt.nva.nvi.events.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import no.sikt.nva.nvi.common.db.ApprovalStatusDao;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+import no.sikt.nva.nvi.common.db.NoteDao;
+import no.sikt.nva.nvi.common.db.NviPeriodDao;
+import nva.commons.core.SingletonCollector;
+
+public enum KeyField {
+    CANDIDATE(CandidateDao.TYPE),
+    APPROVAL(ApprovalStatusDao.TYPE),
+    NOTE(NoteDao.TYPE),
+    PERIOD(NviPeriodDao.TYPE);
+
+    public static final String KEY_FIELDS_DELIMITER = ":";
+    private static final String SEPARATOR = ",";
+    private final String keyField;
+
+    KeyField(String keyField) {
+        this.keyField = keyField;
+    }
+
+    @JsonCreator
+    public static KeyField parse(String candidate) {
+        return Arrays.stream(KeyField.values())
+                   .filter(value -> value.filterByNameOrValue(candidate))
+                   .collect(SingletonCollector.tryCollect())
+                   .orElseThrow(fail -> handleParsingError());
+    }
+
+    public String getKeyField() {
+        return KEY_FIELDS_DELIMITER + keyField;
+    }
+
+    @Override
+    @JsonValue
+    public String toString() {
+        return keyField;
+    }
+
+    private static IllegalArgumentException handleParsingError() {
+        return new IllegalArgumentException("Invalid types. Valid types: " + validValues());
+    }
+
+    private static String validValues() {
+        return Arrays.stream(KeyField.values())
+                   .map(KeyField::toString)
+                   .collect(Collectors.joining(SEPARATOR));
+    }
+
+    private boolean filterByNameOrValue(String candidate) {
+        return toString().equalsIgnoreCase(candidate)
+               || getKeyField().equalsIgnoreCase(candidate);
+    }
+}

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ScanDatabaseRequest.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ScanDatabaseRequest.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.commons.json.JsonUtils;
@@ -18,22 +19,26 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
 public record ScanDatabaseRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
                                   @JsonProperty(START_MARKER_FIELD) Map<String, String> startMarker,
+                                  @JsonProperty(TYPES) List<KeyField> types,
                                   @JsonProperty(TOPIC_FIELD) String topic) implements JsonSerializable {
 
     private static final Logger logger = LoggerFactory.getLogger(ScanDatabaseRequest.class);
-
-    public static final String LOG_INITIALIZATION_MESSAGE_TEMPLATE =
+    private static final String LOG_INITIALIZATION_MESSAGE_TEMPLATE =
         "Starting scanning with pageSize equal to: {}. Set 'pageSize' between [1,1000] "
         + "if you want a different pageSize value.";
-
-    public static final String START_MARKER_FIELD = "startMarker";
-    public static final String PAGE_SIZE_FIELD = "pageSize";
-    public static final int DEFAULT_PAGE_SIZE = 700; // Choosing for safety 3/4 of max page size.
-    public static final int MAX_PAGE_SIZE = 1000;
-    public static final String TOPIC_FIELD = "topic";
+    private static final String START_MARKER_FIELD = "startMarker";
+    private static final String PAGE_SIZE_FIELD = "pageSize";
+    private static final int DEFAULT_PAGE_SIZE = 700; // Choosing for safety 3/4 of max page size.
+    private static final int MAX_PAGE_SIZE = 1000;
+    private static final String TOPIC_FIELD = "topic";
+    private static final String TYPES = "types";
 
     public static ScanDatabaseRequest fromJson(String detail) throws JsonProcessingException {
         return JsonUtils.dtoObjectMapper.readValue(detail, ScanDatabaseRequest.class);
+    }
+
+    public static Builder builder() {
+        return new Builder();
     }
 
     @Override
@@ -44,7 +49,7 @@ public record ScanDatabaseRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
     }
 
     public ScanDatabaseRequest newScanDatabaseRequest(Map<String, String> newStartMarker) {
-        return new ScanDatabaseRequest(this.pageSize(), newStartMarker, topic);
+        return new ScanDatabaseRequest(this.pageSize(), newStartMarker, null, topic);
     }
 
     public PutEventsRequestEntry createNewEventEntry(
@@ -75,11 +80,13 @@ public record ScanDatabaseRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
         return pageSize > 0 && pageSize <= MAX_PAGE_SIZE;
     }
 
-    public static class Builder {
+    public static final class Builder {
 
         public static final ObjectMapper MAPPER = JsonUtils.dtoObjectMapper;
         private Map<String, String> startMarker;
         private int pageSize;
+        private List<KeyField> types;
+
         private String topic;
 
         public Builder fromInputStream(InputStream inputStream) {
@@ -87,6 +94,7 @@ public record ScanDatabaseRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
                               .orElseThrow();
             this.startMarker = request.startMarker();
             this.pageSize = request.pageSize();
+            this.types = request.types();
             return this;
         }
 
@@ -95,8 +103,13 @@ public record ScanDatabaseRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
             return this;
         }
 
+        public Builder withTypes(List<KeyField> types) {
+            this.types = types;
+            return this;
+        }
+
         public ScanDatabaseRequest build() {
-            return new ScanDatabaseRequest(pageSize, startMarker, topic);
+            return new ScanDatabaseRequest(pageSize, startMarker, types, topic);
         }
     }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ScanDatabaseRequest.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ScanDatabaseRequest.java
@@ -111,11 +111,6 @@ public record ScanDatabaseRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
             return this;
         }
 
-        public Builder withTypes(List<KeyField> types) {
-            this.types = types;
-            return this;
-        }
-
         public ScanDatabaseRequest build() {
             return new ScanDatabaseRequest(pageSize, startMarker, types, topic);
         }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ScanDatabaseRequest.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/ScanDatabaseRequest.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.events.model;
 
+import static java.util.Collections.emptyList;
+import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 import static nva.commons.core.ioutils.IoUtils.streamToString;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -9,6 +11,7 @@ import java.io.InputStream;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import no.sikt.nva.nvi.common.db.model.KeyField;
 import no.unit.nva.commons.json.JsonSerializable;
 import no.unit.nva.commons.json.JsonUtils;
 import org.slf4j.Logger;
@@ -48,8 +51,13 @@ public record ScanDatabaseRequest(@JsonProperty(PAGE_SIZE_FIELD) int pageSize,
                    : DEFAULT_PAGE_SIZE;
     }
 
+    @Override
+    public List<KeyField> types() {
+        return nonNull(types) ? types : emptyList();
+    }
+
     public ScanDatabaseRequest newScanDatabaseRequest(Map<String, String> newStartMarker) {
-        return new ScanDatabaseRequest(this.pageSize(), newStartMarker, null, topic);
+        return new ScanDatabaseRequest(this.pageSize(), newStartMarker, this.types(), topic);
     }
 
     public PutEventsRequestEntry createNewEventEntry(

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanStartHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanStartHandlerTest.java
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 public class BatchScanStartHandlerTest {
 
     private static final String TOPIC = "OUTPUT_EVENT_TOPIC";
-    private static final String DEFAULT_PAGE_SIZE = "700";
+    private static final int DEFAULT_PAGE_SIZE = 700;
     private static final int NOT_SET_PAGE_SIZE = 0;
     private final FakeContext context = new FakeContext() {
         @Override

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanStartHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanStartHandlerTest.java
@@ -15,9 +15,9 @@ import org.junit.jupiter.api.Test;
 
 public class BatchScanStartHandlerTest {
 
-    public static final String TOPIC = "OUTPUT_EVENT_TOPIC";
-
-    public static final int NOT_SET_PAGE_SIZE = 0;
+    private static final String TOPIC = "OUTPUT_EVENT_TOPIC";
+    private static final String DEFAULT_PAGE_SIZE = "700";
+    private static final int NOT_SET_PAGE_SIZE = 0;
     private final FakeContext context = new FakeContext() {
         @Override
         public String getInvokedFunctionArn() {
@@ -29,20 +29,20 @@ public class BatchScanStartHandlerTest {
     void shouldSendInitialScanMessageWithDefaultPageSizeWhenPageSizeIsNotSet() throws IOException {
         var client = new FakeEventBridgeClient();
         var handler = new BatchScanStartHandler(client);
-        var scanDatabaseRequest = new ScanDatabaseRequest(NOT_SET_PAGE_SIZE, null, TOPIC);
+        var scanDatabaseRequest = new ScanDatabaseRequest(NOT_SET_PAGE_SIZE, null, null, TOPIC);
         var request = IoUtils.stringToStream(scanDatabaseRequest.toJsonString());
         handler.handleRequest(request, null, context);
         assertThat(client.getRequestEntries(), hasSize(1));
         var eventDetail = client.getRequestEntries().get(0).detail();
         var sentRequest = JsonUtils.dtoObjectMapper.readValue(eventDetail, ScanDatabaseRequest.class);
-        assertThat(sentRequest.pageSize(), is(equalTo(ScanDatabaseRequest.DEFAULT_PAGE_SIZE)));
+        assertThat(sentRequest.pageSize(), is(equalTo(DEFAULT_PAGE_SIZE)));
     }
 
     @Test
     void shouldSendInitialScanMessageForInitiatingBatchScanning() {
         var client = new FakeEventBridgeClient();
         var handler = new BatchScanStartHandler(client);
-        var scanDatabaseRequest = new ScanDatabaseRequest(1, null, TOPIC);
+        var scanDatabaseRequest = new ScanDatabaseRequest(1, null, null, TOPIC);
         var request = IoUtils.stringToStream(scanDatabaseRequest.toJsonString());
         handler.handleRequest(request, null, context);
         assertThat(client.getRequestEntries(), hasSize(1));

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -358,25 +358,6 @@ class EventBasedBatchScanHandlerTest extends LocalDynamoTest {
         return Objects.equals(item.version(), candidateRepository.getUniquenessEntry(item).version());
     }
 
-    private boolean isSameVersionAsRepositoryCopy(ApprovalStatusDao dao) {
-        return Objects.equals(dao.version(),
-                              candidateRepository.findApprovalDaoByIdAndInstitutionId(dao.identifier(),
-                                                                                      dao.approvalStatus()
-                                                                                          .institutionId())
-                                  .version());
-    }
-
-    private boolean isSameVersionAsRepositoryCopy(NviPeriodDao item) {
-        return Objects.equals(item.version(),
-                              periodRepository.findDaoByPublishingYear(item.nviPeriod().publishingYear())
-                                  .version());
-    }
-
-    private boolean isSameVersionAsRepositoryCopy(NoteDao dao) {
-        return Objects.equals(dao.version(),
-                              candidateRepository.getNoteDaoById(dao.identifier(), dao.note().noteId()).version());
-    }
-
     private ScanDatabaseRequest consumeLatestEmittedEvent() {
         var allRequests = eventBridgeClient.getRequestEntries();
         var latest = allRequests.remove(allRequests.size() - 1);

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -349,13 +349,11 @@ class EventBasedBatchScanHandlerTest extends LocalDynamoTest {
             return candidateRepository.getNoteDaoById(noteDao.identifier(), noteDao.note().noteId());
         } else if (dao instanceof NviPeriodDao nviPeriodDao) {
             return periodRepository.findDaoByPublishingYear(nviPeriodDao.nviPeriod().publishingYear());
+        } else if (dao instanceof CandidateUniquenessEntryDao candidateUniquenessEntryDao) {
+            return candidateRepository.getUniquenessEntry(candidateUniquenessEntryDao);
         } else {
             throw new IllegalArgumentException("Unknown type: " + dao);
         }
-    }
-
-    private boolean isSameVersionAsRepositoryCopy(CandidateUniquenessEntryDao item) {
-        return Objects.equals(item.version(), candidateRepository.getUniquenessEntry(item).version());
     }
 
     private ScanDatabaseRequest consumeLatestEmittedEvent() {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -44,7 +44,7 @@ import no.sikt.nva.nvi.common.model.CreateNoteRequest;
 import no.sikt.nva.nvi.common.model.ListingResult;
 import no.sikt.nva.nvi.common.service.NviService;
 import no.sikt.nva.nvi.common.service.model.Candidate;
-import no.sikt.nva.nvi.events.model.KeyField;
+import no.sikt.nva.nvi.common.db.model.KeyField;
 import no.sikt.nva.nvi.events.model.ScanDatabaseRequest;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.unit.nva.commons.json.JsonUtils;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -53,8 +53,6 @@ public class CandidateRepository extends DynamoRepository {
     public static final int DEFAULT_PAGE_SIZE = 700;
     private static final int BATCH_SIZE = 25;
     private static final long INITIAL_RETRY_WAIT_TIME_MS = 1000;
-    private static final String PRIMARY_KEY_HASH_KEY = "PrimaryKeyHashKey";
-    private static final String CANDIDATE_UNIQUENESS_ENTRY = "CandidateUniquenessEntry";
     protected final DynamoDbTable<CandidateDao> candidateTable;
     protected final DynamoDbTable<CandidateUniquenessEntryDao> uniquenessTable;
     protected final DynamoDbTable<ApprovalStatusDao> approvalStatusTable;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/Dao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/Dao.java
@@ -5,7 +5,12 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import no.sikt.nva.nvi.common.db.model.KeyField;
 import software.amazon.awssdk.enhanced.dynamodb.document.EnhancedDocument;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbIgnore;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
@@ -21,9 +26,40 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 public abstract class Dao implements DynamoEntryWithRangeKey {
 
+    public static final String KEY_FIELD_DELIMITER = "#";
+
+    public static String scanFilterExpressionForDataEntries(Collection<KeyField> types) {
+        return getTypesOrDefault(types).map(Dao::toQueryPart).collect(Collectors.joining(" or \n"));
+    }
+
+    public static Map<String, AttributeValue> scanFilterExpressionAttributeValues(Collection<KeyField> types) {
+        return getTypesOrDefault(types).map(Dao::createFilterExpression)
+                   .collect(Collectors.toMap(Entry::getKey, Entry::getValue));
+    }
+
     @DynamoDbIgnore
     public Map<String, AttributeValue> toDynamoFormat() {
         return EnhancedDocument.fromJson(attempt(() -> dynamoObjectMapper.writeValueAsString(this)).orElseThrow())
                    .toMap();
+    }
+
+    private static Entry<String, AttributeValue> createFilterExpression(KeyField keyField) {
+        return switch (keyField) {
+            case CANDIDATE ->
+                Map.entry(keyField.getKeyField(), AttributeValue.fromS(CandidateDao.TYPE + KEY_FIELD_DELIMITER));
+            case APPROVAL ->
+                Map.entry(keyField.getKeyField(), AttributeValue.fromS(ApprovalStatusDao.TYPE + KEY_FIELD_DELIMITER));
+            case NOTE -> Map.entry(keyField.getKeyField(), AttributeValue.fromS(NoteDao.TYPE + KEY_FIELD_DELIMITER));
+            case PERIOD ->
+                Map.entry(keyField.getKeyField(), AttributeValue.fromS(NviPeriodDao.TYPE + KEY_FIELD_DELIMITER));
+        };
+    }
+
+    private static Stream<KeyField> getTypesOrDefault(Collection<KeyField> types) {
+        return types.isEmpty() ? Stream.of(KeyField.values()) : types.stream();
+    }
+
+    private static String toQueryPart(KeyField type) {
+        return "begins_with (#PK, " + type.getKeyField() + ")";
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/KeyField.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/KeyField.java
@@ -1,4 +1,4 @@
-package no.sikt.nva.nvi.events.model;
+package no.sikt.nva.nvi.common.db.model;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
@@ -12,6 +12,7 @@ import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.Dao;
 import no.sikt.nva.nvi.common.db.NviPeriodDao.DbNviPeriod;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.db.model.KeyField;
 import no.sikt.nva.nvi.common.model.ListingResult;
 import no.sikt.nva.nvi.common.service.exception.PeriodNotFoundException;
 import nva.commons.core.JacocoGenerated;
@@ -65,8 +66,8 @@ public class NviService {
         return periodRepository.getPeriods();
     }
 
-    public ListingResult<Dao> migrateAndUpdateVersion(int pageSize, Map<String, String> startMarker) {
-        var scanResult = candidateRepository.scanEntries(pageSize, startMarker);
+    public ListingResult<Dao> migrateAndUpdateVersion(int pageSize, Map<String, String> startMarker, List<KeyField> types) {
+        var scanResult = candidateRepository.scanEntries(pageSize, startMarker, types);
         candidateRepository.writeEntries(scanResult.getDatabaseEntries());
         return scanResult;
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -45,7 +45,7 @@ public class MigrationTests extends LocalDynamoTest {
         periodRepository = periodRepositoryReturningOpenedPeriod(CURRENT_YEAR);
         nviService = new NviService(periodRepository, candidateRepository);
         var candidate = setupCandidateWithApprovalAndNotes();
-        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null);
+        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, null);
         var migratedCandidate = Candidate.fetch(candidate::getIdentifier, candidateRepository,
                                                 periodRepository);
         assertEquals(candidate, migratedCandidate);
@@ -54,7 +54,7 @@ public class MigrationTests extends LocalDynamoTest {
     @Test
     void shouldWriteBackPeriodAsIsWhenMigrating() {
         var period = nviService.createPeriod(createPeriod(String.valueOf(CURRENT_YEAR)));
-        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null);
+        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, null);
         var migratedPeriod = nviService.getPeriod(period.publishingYear());
         assertEquals(period, migratedPeriod);
     }
@@ -64,7 +64,7 @@ public class MigrationTests extends LocalDynamoTest {
         var publicationId = randomUri();
         var candidateToBeMigrated = getCandidateWithoutCreatedDateOrModifiedDate(publicationId);
         candidateRepository.create(candidateToBeMigrated, Collections.emptyList());
-        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null);
+        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, null);
         var migratedCandidate = candidateRepository.findByPublicationId(publicationId).orElseThrow();
         assertNotNull(migratedCandidate.candidate().createdDate());
         assertNotNull(migratedCandidate.candidate().modifiedDate());

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.common;
 
+import static java.util.Collections.emptyList;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createNoteRequest;
 import static no.sikt.nva.nvi.test.TestUtils.createPeriod;
@@ -12,7 +13,6 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.net.URI;
-import java.util.Collections;
 import java.util.Map.Entry;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
@@ -45,7 +45,7 @@ public class MigrationTests extends LocalDynamoTest {
         periodRepository = periodRepositoryReturningOpenedPeriod(CURRENT_YEAR);
         nviService = new NviService(periodRepository, candidateRepository);
         var candidate = setupCandidateWithApprovalAndNotes();
-        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, null);
+        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, emptyList());
         var migratedCandidate = Candidate.fetch(candidate::getIdentifier, candidateRepository,
                                                 periodRepository);
         assertEquals(candidate, migratedCandidate);
@@ -54,7 +54,7 @@ public class MigrationTests extends LocalDynamoTest {
     @Test
     void shouldWriteBackPeriodAsIsWhenMigrating() {
         var period = nviService.createPeriod(createPeriod(String.valueOf(CURRENT_YEAR)));
-        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, null);
+        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, emptyList());
         var migratedPeriod = nviService.getPeriod(period.publishingYear());
         assertEquals(period, migratedPeriod);
     }
@@ -63,8 +63,8 @@ public class MigrationTests extends LocalDynamoTest {
     void shouldSetCreatedDateAndModifiedDateIfMissingWhenMigrating() {
         var publicationId = randomUri();
         var candidateToBeMigrated = getCandidateWithoutCreatedDateOrModifiedDate(publicationId);
-        candidateRepository.create(candidateToBeMigrated, Collections.emptyList());
-        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, null);
+        candidateRepository.create(candidateToBeMigrated, emptyList());
+        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, emptyList());
         var migratedCandidate = candidateRepository.findByPublicationId(publicationId).orElseThrow();
         assertNotNull(migratedCandidate.candidate().createdDate());
         assertNotNull(migratedCandidate.candidate().modifiedDate());

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/model/KeyFieldTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/model/KeyFieldTest.java
@@ -1,0 +1,31 @@
+package no.sikt.nva.nvi.common.db.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIn.in;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import no.unit.nva.commons.json.JsonUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class KeyFieldTest {
+
+    public static final String UNKNOWN_VALUE = "ObviouslyUnknownValue";
+
+    @ParameterizedTest(name = "Should accept textual value {0} for enum")
+    @ValueSource(strings = {"candidate", "note", "approval_status", "period"})
+    void shouldAcceptTextualValueForEnum(String textualValue) throws JsonProcessingException {
+        var jsonString = String.format("\"%s\"", textualValue);
+        var actualValue = JsonUtils.dtoObjectMapper.readValue(jsonString, KeyField.class);
+        assertThat(actualValue, is(in(KeyField.values())));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenInputIsUnknownValue() {
+        Executable executable = () -> KeyField.parse(UNKNOWN_VALUE);
+        assertThrows(IllegalArgumentException.class, executable);
+    }
+}

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
@@ -50,7 +50,7 @@ public class NviServiceTest extends LocalDynamoTest {
     void shouldReturnTrueWhenThereAreMoreItemsToScan() {
         IntStream.range(0, 3).forEach(i -> candidateRepository.create(randomCandidate(), List.of()));
 
-        var result = nviService.migrateAndUpdateVersion(1, null);
+        var result = nviService.migrateAndUpdateVersion(1, null, null);
         assertThat(result.shouldContinueScan(), is(equalTo(true)));
     }
 
@@ -59,7 +59,7 @@ public class NviServiceTest extends LocalDynamoTest {
         IntStream.range(0, 2).forEach(i -> candidateRepository.create(randomCandidate(), List.of()));
         var candidates = getCandidatesInOrder();
         var originalRows = getCandidates(candidates);
-        nviService.migrateAndUpdateVersion(1000, getStartMarker(originalRows.get(FIRST_ROW)));
+        nviService.migrateAndUpdateVersion(1000, getStartMarker(originalRows.get(FIRST_ROW)), null);
         var modifiedRows = getCandidates(candidates);
 
         assertThat(modifiedRows.get(FIRST_ROW).version(), is(equalTo(originalRows.get(FIRST_ROW).version())));
@@ -71,7 +71,7 @@ public class NviServiceTest extends LocalDynamoTest {
         var originalCandidate = randomCandidate();
         var candidate = candidateRepository.create(originalCandidate, List.of());
         var original = candidateRepository.findCandidateById(candidate.identifier()).orElseThrow();
-        var result = nviService.migrateAndUpdateVersion(10, null);
+        var result = nviService.migrateAndUpdateVersion(10, null, null);
         var modified = candidateRepository.findCandidateById(candidate.identifier()).orElseThrow();
         assertThat(modified.version(), is(not(equalTo(original.version()))));
         assertThat(result.getStartMarker().size(), is(equalTo(0)));

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.common.service;
 
+import static java.util.Collections.emptyList;
 import static no.sikt.nva.nvi.test.TestUtils.createNumberOfCandidatesForYear;
 import static no.sikt.nva.nvi.test.TestUtils.getYearIndexStartMarker;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
@@ -50,7 +51,7 @@ public class NviServiceTest extends LocalDynamoTest {
     void shouldReturnTrueWhenThereAreMoreItemsToScan() {
         IntStream.range(0, 3).forEach(i -> candidateRepository.create(randomCandidate(), List.of()));
 
-        var result = nviService.migrateAndUpdateVersion(1, null, null);
+        var result = nviService.migrateAndUpdateVersion(1, null, emptyList());
         assertThat(result.shouldContinueScan(), is(equalTo(true)));
     }
 
@@ -59,7 +60,7 @@ public class NviServiceTest extends LocalDynamoTest {
         IntStream.range(0, 2).forEach(i -> candidateRepository.create(randomCandidate(), List.of()));
         var candidates = getCandidatesInOrder();
         var originalRows = getCandidates(candidates);
-        nviService.migrateAndUpdateVersion(1000, getStartMarker(originalRows.get(FIRST_ROW)), null);
+        nviService.migrateAndUpdateVersion(1000, getStartMarker(originalRows.get(FIRST_ROW)), emptyList());
         var modifiedRows = getCandidates(candidates);
 
         assertThat(modifiedRows.get(FIRST_ROW).version(), is(equalTo(originalRows.get(FIRST_ROW).version())));
@@ -71,7 +72,7 @@ public class NviServiceTest extends LocalDynamoTest {
         var originalCandidate = randomCandidate();
         var candidate = candidateRepository.create(originalCandidate, List.of());
         var original = candidateRepository.findCandidateById(candidate.identifier()).orElseThrow();
-        var result = nviService.migrateAndUpdateVersion(10, null, null);
+        var result = nviService.migrateAndUpdateVersion(10, null, emptyList());
         var modified = candidateRepository.findCandidateById(candidate.identifier()).orElseThrow();
         assertThat(modified.version(), is(not(equalTo(original.version()))));
         assertThat(result.getStartMarker().size(), is(equalTo(0)));


### PR DESCRIPTION
For data migration or reindexing, it would be more effective to be able to run batch scan for specific items in the database, to avoid unnecessary "event production".

Added:
- List of enum `KeyField` `types` in `ScanDatabaseRequest`
- Modified `scanEntries` method in `CandidateRepository` to add `types` in scan request

Similar to solution implemented in publication-api: [Batch scan dao type #1357](https://github.com/BIBSYSDEV/nva-publication-api/pull/1357)