### PR TITLE
summarazing point per approval institution

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
@@ -78,11 +78,16 @@ public final class CristinMapper {
     private static List<DbInstitutionPoints> calculatePoints(CristinNviReport cristinNviReport) {
         var institutions = cristinNviReport.cristinLocales();
         return getCreators(cristinNviReport).stream()
+                   .filter(CristinMapper::hasInstitutionPoints)
                    .collect(collectToMapOfPoints(institutions))
                    .entrySet()
                    .stream()
                    .map(CristinMapper::toDbInstitutionPoints)
                    .collect(Collectors.toList());
+    }
+
+    private static boolean hasInstitutionPoints(ScientificPerson scientificPerson) {
+        return nonNull(scientificPerson.getAuthorPointsForAffiliation());
     }
 
     private static DbInstitutionPoints toDbInstitutionPoints(Entry<URI, BigDecimal> entry) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
@@ -42,7 +42,7 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
         return null;
     }
 
-    private static DbCandidate createDbCandidate(CristinNviReport cristinNviReport, List<DbApprovalStatus> approvals) {
+    private static DbCandidate createDbCandidate(CristinNviReport cristinNviReport) {
         return attempt(() -> CristinMapper.toDbCandidate(cristinNviReport)).orElseThrow(
             CristinConversionException::fromFailure);
     }
@@ -91,7 +91,7 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
 
     private CandidateDao createAndPersist(CristinNviReport cristinNviReport) {
         var approvals = createApprovals(cristinNviReport);
-        var candidate = createDbCandidate(cristinNviReport, approvals);
+        var candidate = createDbCandidate(cristinNviReport);
         return repository.create(candidate, approvals,
                                  String.valueOf(cristinNviReport.yearReported()));
     }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
@@ -42,7 +42,7 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
         return null;
     }
 
