### PR TITLE
Np 46382 Create note, set assignee if approval unassigned

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -377,7 +377,7 @@ class EventBasedBatchScanHandlerTest extends LocalDynamoTest {
                    .map(item -> Candidate.upsert(createUpsertCandidateRequest(randomUri()), candidateRepository,
                                                  periodRepository))
                    .map(Optional::orElseThrow)
-                   .map(a -> a.createNote(new CreateNoteRequest(randomString(), randomString())));
+                   .map(a -> a.createNote(new CreateNoteRequest(randomString(), randomString(), randomUri())));
     }
 
     private InputStream eventToInputStream(ScanDatabaseRequest scanDatabaseRequest) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/CreateNoteRequest.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/CreateNoteRequest.java
@@ -1,15 +1,8 @@
 package no.sikt.nva.nvi.common.model;
 
-public record CreateNoteRequest(String text, String username)
+import java.net.URI;
+
+public record CreateNoteRequest(String text, String username, URI institutionId)
     implements no.sikt.nva.nvi.common.service.requests.CreateNoteRequest {
 
-    @Override
-    public String text() {
-        return text;
-    }
-
-    @Override
-    public String username() {
-        return username;
-    }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Approval.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Approval.java
@@ -64,6 +64,10 @@ public class Approval {
         return reason;
     }
 
+    public boolean isAssigned() {
+        return nonNull(assignee) && nonNull(assignee.value());
+    }
+
     public Approval update(UpdateApprovalRequest input) {
         if (input instanceof UpdateAssigneeRequest request) {
             var newDao = repository.updateApprovalStatusDao(identifier, updateAssignee(request));
@@ -138,10 +142,6 @@ public class Approval {
         return new DbApprovalStatus(institutionId, DbStatus.REJECTED,
                                     assigneeOrUsername(username),
                                     username, Instant.now(), request.reason());
-    }
-
-    private boolean isAssigned() {
-        return nonNull(assignee) && nonNull(assignee.value());
     }
 
     private no.sikt.nva.nvi.common.db.model.Username assigneeOrUsername(

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/requests/CreateNoteRequest.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/requests/CreateNoteRequest.java
@@ -1,8 +1,11 @@
 package no.sikt.nva.nvi.common.service.requests;
 
+import java.net.URI;
+
 public interface CreateNoteRequest {
 
     String text();
 
     String username();
+    URI institutionId();
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateNotesTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateNotesTest.java
@@ -72,7 +72,7 @@ public class CandidateNotesTest extends LocalDynamoTest {
     void shouldDeleteNoteWhenValidDeleteNoteRequest() {
         var candidate = createCandidate();
         var username = randomString();
-        var candidateWithNote = candidate.createNote(new CreateNoteRequest(randomString(), username));
+        var candidateWithNote = candidate.createNote(new CreateNoteRequest(randomString(), username, randomUri()));
         var noteToDelete = candidateWithNote.toDto().notes().get(0);
         var updatedCandidate = candidate.deleteNote(new DeleteNoteRequest(noteToDelete.identifier(), username));
 
@@ -82,7 +82,7 @@ public class CandidateNotesTest extends LocalDynamoTest {
     @Test
     void shouldThrowUnauthorizedOperationExceptionWhenRequesterIsNotAnOwner() {
         var candidate = createCandidate();
-        var candidateWithNote = candidate.createNote(new CreateNoteRequest(randomString(), randomString()));
+        var candidateWithNote = candidate.createNote(new CreateNoteRequest(randomString(), randomString(), randomUri()));
         var noteToDelete = candidateWithNote.toDto().notes().get(0);
 
         assertThrows(UnauthorizedOperationException.class,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateNotesTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateNotesTest.java
@@ -10,13 +10,16 @@ import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.net.URI;
 import java.time.ZonedDateTime;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
-import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.service.exception.UnauthorizedOperationException;
+import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.requests.DeleteNoteRequest;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import org.junit.jupiter.api.BeforeEach;
@@ -82,15 +85,43 @@ public class CandidateNotesTest extends LocalDynamoTest {
     @Test
     void shouldThrowUnauthorizedOperationExceptionWhenRequesterIsNotAnOwner() {
         var candidate = createCandidate();
-        var candidateWithNote = candidate.createNote(new CreateNoteRequest(randomString(), randomString(), randomUri()));
+        var candidateWithNote = candidate.createNote(
+            new CreateNoteRequest(randomString(), randomString(), randomUri()));
         var noteToDelete = candidateWithNote.toDto().notes().get(0);
 
         assertThrows(UnauthorizedOperationException.class,
                      () -> candidate.deleteNote(new DeleteNoteRequest(noteToDelete.identifier(), randomString())));
     }
 
-    private Candidate createCandidate() {
-        return Candidate.upsert(createUpsertCandidateRequest(randomUri()), candidateRepository,
+    @Test
+    void shouldSetUserCreatingNoteAsAssigneeIfApprovalIsUnassigned() {
+        var institutionId = randomUri();
+        var candidate = createCandidate(institutionId);
+        var username = randomString();
+        var noteRequest = new CreateNoteRequest(randomString(), username, institutionId);
+        var candidateWithNote = candidate.createNote(noteRequest);
+        var actualAssignee = candidateWithNote.getApprovals().get(institutionId).getAssignee();
+        assertEquals(username, actualAssignee.value());
+    }
+
+    @Test
+    void shouldNotSetUserCreatingNoteAsAssigneeIfApprovalHasAssignee() {
+        var institutionId = randomUri();
+        var candidate = createCandidate(institutionId);
+        var existingAssignee = randomString();
+        candidate.updateApproval(new UpdateAssigneeRequest(institutionId, existingAssignee));
+        var noteRequest = new CreateNoteRequest(randomString(), randomString(), institutionId);
+        var candidateWithNote = candidate.createNote(noteRequest);
+        var actualAssignee = candidateWithNote.getApprovals().get(institutionId).getAssignee();
+        assertEquals(existingAssignee, actualAssignee.value());
+    }
+
+    private Candidate createCandidate(URI institutionId) {
+        return Candidate.upsert(createUpsertCandidateRequest(institutionId), candidateRepository,
                                 periodRepository).orElseThrow();
+    }
+
+    private Candidate createCandidate() {
+        return createCandidate(randomUri());
     }
 }

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
@@ -9,12 +9,12 @@ import java.util.Objects;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.exceptions.NotApplicableException;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
-import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
+import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.utils.ExceptionMapper;
 import no.sikt.nva.nvi.utils.RequestUtil;
-import no.sikt.nva.nvi.common.exceptions.NotApplicableException;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -46,9 +46,11 @@ public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, Candida
         validate(input);
         var username = RequestUtil.getUsername(requestInfo);
         var candidateIdentifier = UUID.fromString(requestInfo.getPathParameter(CANDIDATE_IDENTIFIER));
+        var institutionId = requestInfo.getTopLevelOrgCristinId().orElseThrow();
         return attempt(() -> Candidate.fetch(() -> candidateIdentifier, candidateRepository, periodRepository))
                    .map(this::checkIfApplicable)
-                   .map(candidate -> candidate.createNote(new CreateNoteRequest(input.text(), username.value())))
+                   .map(candidate -> candidate.createNote(new CreateNoteRequest(input.text(), username.value(),
+                                                                                institutionId)))
                    .map(Candidate::toDto)
                    .orElseThrow(ExceptionMapper::map);
     }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -166,20 +166,25 @@ public class CreateNoteHandlerTest extends LocalDynamoTest {
         return createRequest(identifier, body, userName, randomUri());
     }
 
-    private InputStream createRequest(UUID identifier, NviNoteRequest body, String userName, URI customerId1)
+    private InputStream createRequest(UUID identifier, NviNoteRequest body, String userName, URI institutionId)
         throws JsonProcessingException {
-        return new HandlerRequestBuilder<NviNoteRequest>(JsonUtils.dtoObjectMapper).withBody(body)
-                   .withCurrentCustomer(customerId1)
+        var customerId = randomUri();
+        return new HandlerRequestBuilder<NviNoteRequest>(JsonUtils.dtoObjectMapper)
+                   .withBody(body)
+                   .withCurrentCustomer(customerId)
+                   .withTopLevelCristinOrgId(institutionId)
                    .withPathParameters(Map.of("candidateIdentifier", identifier.toString()))
-                   .withAccessRights(customerId1, AccessRight.MANAGE_NVI_CANDIDATES)
+                   .withAccessRights(customerId, AccessRight.MANAGE_NVI_CANDIDATES)
                    .withUserName(userName)
                    .build();
     }
 
     private InputStream createRequest(UUID identifier, String body, String userName) throws JsonProcessingException {
         var customerId = randomUri();
-        return new HandlerRequestBuilder<String>(JsonUtils.dtoObjectMapper).withBody(body)
+        return new HandlerRequestBuilder<String>(JsonUtils.dtoObjectMapper)
+                   .withBody(body)
                    .withCurrentCustomer(customerId)
+                   .withTopLevelCristinOrgId(randomUri())
                    .withPathParameters(Map.of("candidateIdentifier", identifier.toString()))
                    .withAccessRights(customerId, AccessRight.MANAGE_NVI_CANDIDATES)
                    .withUserName(userName)

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -104,7 +104,7 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
     void shouldReturnConflictWhenRemovingNoteAndReportingPeriodIsClosed() throws IOException {
         var candidate = createCandidate();
         var user = randomString();
-        candidate.createNote(new CreateNoteRequest(randomString(), user));
+        candidate.createNote(new CreateNoteRequest(randomString(), user, randomUri()));
         var noteId = candidate.toDto().notes().get(0).identifier();
         var request = createRequest(candidate.getIdentifier(), noteId, user).build();
         handler = new RemoveNoteHandler(candidateRepository, periodRepositoryReturningClosedPeriod(YEAR));
@@ -125,7 +125,7 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
     }
 
     private Candidate createNote(Candidate candidate, Username user) {
-        return candidate.createNote(new CreateNoteRequest(randomString(), user.value()));
+        return candidate.createNote(new CreateNoteRequest(randomString(), user.value(), randomUri()));
     }
 
     private Candidate createCandidate() {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -382,7 +382,7 @@ public final class TestUtils {
     }
 
     public static CreateNoteRequest createNoteRequest(String text, String username) {
-        return new CreateNoteRequest(text, username);
+        return new CreateNoteRequest(text, username, randomUri());
     }
 
     private static DbCandidate randomCandidateWithYear(String year) {


### PR DESCRIPTION
Jira issue: [When a Curator adds a message to a NVI-candidate they are not set as Curator for the NVI-Candidate](https://unit.atlassian.net/browse/NP-46382)

- Set user as `assignee` if users top level org has an `Approval` for `Candidate`
- Add institutionId in `CreateNoteRequest`