### PR TITLE
Np 46529 EvaluateNviCandidateHandler: Send points for affiliation

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -20,13 +20,14 @@ import java.util.stream.Collectors;
 import no.sikt.nva.nvi.common.StorageReader;
 import no.sikt.nva.nvi.events.evaluator.calculator.CandidateCalculator;
 import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints;
-import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints.AffiliationPoints;
+import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints.InstitutionAffiliationPoints;
 import no.sikt.nva.nvi.events.evaluator.model.PointCalculation;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.CandidateType;
 import no.sikt.nva.nvi.events.model.NonNviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate.NviCreatorWithAffiliationPoints;
+import no.sikt.nva.nvi.events.model.NviCandidate.NviCreatorWithAffiliationPoints.AffiliationPoints;
 import no.sikt.nva.nvi.events.model.NviCandidate.PublicationDate;
 
 public class EvaluatorService {
@@ -86,8 +87,8 @@ public class EvaluatorService {
     private static List<NviCreatorWithAffiliationPoints> mapToNviCreatorWithAffiliationPoints(
         PointCalculation pointCalculation) {
         return pointCalculation.institutionPoints().stream()
-                   .flatMap(institutionPoints -> institutionPoints.affiliationPoints().stream())
-                   .collect(Collectors.groupingBy(AffiliationPoints::nviCreator))
+                   .flatMap(institutionPoints -> institutionPoints.institutionAffiliationPoints().stream())
+                   .collect(Collectors.groupingBy(InstitutionAffiliationPoints::nviCreator))
                    .entrySet()
                    .stream()
                    .map(entry -> new NviCreatorWithAffiliationPoints(entry.getKey(), mapToAffiliationPoints(entry)))
@@ -95,11 +96,9 @@ public class EvaluatorService {
     }
 
     private static List<NviCreatorWithAffiliationPoints.AffiliationPoints> mapToAffiliationPoints(
-        Entry<URI, List<AffiliationPoints>> entry) {
+        Entry<URI, List<InstitutionAffiliationPoints>> entry) {
         return entry.getValue().stream()
-                   .map(affiliationPoints -> new NviCreatorWithAffiliationPoints.AffiliationPoints(
-                       affiliationPoints.affiliationId(),
-                       affiliationPoints.points()))
+                   .map(AffiliationPoints::from)
                    .toList();
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -14,19 +14,19 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import no.sikt.nva.nvi.common.StorageReader;
 import no.sikt.nva.nvi.events.evaluator.calculator.CandidateCalculator;
 import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints;
+import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints.AffiliationPoints;
 import no.sikt.nva.nvi.events.evaluator.model.PointCalculation;
-import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.CandidateType;
 import no.sikt.nva.nvi.events.model.NonNviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate;
-import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator;
-import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator.AffiliationPoints;
+import no.sikt.nva.nvi.events.model.NviCandidate.NviCreatorWithAffiliationPoints;
 import no.sikt.nva.nvi.events.model.NviCandidate.PublicationDate;
 
 public class EvaluatorService {
@@ -49,8 +49,8 @@ public class EvaluatorService {
             publication);
         if (!verifiedCreatorsWithNviInstitutions.isEmpty()) {
             var pointCalculation = pointService.calculatePoints(publication, verifiedCreatorsWithNviInstitutions);
-            var nviCandidate = constructNviCandidate(publication, verifiedCreatorsWithNviInstitutions, pointCalculation,
-                                                     publicationId, publicationBucketUri);
+            var nviCandidate = constructNviCandidate(publication, pointCalculation, publicationId,
+                                                     publicationBucketUri);
             return constructMessage(nviCandidate);
         } else {
             return constructMessage(new NonNviCandidate(publicationId));
@@ -58,7 +58,6 @@ public class EvaluatorService {
     }
 
     private static NviCandidate constructNviCandidate(JsonNode jsonNode,
-                                                      List<VerifiedNviCreator> nviCreators,
                                                       PointCalculation pointCalculation, URI publicationId,
                                                       URI publicationBucketUri) {
         return NviCandidate.builder()
@@ -74,7 +73,7 @@ public class EvaluatorService {
                    .withCollaborationFactor(pointCalculation.collaborationFactor())
                    .withCreatorShareCount(pointCalculation.creatorShareCount())
                    .withInstitutionPoints(mapToInstitutionPoints(pointCalculation.institutionPoints()))
-                   .withVerifiedCreators(mapToCreators(nviCreators))
+                   .withVerifiedCreators(mapToNviCreatorWithAffiliationPoints(pointCalculation))
                    .withTotalPoints(pointCalculation.totalPoints())
                    .build();
     }
@@ -84,18 +83,24 @@ public class EvaluatorService {
                                                                    InstitutionPoints::institutionPoints));
     }
 
-    private static List<NviCreator> mapToCreators(List<VerifiedNviCreator> nviCreators) {
-        return nviCreators.stream()
-                   .map(EvaluatorService::toNviCreator)
+    private static List<NviCreatorWithAffiliationPoints> mapToNviCreatorWithAffiliationPoints(
+        PointCalculation pointCalculation) {
+        return pointCalculation.institutionPoints().stream()
+                   .flatMap(institutionPoints -> institutionPoints.affiliationPoints().stream())
+                   .collect(Collectors.groupingBy(AffiliationPoints::nviCreator))
+                   .entrySet()
+                   .stream()
+                   .map(entry -> new NviCreatorWithAffiliationPoints(entry.getKey(), mapToAffiliationPoints(entry)))
                    .toList();
     }
 
-    private static NviCreator toNviCreator(VerifiedNviCreator creator) {
-        //TODO: implement AffiliationPoints.points
-        return new NviCreator(creator.id(), creator.nviAffiliations()
-                                                .stream()
-                                                .map(affiliation -> new AffiliationPoints(affiliation.id(), null))
-                                                .toList());
+    private static List<NviCreatorWithAffiliationPoints.AffiliationPoints> mapToAffiliationPoints(
+        Entry<URI, List<AffiliationPoints>> entry) {
+        return entry.getValue().stream()
+                   .map(affiliationPoints -> new NviCreatorWithAffiliationPoints.AffiliationPoints(
+                       affiliationPoints.affiliationId(),
+                       affiliationPoints.points()))
+                   .toList();
     }
 
     private static URI extractPublicationId(JsonNode publication) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -21,12 +21,12 @@ import no.sikt.nva.nvi.events.evaluator.calculator.CandidateCalculator;
 import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints;
 import no.sikt.nva.nvi.events.evaluator.model.PointCalculation;
 import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
-import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator.NviOrganization;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.CandidateType;
 import no.sikt.nva.nvi.events.model.NonNviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator;
+import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator.AffiliationPoints;
 import no.sikt.nva.nvi.events.model.NviCandidate.PublicationDate;
 
 public class EvaluatorService {
@@ -91,9 +91,10 @@ public class EvaluatorService {
     }
 
     private static NviCreator toNviCreator(VerifiedNviCreator creator) {
+        //TODO: implement AffiliationPoints.points
         return new NviCreator(creator.id(), creator.nviAffiliations()
                                                 .stream()
-                                                .map(NviOrganization::id)
+                                                .map(affiliation -> new AffiliationPoints(affiliation.id(), null))
                                                 .toList());
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
@@ -19,7 +19,7 @@ import java.util.stream.Stream;
 import no.sikt.nva.nvi.events.evaluator.model.Channel;
 import no.sikt.nva.nvi.events.evaluator.model.InstanceType;
 import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints;
-import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints.AffiliationPoints;
+import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints.InstitutionAffiliationPoints;
 import no.sikt.nva.nvi.events.evaluator.model.PointCalculation;
 import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
 import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator.NviOrganization;
@@ -74,12 +74,12 @@ public class PointCalculator {
                    .reduce(ZERO, BigDecimal::add);
     }
 
-    private static Stream<AffiliationPoints> calculatePointsForAffiliation(Long institutionCreatorShareCount,
-                                                                           Entry<URI, List<URI>> nviCreator,
-                                                                           BigDecimal institutionPoints) {
+    private static Stream<InstitutionAffiliationPoints> calculatePointsForAffiliation(Long institutionCreatorShareCount,
+                                                                                      Entry<URI, List<URI>> nviCreator,
+                                                                                      BigDecimal institutionPoints) {
         return nviCreator.getValue().stream()
-                   .map(affiliationId -> new AffiliationPoints(affiliationId, nviCreator.getKey(),
-                                                               dividePointsOnCreatorShareCount(
+                   .map(affiliationId -> new InstitutionAffiliationPoints(affiliationId, nviCreator.getKey(),
+                                                                          dividePointsOnCreatorShareCount(
                                                                    institutionCreatorShareCount,
                                                                    institutionPoints)));
     }
@@ -133,8 +133,8 @@ public class PointCalculator {
                                                                 institutionPoints));
     }
 
-    private List<AffiliationPoints> calculateAffiliationPoints(URI institutionId, Long institutionCreatorShareCount,
-                                                               BigDecimal institutionPoints) {
+    private List<InstitutionAffiliationPoints> calculateAffiliationPoints(URI institutionId, Long institutionCreatorShareCount,
+                                                                          BigDecimal institutionPoints) {
         return nviCreators.stream()
                    .filter(creator -> isAffiliated(institutionId, creator))
                    .collect(Collectors.toMap(VerifiedNviCreator::id, creator -> mapToAffiliations(institutionId,

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/InstitutionPoints.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/InstitutionPoints.java
@@ -6,9 +6,9 @@ import java.util.List;
 
 public record InstitutionPoints(URI institutionId,
                                 BigDecimal institutionPoints,
-                                List<AffiliationPoints> affiliationPoints) {
+                                List<InstitutionAffiliationPoints> institutionAffiliationPoints) {
 
-    public record AffiliationPoints(URI affiliationId, URI nviCreator, BigDecimal points) {
+    public record InstitutionAffiliationPoints(URI affiliationId, URI nviCreator, BigDecimal points) {
 
     }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -12,6 +12,7 @@ import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.Creator;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
+import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints.InstitutionAffiliationPoints;
 import no.sikt.nva.nvi.events.model.NviCandidate.NviCreatorWithAffiliationPoints.AffiliationPoints;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
@@ -106,6 +107,10 @@ public record NviCandidate(URI publicationId,
 
         public record AffiliationPoints(URI affiliationId, BigDecimal points) {
 
+            public static AffiliationPoints from(InstitutionAffiliationPoints institutionAffiliationPoints) {
+                return new AffiliationPoints(institutionAffiliationPoints.affiliationId(),
+                                             institutionAffiliationPoints.points());
+            }
         }
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -12,7 +12,7 @@ import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.Creator;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
-import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator.AffiliationPoints;
+import no.sikt.nva.nvi.events.model.NviCandidate.NviCreatorWithAffiliationPoints.AffiliationPoints;
 
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonSerialize
@@ -20,7 +20,7 @@ public record NviCandidate(URI publicationId,
                            URI publicationBucketUri,
                            String instanceType,
                            @JsonProperty("publicationDate") PublicationDate date,
-                           List<NviCreator> nviCreators,
+                           List<NviCreatorWithAffiliationPoints> nviCreatorWithAffiliationPoints,
                            String channelType,
                            URI publicationChannelId,
                            String level,
@@ -65,8 +65,8 @@ public record NviCandidate(URI publicationId,
 
     @Override
     public Map<URI, List<URI>> creators() {
-        return nviCreators().stream()
-                   .collect(Collectors.toMap(NviCreator::id,
+        return nviCreatorWithAffiliationPoints().stream()
+                   .collect(Collectors.toMap(NviCreatorWithAffiliationPoints::id,
                                              creator -> creator.affiliationPoints().stream()
                                                             .map(AffiliationPoints::affiliationId)
                                                             .toList()));
@@ -77,8 +77,8 @@ public record NviCandidate(URI publicationId,
         return mapToPublicationDate(date);
     }
 
-    private static NviCreator mapToNviCreator(Creator creator) {
-        return new NviCreator(creator.id(), mapToAffiliationPoints(creator.affiliations()));
+    private static NviCreatorWithAffiliationPoints mapToNviCreator(Creator creator) {
+        return new NviCreatorWithAffiliationPoints(creator.id(), mapToAffiliationPoints(creator.affiliations()));
     }
 
     private static List<AffiliationPoints> mapToAffiliationPoints(List<URI> affiliations) {
@@ -102,7 +102,7 @@ public record NviCandidate(URI publicationId,
                                                       publicationDate.day());
     }
 
-    public record NviCreator(URI id, List<AffiliationPoints> affiliationPoints) {
+    public record NviCreatorWithAffiliationPoints(URI id, List<AffiliationPoints> affiliationPoints) {
 
         public record AffiliationPoints(URI affiliationId, BigDecimal points) {
 
@@ -119,7 +119,7 @@ public record NviCandidate(URI publicationId,
         private URI publicationBucketUri;
         private String instanceType;
         private PublicationDate date;
-        private List<NviCreator> nviCreators;
+        private List<NviCreatorWithAffiliationPoints> nviCreatorWithAffiliationPoints;
         private String channelType;
         private URI publicationChannelId;
         private String level;
@@ -153,8 +153,8 @@ public record NviCandidate(URI publicationId,
             return this;
         }
 
-        public Builder withVerifiedCreators(List<NviCreator> nviCreators) {
-            this.nviCreators = nviCreators;
+        public Builder withVerifiedCreators(List<NviCreatorWithAffiliationPoints> nviCreatorWithAffiliationPoints) {
+            this.nviCreatorWithAffiliationPoints = nviCreatorWithAffiliationPoints;
             return this;
         }
 
@@ -204,7 +204,8 @@ public record NviCandidate(URI publicationId,
         }
 
         public NviCandidate build() {
-            return new NviCandidate(publicationId, publicationBucketUri, instanceType, date, nviCreators,
+            return new NviCandidate(publicationId, publicationBucketUri, instanceType, date,
+                                    nviCreatorWithAffiliationPoints,
                                     channelType, publicationChannelId, level, basePoints, isInternationalCollaboration,
                                     collaborationFactor, creatorShareCount, institutionPoints, totalPoints);
         }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -542,7 +542,10 @@ class EvaluateNviCandidateHandlerTest {
                                                         PublicationChannel channelType, String level,
                                                         BigDecimal basePoints, BigDecimal totalPoints,
                                                         URI publicationBucketUri) {
-        var verifiedCreators = List.of(new NviCreator(HARDCODED_CREATOR_ID, List.of(CRISTIN_NVI_ORG_SUB_UNIT_ID)));
+        var verifiedCreators = List.of(
+            new NviCreator(HARDCODED_CREATOR_ID, List.of(new NviCreator.AffiliationPoints(CRISTIN_NVI_ORG_SUB_UNIT_ID,
+                                                                                          institutionPoints.get(
+                                                                                              CRISTIN_NVI_ORG_TOP_LEVEL_ID)))));
         return NviCandidate.builder()
                    .withPublicationId(HARDCODED_PUBLICATION_ID)
                    .withPublicationBucketUri(publicationBucketUri)
@@ -563,7 +566,7 @@ class EvaluateNviCandidateHandlerTest {
 
     private static int countCreatorShares(List<NviCreator> nviCreators) {
         return (int) nviCreators.stream()
-                         .mapToLong(nviCreator -> nviCreator.nviAffiliation().size())
+                         .mapToLong(nviCreator -> nviCreator.affiliationPoints().size())
                          .sum();
     }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -46,7 +46,7 @@ import no.sikt.nva.nvi.events.evaluator.model.PublicationChannel;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.NonNviCandidate;
 import no.sikt.nva.nvi.events.model.NviCandidate;
-import no.sikt.nva.nvi.events.model.NviCandidate.NviCreator;
+import no.sikt.nva.nvi.events.model.NviCandidate.NviCreatorWithAffiliationPoints;
 import no.sikt.nva.nvi.events.model.NviCandidate.PublicationDate;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
 import no.sikt.nva.nvi.test.FakeSqsClient;
@@ -543,9 +543,10 @@ class EvaluateNviCandidateHandlerTest {
                                                         BigDecimal basePoints, BigDecimal totalPoints,
                                                         URI publicationBucketUri) {
         var verifiedCreators = List.of(
-            new NviCreator(HARDCODED_CREATOR_ID, List.of(new NviCreator.AffiliationPoints(CRISTIN_NVI_ORG_SUB_UNIT_ID,
-                                                                                          institutionPoints.get(
-                                                                                              CRISTIN_NVI_ORG_TOP_LEVEL_ID)))));
+            new NviCreatorWithAffiliationPoints(HARDCODED_CREATOR_ID, List.of(
+                new NviCreatorWithAffiliationPoints.AffiliationPoints(CRISTIN_NVI_ORG_SUB_UNIT_ID,
+                                                                      institutionPoints.get(
+                                                                          CRISTIN_NVI_ORG_TOP_LEVEL_ID)))));
         return NviCandidate.builder()
                    .withPublicationId(HARDCODED_PUBLICATION_ID)
                    .withPublicationBucketUri(publicationBucketUri)
@@ -564,9 +565,9 @@ class EvaluateNviCandidateHandlerTest {
                    .build();
     }
 
-    private static int countCreatorShares(List<NviCreator> nviCreators) {
+    private static int countCreatorShares(List<NviCreatorWithAffiliationPoints> nviCreators) {
         return (int) nviCreators.stream()
-                         .mapToLong(nviCreator -> nviCreator.affiliationPoints().size())
+                         .mapToLong(creator -> creator.affiliationPoints().size())
                          .sum();
     }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
@@ -27,7 +27,7 @@ import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.events.evaluator.PointService;
 import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints;
-import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints.AffiliationPoints;
+import no.sikt.nva.nvi.events.evaluator.model.InstitutionPoints.InstitutionAffiliationPoints;
 import no.sikt.nva.nvi.events.evaluator.model.PointCalculation;
 import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
 import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator.NviOrganization;
@@ -265,18 +265,19 @@ class PointServiceTest {
     private static BigDecimal getActualAffiliationPoints(PointCalculation pointCalculation, URI institutionId,
                                                          URI someSubUnitId,
                                                          URI creator1) {
-        return getInstitutionPoints(pointCalculation, institutionId).affiliationPoints()
+        return getInstitutionPoints(pointCalculation, institutionId).institutionAffiliationPoints()
                    .stream()
                    .filter(affiliationPoints -> isForCreatorAndAffiliation(someSubUnitId, creator1, affiliationPoints))
                    .findFirst()
-                   .map(InstitutionPoints.AffiliationPoints::points)
+                   .map(InstitutionAffiliationPoints::points)
                    .orElseThrow();
     }
 
     private static boolean isForCreatorAndAffiliation(URI someSubUnitId, URI creator1,
-                                                      AffiliationPoints affiliationPoints) {
-        return affiliationPoints.affiliationId().equals(someSubUnitId) && affiliationPoints.nviCreator()
-                                                                              .equals(creator1);
+                                                      InstitutionAffiliationPoints institutionAffiliationPoints) {
+        return institutionAffiliationPoints.affiliationId().equals(someSubUnitId)
+               && institutionAffiliationPoints.nviCreator()
+                      .equals(creator1);
     }
 
     private static BigDecimal getActualPoints(PointCalculation pointCalculation, URI institutionId) {


### PR DESCRIPTION
Jira task: NP-46529, Refactor points for affiliation calculation, persist in db.

Part 1 -> [PR Merged](https://github.com/BIBSYSDEV/nva-nvi/pull/279)
This is part 2 -> Send points for affiliation from `EvaluateNviCandidateHandler` to `UpsertNviCandidateHandler`

- Modified `NviCandidate` with list of nvi creators to contain `List<NviCreatorWithAffiliationPoints>`
- Added `List<AffiliationPoints>` in `NviCreatorWithAffiliationPoints`

In next PR: Consume and persist points for affiliation in `UpsertNviCandidateHandler`