-    private static DbCandidate createDbCandidate(CristinNviReport cristinNviReport) {
+    private static DbCandidate createDbCandidate(CristinNviReport cristinNviReport, List<DbApprovalStatus> approvals) {
         return attempt(() -> CristinMapper.toDbCandidate(cristinNviReport)).orElseThrow(
             CristinConversionException::fromFailure);
     }
@@ -90,7 +90,9 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
     }
 
     private CandidateDao createAndPersist(CristinNviReport cristinNviReport) {
-        return repository.create(createDbCandidate(cristinNviReport), createApprovals(cristinNviReport),
+        var approvals = createApprovals(cristinNviReport);
+        var candidate = createDbCandidate(cristinNviReport, approvals);
+        return repository.create(candidate, approvals,
                                  String.valueOf(cristinNviReport.yearReported()));
     }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinMapperTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinMapperTest.java
@@ -6,6 +6,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.net.URI;
 import java.util.List;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
@@ -37,7 +38,7 @@ class CristinMapperTest {
         var expectedInstitutionId = constructExpectedInstitutionId(cristinLocale);
         var expectedPointsForInstitution = BigDecimal.ZERO
                                                .add(new BigDecimal(POINTS_PER_CONTRIBUTOR))
-                                               .add(new BigDecimal(POINTS_PER_CONTRIBUTOR)).setScale(1);
+                                               .add(new BigDecimal(POINTS_PER_CONTRIBUTOR)).setScale(4, RoundingMode.HALF_UP);
 
         assertEquals(dbCandidate.points().get(0).points(), expectedPointsForInstitution);
         assertEquals(institutionId, expectedInstitutionId);

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinMapperTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinMapperTest.java
@@ -1,16 +1,98 @@
 package no.sikt.nva.nvi.events.cristin;
 
+import static no.sikt.nva.nvi.events.cristin.CristinMapper.AFFILIATION_DELIMITER;
+import static no.sikt.nva.nvi.events.cristin.CristinMapper.API_HOST;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import java.math.BigDecimal;
+import java.net.URI;
 import java.util.List;
+import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
+import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.Test;
 
 class CristinMapperTest {
 
+    public static final double POINTS_PER_CONTRIBUTOR = 2.0;
+
     @Test
     void shouldThrowNullPointerExceptionWhenQualityCodeIsMissing() {
         var empty = emptyScientificResource();
-        var build = CristinNviReport.builder().withScientificResources(List.of(empty)).build();
-        assertThrows(NullPointerException.class, () -> CristinMapper.toDbCandidate(build));
+        var report = CristinNviReport.builder().withScientificResources(List.of(empty)).build();
+        assertThrows(NullPointerException.class, () -> CristinMapper.toDbCandidate(report));
+    }
+
+    @Test
+    void shouldUseCristinLocaleInstitutionWhenSummarizingPoints() {
+        var institutionIdentifier = randomString();
+        var creators = List.of(scientificPersonAtInstitutionWithPoints(institutionIdentifier, POINTS_PER_CONTRIBUTOR),
+                               scientificPersonAtInstitutionWithPoints(institutionIdentifier, POINTS_PER_CONTRIBUTOR));
+        var scientificResource = scientificResourceWithCreators(creators);
+        var cristinLocale = cristinLocaleWithInstitutionIdentifier(institutionIdentifier);
+        var report = cristinReportFromCristinLocalesAndScientificResource(cristinLocale, scientificResource);
+        var dbCandidate = CristinMapper.toDbCandidate(report);
+
+        var institutionId = dbCandidate.points().get(0).institutionId();
+        var expectedInstitutionId = constructExpectedInstitutionId(cristinLocale);
+        var expectedPointsForInstitution = BigDecimal.ZERO
+                                               .add(new BigDecimal(POINTS_PER_CONTRIBUTOR))
+                                               .add(new BigDecimal(POINTS_PER_CONTRIBUTOR)).setScale(1);
+
+        assertEquals(dbCandidate.points().get(0).points(), expectedPointsForInstitution);
+        assertEquals(institutionId, expectedInstitutionId);
+    }
+
+    private static ScientificResource scientificResourceWithCreators(List<ScientificPerson> creators) {
+        return ScientificResource.build()
+                   .withScientificPeople(creators)
+                   .withQualityCode(randomString())
+                   .build();
+    }
+
+    private static CristinNviReport cristinReportFromCristinLocalesAndScientificResource(CristinLocale cristinLocales,
+                                                                                         ScientificResource scientificResource) {
+        return CristinNviReport.builder()
+                   .withPublicationIdentifier(randomString())
+                   .withYearReported(randomString())
+                   .withInstanceType(randomString())
+                   .withPublicationDate(new PublicationDate(randomString(), randomString(), randomString()))
+                   .withCristinLocales(List.of(cristinLocales))
+                   .withScientificResources(List.of(scientificResource))
+                   .build();
+    }
+
+    private static CristinLocale cristinLocaleWithInstitutionIdentifier(String institutionIdentifier) {
+        return CristinLocale.builder()
+                   .withDepartmentIdentifier(randomString())
+                   .withSubDepartmentIdentifier(randomString())
+                   .withDepartmentIdentifier(randomString())
+                   .withGroupIdentifier(randomString())
+                   .withInstitutionIdentifier(institutionIdentifier)
+                   .build();
+    }
+
+    private static ScientificPerson scientificPersonAtInstitutionWithPoints(String institutionIdentifier,
+                                                                            double points) {
+        return ScientificPerson.builder()
+                   .withInstitutionIdentifier(institutionIdentifier)
+                   .withDepartmentIdentifier(randomString())
+                   .withSubDepartmentIdentifier(randomString())
+                   .withGroupIdentifier(randomString())
+                   .withPublicationTypeLevelPoints("1.0")
+                   .withAuthorPointsForAffiliation(String.valueOf(points))
+                   .build();
+    }
+
+    private URI constructExpectedInstitutionId(CristinLocale locale) {
+        var identifier = locale.getInstitutionIdentifier()
+                         + AFFILIATION_DELIMITER
+                         + locale.getDepartmentIdentifier()
+                         + AFFILIATION_DELIMITER
+                         + locale.getSubDepartmentIdentifier()
+                         + AFFILIATION_DELIMITER
+                         + locale.getGroupIdentifier();
+        return UriWrapper.fromHost(API_HOST).addChild("cristin").addChild("organization").addChild(identifier).getUri();
     }
 
     private ScientificResource emptyScientificResource() {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
@@ -167,13 +167,14 @@ class CristinNviReportEventConsumerTest extends LocalDynamoTest {
     }
 
     private CristinNviReport randomCristinNviReport() {
+        var institutionIdentifier = randomString();
         return CristinNviReport.builder()
                    .withCristinIdentifier(randomString())
                    .withPublicationIdentifier(randomUUID().toString())
                    .withYearReported(randomYear())
                    .withPublicationDate(randomPublicationDate())
-                   .withCristinLocales(List.of(randomCristinLocale()))
-                   .withScientificResources(List.of(scientificResource()))
+                   .withCristinLocales(List.of(randomCristinLocale(institutionIdentifier)))
+                   .withScientificResources(List.of(scientificResource(institutionIdentifier)))
                    .withInstanceType(randomString())
                    .withReference(randomString())
                    .build();
@@ -185,25 +186,26 @@ class CristinNviReportEventConsumerTest extends LocalDynamoTest {
                    .build();
     }
 
-    private ScientificResource scientificResource() {
+    private ScientificResource scientificResource(String institutionIdentifier) {
         var cristinIdentifier = randomString();
         return ScientificResource.build()
                    .withQualityCode("1")
                    .withReportedYear(randomYear())
-                   .withScientificPeople(List.of(scientificPersonWithCristinIdentifier(cristinIdentifier),
-                                                 scientificPersonWithCristinIdentifier(cristinIdentifier)))
+                   .withScientificPeople(List.of(scientificPersonWithCristinIdentifier(cristinIdentifier, institutionIdentifier),
+                                                 scientificPersonWithCristinIdentifier(cristinIdentifier, institutionIdentifier)))
                    .build();
     }
 
-    private ScientificPerson scientificPersonWithCristinIdentifier(String cristinIdentifier) {
+    private ScientificPerson scientificPersonWithCristinIdentifier(String personIdentifier,
+                                                                   String institutionIdentifier) {
         return ScientificPerson.builder()
-                   .withCristinPersonIdentifier(cristinIdentifier)
-                   .withInstitutionIdentifier(randomString())
+                   .withCristinPersonIdentifier(personIdentifier)
+                   .withInstitutionIdentifier(institutionIdentifier)
                    .withDepartmentIdentifier(randomString())
                    .withSubDepartmentIdentifier(randomString())
                    .withGroupIdentifier(randomString())
                    .withGroupIdentifier(randomString())
-                   .withAuthorPointsForAffiliation(randomString())
+                   .withAuthorPointsForAffiliation("1.0")
                    .withCollaborationFactor(randomString())
                    .withPublicationTypeLevelPoints(randomString())
                    .build();
@@ -215,11 +217,11 @@ class CristinNviReportEventConsumerTest extends LocalDynamoTest {
                                    randomString());
     }
 
-    private CristinLocale randomCristinLocale() {
+    private CristinLocale randomCristinLocale(String institutionIdentifier) {
         return CristinLocale.builder()
                    .withDateControlled(DATE_CONTROLLED)
                    .withControlStatus(STATUS_CONTROLLED)
-                   .withInstitutionIdentifier(randomString())
+                   .withInstitutionIdentifier(institutionIdentifier)
                    .withDepartmentIdentifier(randomString())
                    .withOwnerCode(randomString())
                    .withGroupIdentifier(randomString())


### PR DESCRIPTION
Cristin object looks like this:

Each **h_dbh_forskres_forfatter** has points for his affiliation. 
**CristinLocales** contains approvals for each topLevelOrganization. 

When crafting points, we summarize points for each **h_dbh_forskres_forfatter** at **institusjonsnr** and use topLevelOrg from CristinLocale to create institution points

```
{
  "publicationIdentifier": "018dc1025afe-4a3747e4-0f53-4602-84cb-10e66a941abd",
  "scientificResources": [
    {
      "h_dbh_forskres_forfatter": [
        {
          "personlopenr": "58612",
          "institusjonsnr": "186",
          "avdnr": "33",
          "undavdnr": "81",
          "gruppenr": "0"
        },
        {
          "personlopenr": "58613",
          "institusjonsnr": "186",
          "avdnr": "33",
          "undavdnr": "81",
          "gruppenr": "0"
        }
      ],
      "kvalitetsnivakode": "2",
      "arstall": "2011"
    }
  ],
  "cristinLocales": [
    {
      "eierkode": "UITO",
      "institusjonsnr": "186",
      "avdnr": "0",
      "undavdnr": "0",
      "gruppenr": "0",
      "brukernavn_kontrollert": "eer000",
      "dato_kontrollert": "2012-02-14",
      "status_kontrollert": "J"
    }
  ],
  "yearReported": "2011",
  "publicationDate": {
    "type": "PublicationDate",
    "year": "2011"
  },
  "instanceType": "AcademicChapter"
}
```