### PR TITLE
Migrate CandidateDao periodYear

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -180,8 +180,9 @@ public final class CandidateDao extends Dao {
         return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
     }
 
+    @DynamoDbAttribute(PERIOD_YEAR_FIELD)
     public String periodYear() {
-        return periodYear;
+        return isNull(periodYear) ? candidate.publicationDate().year() : periodYear;
     }
 
     public enum DbLevel {
@@ -395,7 +396,8 @@ public final class CandidateDao extends Dao {
             return Objects.hash(publicationId, publicationBucketUri, applicable, instanceType, channelType, channelId,
                                 level,
                                 publicationDate, internationalCollaboration, collaborationFactor, creatorCount,
-                                creatorShareCount, creators, basePoints, points, totalPoints, createdDate, reportStatus);
+                                creatorShareCount, creators, basePoints, points, totalPoints, createdDate,
+                                reportStatus);
         }
 
         @Deprecated

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -182,7 +182,16 @@ public final class CandidateDao extends Dao {
 
     @DynamoDbAttribute(PERIOD_YEAR_FIELD)
     public String periodYear() {
-        return isNull(periodYear) ? candidate.publicationDate().year() : periodYear;
+        return migratePeriodYear();
+    }
+
+    @Deprecated
+    private String migratePeriodYear() {
+        return isApplicableAndMissingPeriodYear() ? candidate.publicationDate().year() : periodYear;
+    }
+
+    private boolean isApplicableAndMissingPeriodYear() {
+        return isNull(periodYear) && candidate.applicable();
     }
 
     public enum DbLevel {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -7,6 +7,7 @@ import static no.sikt.nva.nvi.test.TestUtils.createPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
+import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -68,6 +69,16 @@ public class MigrationTests extends LocalDynamoTest {
         var migratedCandidate = candidateRepository.findByPublicationId(publicationId).orElseThrow();
         assertNotNull(migratedCandidate.candidate().createdDate());
         assertNotNull(migratedCandidate.candidate().modifiedDate());
+    }
+
+    @Test
+    void shouldSetPeriodYearIfMissingWhenMigrating() {
+        var dbCandidate = randomCandidate();
+        var existingDao = candidateRepository.create(dbCandidate, emptyList(), null);
+        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, emptyList());
+        var migratedCandidate = candidateRepository.findCandidateById(existingDao.identifier()).orElseThrow();
+        assertNotNull(migratedCandidate.periodYear());
+        assertEquals(dbCandidate.publicationDate().year(), migratedCandidate.periodYear());
     }
 
     private static DbCandidate getCandidateWithoutCreatedDateOrModifiedDate(URI publicationId) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -8,11 +8,13 @@ import static no.sikt.nva.nvi.test.TestUtils.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
+import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import java.net.URI;
 import java.util.Map.Entry;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
@@ -79,6 +81,15 @@ public class MigrationTests extends LocalDynamoTest {
         var migratedCandidate = candidateRepository.findCandidateById(existingDao.identifier()).orElseThrow();
         assertNotNull(migratedCandidate.periodYear());
         assertEquals(dbCandidate.publicationDate().year(), migratedCandidate.periodYear());
+    }
+
+    @Test
+    void shouldNotMigratePeriodYearCandidateIsNotApplicable() {
+        var dbCandidate = randomCandidateBuilder(false).build();
+        var existingDao = candidateRepository.create(dbCandidate, emptyList(), null);
+        nviService.migrateAndUpdateVersion(DEFAULT_PAGE_SIZE, null, emptyList());
+        var migratedCandidate = candidateRepository.findCandidateById(existingDao.identifier()).orElseThrow();
+        assertNull(migratedCandidate.periodYear());
     }
 
     private static DbCandidate getCandidateWithoutCreatedDateOrModifiedDate(URI publicationId) {


### PR DESCRIPTION
Noticed that a lot of (applicable) `CandidateDao`s in database in test environment are missing attribute `periodYear`. Was not able to find root cause. @truhacevkir pushed [setting currect publication year when resetting candidate](https://github.com/BIBSYSDEV/nva-nvi/commit/3069c72677caafa3592b9b3fe9cc0531cc5af502).

This attribute is required to export nvi reports for institutions.

- Added code for migrating `periodYear` in `CandidateDao` if missing.