### PR TITLE
NP-46476 Index document, global approval status Dispute

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -8,8 +8,8 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
-import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
 import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 
@@ -25,7 +25,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         int numberOfApprovals,
                                         BigDecimal points,
                                         BigDecimal publicationTypeChannelLevelPoints,
-                                        ApprovalStatus globalApprovalStatus,
+                                        GlobalApprovalStatus globalApprovalStatus,
                                         int creatorShareCount,
                                         BigDecimal internationalCollaborationFactor,
                                         ReportingPeriod reportingPeriod,
@@ -57,7 +57,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         private int numberOfApprovals;
         private BigDecimal points;
         private BigDecimal publicationTypeChannelLevelPoints;
-        private ApprovalStatus globalApprovalStatus;
+        private GlobalApprovalStatus globalApprovalStatus;
         private int creatorShareCount;
         private BigDecimal internationalCollaborationFactor;
         private ReportingPeriod reportingPeriod;
@@ -112,7 +112,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
             return this;
         }
 
-        public Builder withGlobalApprovalStatus(ApprovalStatus globalApprovalStatus) {
+        public Builder withGlobalApprovalStatus(GlobalApprovalStatus globalApprovalStatus) {
             this.globalApprovalStatus = globalApprovalStatus;
             return this;
         }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -221,13 +221,15 @@ public final class Candidate {
         return REPORTED.equals(reportStatus);
     }
 
-    public ApprovalStatus getGlobalApprovalStatus() {
-        if (areAllApprovalStatusesEqualTo(APPROVED)) {
-            return APPROVED;
+    public GlobalApprovalStatus getGlobalApprovalStatus() {
+        if (areAnyApprovalsPending()) {
+            return GlobalApprovalStatus.PENDING;
+        } else if (areAllApprovalStatusesEqualTo(APPROVED)) {
+            return GlobalApprovalStatus.APPROVED;
         } else if (areAllApprovalStatusesEqualTo(REJECTED)) {
-            return REJECTED;
+            return GlobalApprovalStatus.REJECTED;
         } else {
-            return ApprovalStatus.PENDING;
+            return GlobalApprovalStatus.DISPUTE;
         }
     }
 
@@ -577,6 +579,10 @@ public final class Candidate {
 
     private boolean areAllApprovalStatusesEqualTo(ApprovalStatus approvalStatus) {
         return approvals.values().stream().map(Approval::getStatus).allMatch(approvalStatus::equals);
+    }
+
+    private boolean areAnyApprovalsPending() {
+        return approvals.values().stream().anyMatch(approval -> ApprovalStatus.PENDING.equals(approval.getStatus()));
     }
 
     private PublicationDetails mapToPublicationDetails(CandidateDao candidateDao) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -23,6 +23,7 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
@@ -222,14 +223,14 @@ public final class Candidate {
     }
 
     public GlobalApprovalStatus getGlobalApprovalStatus() {
-        if (areAnyApprovalsPending()) {
-            return GlobalApprovalStatus.PENDING;
-        } else if (areAllApprovalStatusesEqualTo(APPROVED)) {
-            return GlobalApprovalStatus.APPROVED;
-        } else if (areAllApprovalStatusesEqualTo(REJECTED)) {
-            return GlobalApprovalStatus.REJECTED;
-        } else {
+        if (isDispute()) {
             return GlobalApprovalStatus.DISPUTE;
+        } else if (areAnyApprovalsPending()) {
+            return GlobalApprovalStatus.PENDING;
+        } else if (areAllApprovalsApproved()) {
+            return GlobalApprovalStatus.APPROVED;
+        } else {
+            return GlobalApprovalStatus.REJECTED;
         }
     }
 
@@ -577,12 +578,22 @@ public final class Candidate {
                    : approval.update(new UpdateAssigneeRequest(approval.getInstitutionId(), username));
     }
 
-    private boolean areAllApprovalStatusesEqualTo(ApprovalStatus approvalStatus) {
-        return approvals.values().stream().map(Approval::getStatus).allMatch(approvalStatus::equals);
+    private boolean isDispute() {
+        var approvalStatuses = streamApprovals().map(Approval::getStatus).toList();
+        return approvalStatuses.stream().anyMatch(APPROVED::equals)
+               && approvalStatuses.stream().anyMatch(REJECTED::equals);
+    }
+
+    private boolean areAllApprovalsApproved() {
+        return streamApprovals().map(Approval::getStatus).allMatch(ApprovalStatus.APPROVED::equals);
     }
 
     private boolean areAnyApprovalsPending() {
-        return approvals.values().stream().anyMatch(approval -> ApprovalStatus.PENDING.equals(approval.getStatus()));
+        return streamApprovals().anyMatch(approval -> ApprovalStatus.PENDING.equals(approval.getStatus()));
+    }
+
+    private Stream<Approval> streamApprovals() {
+        return approvals.values().stream();
     }
 
     private PublicationDetails mapToPublicationDetails(CandidateDao candidateDao) {
@@ -615,7 +626,7 @@ public final class Candidate {
     }
 
     private List<ApprovalDto> mapToApprovalDtos() {
-        return approvals.values().stream().map(this::mapToApprovalDto).toList();
+        return streamApprovals().map(this::mapToApprovalDto).toList();
     }
 
     private ApprovalDto mapToApprovalDto(Approval approval) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -585,7 +585,7 @@ public final class Candidate {
     }
 
     private boolean areAllApprovalsApproved() {
-        return streamApprovals().map(Approval::getStatus).allMatch(ApprovalStatus.APPROVED::equals);
+        return streamApprovals().map(Approval::getStatus).allMatch(APPROVED::equals);
     }
 
     private boolean areAnyApprovalsPending() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/GlobalApprovalStatus.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/GlobalApprovalStatus.java
@@ -1,0 +1,19 @@
+package no.sikt.nva.nvi.common.service.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum GlobalApprovalStatus {
+
+    APPROVED("Approved"), PENDING("Pending"), REJECTED("Rejected"), DISPUTE("Dispute");
+
+    @JsonValue
+    private final String value;
+
+    GlobalApprovalStatus(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -265,14 +265,17 @@ class CandidateTest extends LocalDynamoTest {
     }
 
     @Test()
-    @DisplayName("Should return global approval status dispute when all approvals are processed but conflicts exist")
-    void shouldReturnGlobalApprovalStatusDisputeWhenAllApprovalsAreProcessedButConflictsExist() {
+    @DisplayName("Should return global approval status dispute when a candidate has at least one Rejected and one "
+                 + "Approved approval")
+    void shouldReturnGlobalApprovalStatusDisputeWhenConflictsExist() {
         var institution1 = randomUri();
         var institution2 = randomUri();
-        var createRequest = createUpsertCandidateRequest(institution1, institution2);
+        var institution3 = randomUri();
+        var createRequest = createUpsertCandidateRequest(institution1, institution2, institution3);
         var candidate = Candidate.upsert(createRequest, candidateRepository, periodRepository).orElseThrow();
         candidate.updateApproval(createUpdateStatusRequest(ApprovalStatus.APPROVED, institution1, randomString()));
         candidate.updateApproval(createUpdateStatusRequest(ApprovalStatus.REJECTED, institution2, randomString()));
+        assertEquals(ApprovalStatus.PENDING, candidate.getApprovals().get(institution3).getStatus());
         assertEquals(GlobalApprovalStatus.DISPUTE, candidate.getGlobalApprovalStatus());
     }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -259,9 +259,7 @@ class CandidateTest extends LocalDynamoTest {
     @Test()
     @DisplayName("Should return global approval status pending when any approval is pending")
     void shouldReturnGlobalApprovalStatusPendingWhenAnyApprovalIsPending() {
-        var institution1 = randomUri();
-        var institution2 = randomUri();
-        var createRequest = createUpsertCandidateRequest(institution1, institution2);
+        var createRequest = createUpsertCandidateRequest(randomUri());
         var candidate = Candidate.upsert(createRequest, candidateRepository, periodRepository).orElseThrow();
         assertEquals(GlobalApprovalStatus.PENDING, candidate.getGlobalApprovalStatus());
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -68,6 +68,7 @@ import no.sikt.nva.nvi.common.service.dto.PeriodStatusDto;
 import no.sikt.nva.nvi.common.service.exception.CandidateNotFoundException;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
@@ -252,19 +253,29 @@ class CandidateTest extends LocalDynamoTest {
         var candidate = Candidate.upsert(createRequest, candidateRepository, periodRepository).orElseThrow();
         candidate.updateApproval(createUpdateStatusRequest(approvalStatus, institution1, randomString()));
         candidate.updateApproval(createUpdateStatusRequest(approvalStatus, institution2, randomString()));
-        assertEquals(approvalStatus, candidate.getGlobalApprovalStatus());
+        assertEquals(approvalStatus.getValue(), candidate.getGlobalApprovalStatus().getValue());
     }
 
     @Test()
-    @DisplayName("Should return global approval status pending when all approvals neither approved or rejected")
-    void shouldReturnGlobalApprovalStatusPendingWhenAllApprovalDoNotHaveSameStatus() {
+    @DisplayName("Should return global approval status pending when any approval is pending")
+    void shouldReturnGlobalApprovalStatusPendingWhenAnyApprovalIsPending() {
+        var institution1 = randomUri();
+        var institution2 = randomUri();
+        var createRequest = createUpsertCandidateRequest(institution1, institution2);
+        var candidate = Candidate.upsert(createRequest, candidateRepository, periodRepository).orElseThrow();
+        assertEquals(GlobalApprovalStatus.PENDING, candidate.getGlobalApprovalStatus());
+    }
+
+    @Test()
+    @DisplayName("Should return global approval status dispute when all approvals are processed but conflicts exist")
+    void shouldReturnGlobalApprovalStatusDisputeWhenAllApprovalsAreProcessedButConflictsExist() {
         var institution1 = randomUri();
         var institution2 = randomUri();
         var createRequest = createUpsertCandidateRequest(institution1, institution2);
         var candidate = Candidate.upsert(createRequest, candidateRepository, periodRepository).orElseThrow();
         candidate.updateApproval(createUpdateStatusRequest(ApprovalStatus.APPROVED, institution1, randomString()));
         candidate.updateApproval(createUpdateStatusRequest(ApprovalStatus.REJECTED, institution2, randomString()));
-        assertEquals(ApprovalStatus.PENDING, candidate.getGlobalApprovalStatus());
+        assertEquals(GlobalApprovalStatus.DISPUTE, candidate.getGlobalApprovalStatus());
     }
 
     @Test


### PR DESCRIPTION
Jira issue: [Add Dispute (tvist) as enum value for global approval status](https://unit.atlassian.net/browse/NP-46476)

Global approval status value `Dispute` (også kjent som tvist) is required in data export and institution reports. See `RAPPORTSTATUS` in [instruks](https://www.cristin.no/nvi-rapportering/nvi-veiledninger/hvordan_lese_nvi-kontrolldata.html).

- If at least two institutions disagree on whether the candidate should be approved or rejected (one approved approval and one rejected approval), set `globalApprovalStatus` `Dispute` in index document.