### PR TITLE
Np 46529 fix creator affiliation points batch scan

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.math.BigDecimal;
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -55,7 +54,7 @@ public record NviCandidate(URI publicationId,
                    .withIsInternationalCollaboration(candidate.isInternationalCollaboration())
                    .withCollaborationFactor(candidate.getCollaborationFactor())
                    .withCreatorShareCount(candidate.getCreatorShareCount())
-                   .withInstitutionPoints(mapToInstitutionPoints(candidate.getInstitutionPoints()))
+                   .withInstitutionPoints(candidate.getInstitutionPoints())
                    .withTotalPoints(candidate.getTotalPoints())
                    .build();
     }
@@ -74,16 +73,6 @@ public record NviCandidate(URI publicationId,
     @Override
     public PublicationDetails.PublicationDate publicationDate() {
         return mapToPublicationDate(date);
-    }
-
-    private static List<InstitutionPoints> mapToInstitutionPoints(Map<URI, BigDecimal> institutionPoints) {
-        return institutionPoints.entrySet().stream()
-                   .map(entry -> new InstitutionPoints(entry.getKey(),
-                                                       entry.getValue(),
-                                                       //TODO: Implement when Candidate contains
-                                                       // InstitutionAffiliationPoints
-                                                       Collections.emptyList()))
-                   .toList();
     }
 
     private static NviCreator mapToNviCreator(Creator creator) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.events.batch;
 
+import static no.sikt.nva.nvi.events.batch.RequeueDlqTestUtils.generateMessages;
+import static no.sikt.nva.nvi.events.batch.RequeueDlqTestUtils.setUpSqsClient;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -15,13 +17,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
-import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints.DbCreatorAffiliationPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -32,13 +31,9 @@ import no.sikt.nva.nvi.common.queue.NviQueueClient;
 import no.unit.nva.commons.json.JsonUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import software.amazon.awssdk.http.SdkHttpResponse;
 import software.amazon.awssdk.services.sqs.SqsClient;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
-import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
 import software.amazon.awssdk.services.sqs.model.Message;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
@@ -47,19 +42,17 @@ import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 public class RequeueDlqHandlerTest {
 
     public static final Context CONTEXT = mock(Context.class);
-    private static final String DLQ_URL = "https://some-sqs-url";
     private RequeueDlqHandler handler;
     private SqsClient sqsClient;
+    private static final String DLQ_URL = "https://some-sqs-url";
     private CandidateRepository candidateRepository;
     private PeriodRepository periodRepository;
-
-    private NviQueueClient client;
 
     @BeforeEach
     void setUp() {
         sqsClient = setUpSqsClient();
 
-        client = new NviQueueClient(sqsClient);
+        var client = new NviQueueClient(sqsClient);
 
         candidateRepository = setupCandidateRepository();
 
@@ -68,18 +61,18 @@ public class RequeueDlqHandlerTest {
         handler = new RequeueDlqHandler(client, DLQ_URL, candidateRepository, periodRepository);
     }
 
-    @Test
-    void shouldRequeueCandidateWithoutLossOfInformation() {
-        var candidateDao = createCandidateDao();
-        var repo = setupCandidateRepository(candidateDao);
-        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
-            .thenReturn(ReceiveMessageResponse.builder().messages(generateMessages(1, "firstBatch",
-                                                                                   candidateDao.identifier())).build());
+    private static CandidateRepository setupCandidateRepository() {
+        var repo = mock(CandidateRepository.class);
 
-        handler = new RequeueDlqHandler(client, DLQ_URL, repo, periodRepository);
-        handler.handleRequest(new RequeueDlqInput(1), CONTEXT);
+        var candidate = createCandidateDao();
 
-        Mockito.verify(candidateRepository, Mockito.times(1)).updateCandidate(candidateDao);
+        when(repo.findByPublicationId(any()))
+            .thenReturn(Optional.of(candidate));
+
+        when(repo.findCandidateById(any()))
+            .thenReturn(Optional.of(candidate));
+
+        return repo;
     }
 
     @Test
@@ -167,6 +160,10 @@ public class RequeueDlqHandlerTest {
         assertEquals(5, response.failedBatchesCount());
     }
 
+    private static long getSuccessCount(RequeueDlqOutput response) {
+        return response.messages().stream().filter(NviProcessMessageResult::success).count();
+    }
+
     @Test
     void missingCustomAttributeShouldFail() {
         var message = Message.builder()
@@ -184,6 +181,10 @@ public class RequeueDlqHandlerTest {
 
         var error = response.messages().stream().filter(a -> !a.success()).findFirst().get().error().get();
         assertTrue(error.contains("Exception"));
+    }
+
+    private static long getFailureCount(RequeueDlqOutput response) {
+        return response.messages().stream().filter(a -> !a.success()).count();
     }
 
     @Test
@@ -210,8 +211,9 @@ public class RequeueDlqHandlerTest {
 
         var response = handler.handleRequest(new RequeueDlqInput(100), CONTEXT);
 
+
         var message = response.messages().stream().filter(NviProcessMessageResult::success).findFirst()
-                          .get().message().messageId();
+                                .get().message().messageId();
 
         assertTrue(message.contains("myInput"));
     }
@@ -242,49 +244,8 @@ public class RequeueDlqHandlerTest {
         assertEquals(10, input.count());
     }
 
-    private static SqsClient setUpSqsClient() {
-        var client = mock(SqsClient.class);
-
-        var status = SdkHttpResponse.builder().statusCode(202).build();
-        var response = DeleteMessageResponse.builder();
-        response.sdkHttpResponse(status);
-
-        when(client.deleteMessage(any(DeleteMessageRequest.class)))
-            .thenReturn(response.build());
-
-        return client;
-    }
-
-    private static CandidateRepository setupCandidateRepository() {
-        return setupCandidateRepository(createCandidateDao());
-    }
-
-    private static CandidateRepository setupCandidateRepository(CandidateDao candidateDao) {
-        var repo = mock(CandidateRepository.class);
-
-        when(repo.findByPublicationId(any()))
-            .thenReturn(Optional.of(candidateDao));
-
-        when(repo.findCandidateById(any()))
-            .thenReturn(Optional.of(candidateDao));
-
-        return repo;
-    }
-
-    private static long getSuccessCount(RequeueDlqOutput response) {
-        return response.messages().stream().filter(NviProcessMessageResult::success).count();
-    }
-
-    private static long getFailureCount(RequeueDlqOutput response) {
-        return response.messages().stream().filter(a -> !a.success()).count();
-    }
-
     private static CandidateDao createCandidateDao() {
-        var institutionId = randomUri();
-        var institutionPoints = BigDecimal.valueOf(1);
-        var creatorId = randomUri();
         return CandidateDao.builder()
-                   .identifier(UUID.randomUUID())
                    .candidate(DbCandidate.builder()
                                   .publicationDate(
                                       DbPublicationDate.builder()
@@ -293,14 +254,11 @@ public class RequeueDlqHandlerTest {
                                           .year("2000").build())
                                   .points(List.of(
                                       DbInstitutionPoints.builder()
-                                          .institutionId(institutionId)
-                                          .points(institutionPoints)
-                                          .creatorAffiliationPoints(List.of(new DbCreatorAffiliationPoints(creatorId,
-                                                                                                           institutionId,
-                                                                                                           institutionPoints)))
+                                          .institutionId(randomUri())
+                                          .points(BigDecimal.valueOf(1))
                                           .build()))
                                   .instanceType(InstanceType.ACADEMIC_ARTICLE.getValue())
-                                  .creators(List.of(new DbCreator(creatorId, List.of(institutionId))))
+                                  .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))))
                                   .level(DbLevel.LEVEL_ONE)
                                   .channelType(ChannelType.JOURNAL)
                                   .totalPoints(BigDecimal.valueOf(1))
@@ -309,21 +267,5 @@ public class RequeueDlqHandlerTest {
                                   .publicationBucketUri(randomUri())
                                   .build())
                    .build();
-    }
-
-    private static List<Message> generateMessages(int count, String batchPrefix) {
-        return generateMessages(count, batchPrefix, UUID.randomUUID());
-    }
-
-    private static List<Message> generateMessages(int count, String batchPrefix, UUID candidateIdentifier) {
-        return IntStream.rangeClosed(1, count)
-                   .mapToObj(i -> Message.builder()
-                                      .messageId(batchPrefix + i)
-                                      .receiptHandle(batchPrefix + i)
-                                      .messageAttributes(
-                                          Map.of("candidateIdentifier", MessageAttributeValue.builder().stringValue(
-                                              candidateIdentifier.toString()).build()))
-                                      .build())
-                   .collect(Collectors.toList());
     }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
@@ -21,6 +21,7 @@ import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints.DbCreatorAffiliationPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbLevel;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -245,7 +246,11 @@ public class RequeueDlqHandlerTest {
     }
 
     private static CandidateDao createCandidateDao() {
+        var institutionId = randomUri();
+        var institutionPoints = BigDecimal.valueOf(1);
+        var creatorId = randomUri();
         return CandidateDao.builder()
+                   .identifier(UUID.randomUUID())
                    .candidate(DbCandidate.builder()
                                   .publicationDate(
                                       DbPublicationDate.builder()
@@ -256,9 +261,15 @@ public class RequeueDlqHandlerTest {
                                       DbInstitutionPoints.builder()
                                           .institutionId(randomUri())
                                           .points(BigDecimal.valueOf(1))
+                                          .institutionId(institutionId)
+                                          .points(institutionPoints)
+                                          .creatorAffiliationPoints(List.of(new DbCreatorAffiliationPoints(creatorId,
+                                                                                                           institutionId,
+                                                                                                           institutionPoints)))
                                           .build()))
                                   .instanceType(InstanceType.ACADEMIC_ARTICLE.getValue())
                                   .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))))
+                                  .creators(List.of(new DbCreator(creatorId, List.of(institutionId))))
                                   .level(DbLevel.LEVEL_ONE)
                                   .channelType(ChannelType.JOURNAL)
                                   .totalPoints(BigDecimal.valueOf(1))

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerWithLocalDynamoTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerWithLocalDynamoTest.java
@@ -1,0 +1,58 @@
+package no.sikt.nva.nvi.events.batch;
+
+import static no.sikt.nva.nvi.events.batch.RequeueDlqTestUtils.generateMessages;
+import static no.sikt.nva.nvi.events.batch.RequeueDlqTestUtils.setUpSqsClient;
+import static no.sikt.nva.nvi.test.TestUtils.createCandidateDao;
+import static no.sikt.nva.nvi.test.TestUtils.randomCandidateWithYear;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import com.amazonaws.services.lambda.runtime.Context;
+import no.sikt.nva.nvi.common.db.CandidateRepository;
+import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.queue.NviQueueClient;
+import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.sikt.nva.nvi.test.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
+
+public class RequeueDlqHandlerWithLocalDynamoTest extends LocalDynamoTest {
+
+    public static final Context CONTEXT = mock(Context.class);
+    public static final int YEAR = 2021;
+    private static final String DLQ_URL = "https://some-sqs-url";
+    private RequeueDlqHandler handler;
+    private SqsClient sqsClient;
+    private CandidateRepository candidateRepository;
+    private PeriodRepository periodRepository;
+    private NviQueueClient client;
+
+    @BeforeEach
+    void setUp() {
+        sqsClient = setUpSqsClient();
+        client = new NviQueueClient(sqsClient);
+        var localDynamoDbClient = initializeTestDatabase();
+        candidateRepository = new CandidateRepository(localDynamoDbClient);
+        periodRepository = TestUtils.periodRepositoryReturningOpenedPeriod(YEAR);
+        handler = new RequeueDlqHandler(client, DLQ_URL, candidateRepository, periodRepository);
+    }
+
+    @Test
+    void shouldRequeueCandidateWithoutLossOfInformation() {
+        var expectedCandidate = createCandidateDao(candidateRepository, randomCandidateWithYear(String.valueOf(YEAR)));
+        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
+            .thenReturn(ReceiveMessageResponse.builder()
+                            .messages(generateMessages(1, "firstBatch",
+                                                       expectedCandidate.identifier()))
+                            .build());
+
+        handler = new RequeueDlqHandler(client, DLQ_URL, candidateRepository, periodRepository);
+        handler.handleRequest(new RequeueDlqInput(1), CONTEXT);
+        var actualCandidate = candidateRepository.findCandidateById(expectedCandidate.identifier()).orElseThrow();
+        assertEquals(expectedCandidate, actualCandidate);
+    }
+}

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqTestUtils.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqTestUtils.java
@@ -1,0 +1,53 @@
+package no.sikt.nva.nvi.events.batch;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import software.amazon.awssdk.http.SdkHttpResponse;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
+import software.amazon.awssdk.services.sqs.model.DeleteMessageResponse;
+import software.amazon.awssdk.services.sqs.model.Message;
+import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
+
+public class RequeueDlqTestUtils {
+
+    private RequeueDlqTestUtils() {
+        // NO-OP
+    }
+
+    public static SqsClient setUpSqsClient() {
+        var client = mock(SqsClient.class);
+
+        var status = SdkHttpResponse.builder().statusCode(202).build();
+        var response = DeleteMessageResponse.builder();
+        response.sdkHttpResponse(status);
+
+        when(client.deleteMessage(any(DeleteMessageRequest.class)))
+            .thenReturn(response.build());
+
+        return client;
+    }
+
+    public static List<Message> generateMessages(int count, String batchPrefix) {
+        return generateMessages(count, batchPrefix, UUID.randomUUID());
+    }
+
+    public static List<Message> generateMessages(int count, String batchPrefix, UUID candidateIdentifier) {
+        return IntStream.rangeClosed(1, count)
+                   .mapToObj(i -> Message.builder()
+                                      .messageId(batchPrefix + i)
+                                      .receiptHandle(batchPrefix + i)
+                                      .messageAttributes(
+                                          Map.of("candidateIdentifier", MessageAttributeValue.builder().stringValue(
+                                              candidateIdentifier.toString()).build()))
+                                      .build())
+                   .collect(Collectors.toList());
+    }
+
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -74,7 +74,7 @@ public final class NviCandidateIndexDocumentGenerator {
     }
 
     private static BigDecimal getInstitutionPoints(Approval approval, Candidate candidate) {
-        return candidate.getInstitutionPoints().get(approval.getInstitutionId());
+        return candidate.getInstitutionPointsMap().get(approval.getInstitutionId());
     }
 
     private NviCandidateIndexDocument buildCandidate(JsonNode resource, Candidate candidate,

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/InstitutionPoints.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/InstitutionPoints.java
@@ -3,12 +3,27 @@ package no.sikt.nva.nvi.common.service.model;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints.DbCreatorAffiliationPoints;
 
 public record InstitutionPoints(URI institutionId,
                                 BigDecimal institutionPoints,
                                 List<CreatorAffiliationPoints> creatorAffiliationPoints) {
 
+    public static InstitutionPoints from(DbInstitutionPoints dbInstitutionPoints) {
+        return new InstitutionPoints(dbInstitutionPoints.institutionId(),
+                                     dbInstitutionPoints.points(),
+                                     dbInstitutionPoints.creatorAffiliationPoints().stream()
+                                         .map(CreatorAffiliationPoints::from)
+                                         .toList());
+    }
+
     public record CreatorAffiliationPoints(URI nviCreator, URI affiliationId, BigDecimal points) {
 
+        public static CreatorAffiliationPoints from(DbCreatorAffiliationPoints dbCreatorAffiliationPoints) {
+            return new CreatorAffiliationPoints(dbCreatorAffiliationPoints.creatorId(),
+                                                dbCreatorAffiliationPoints.affiliationId(),
+                                                dbCreatorAffiliationPoints.points());
+        }
     }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -11,9 +11,9 @@ import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeri
 import static no.sikt.nva.nvi.test.TestUtils.randomApproval;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
-import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
 import static no.sikt.nva.nvi.test.TestUtils.randomInstanceTypeExcluding;
 import static no.sikt.nva.nvi.test.TestUtils.randomLevelExcluding;
+import static no.sikt.nva.nvi.test.TestUtils.setupReportedCandidate;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
@@ -501,8 +501,7 @@ class CandidateTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnCandidateWithReportStatus() {
-        var institutionId = randomUri();
-        var dao = setupReportedCandidateWithInstitution(institutionId);
+        var dao = setupReportedCandidate(candidateRepository);
         var candidate = Candidate.fetch(dao::identifier, candidateRepository, periodRepository);
         assertThat(candidate.toDto().status(), is(equalTo(ReportStatus.REPORTED.getValue())));
         assertThat(candidate.toDto().status(), is(equalTo(ReportStatus.REPORTED.getValue())));
@@ -592,14 +591,6 @@ class CandidateTest extends LocalDynamoTest {
 
     private static BigDecimal setScaleAndRoundingMode(BigDecimal bigDecimal) {
         return bigDecimal.setScale(EXPECTED_SCALE, EXPECTED_ROUNDING_MODE);
-    }
-
-    private CandidateDao setupReportedCandidateWithInstitution(URI institutionId) {
-        return candidateRepository.create(randomCandidateBuilder(true, institutionId).build()
-                                              .copy()
-                                              .reportStatus(ReportStatus.REPORTED)
-                                              .build(),
-                                          List.of(randomApproval(institutionId)));
     }
 
     private List<InstitutionPoints> createPoints(Map<URI, List<URI>> creators) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -11,6 +11,7 @@ import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeri
 import static no.sikt.nva.nvi.test.TestUtils.randomApproval;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
+import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
 import static no.sikt.nva.nvi.test.TestUtils.randomInstanceTypeExcluding;
 import static no.sikt.nva.nvi.test.TestUtils.randomLevelExcluding;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
@@ -500,8 +501,8 @@ class CandidateTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnCandidateWithReportStatus() {
-        var dao = candidateRepository.create(randomCandidate().copy().reportStatus(ReportStatus.REPORTED).build(),
-                                             List.of(randomApproval()));
+        var institutionId = randomUri();
+        var dao = setupReportedCandidateWithInstitution(institutionId);
         var candidate = Candidate.fetch(dao::identifier, candidateRepository, periodRepository);
         assertThat(candidate.toDto().status(), is(equalTo(ReportStatus.REPORTED.getValue())));
         assertThat(candidate.toDto().status(), is(equalTo(ReportStatus.REPORTED.getValue())));
@@ -591,6 +592,14 @@ class CandidateTest extends LocalDynamoTest {
 
     private static BigDecimal setScaleAndRoundingMode(BigDecimal bigDecimal) {
         return bigDecimal.setScale(EXPECTED_SCALE, EXPECTED_ROUNDING_MODE);
+    }
+
+    private CandidateDao setupReportedCandidateWithInstitution(URI institutionId) {
+        return candidateRepository.create(randomCandidateBuilder(true, institutionId).build()
+                                              .copy()
+                                              .reportStatus(ReportStatus.REPORTED)
+                                              .build(),
+                                          List.of(randomApproval(institutionId)));
     }
 
     private List<InstitutionPoints> createPoints(Map<URI, List<URI>> creators) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -350,7 +350,7 @@ class CandidateTest extends LocalDynamoTest {
         assertEquals(candidate.isApplicable(), isApplicable);
         assertEquals(candidate.getPublicationDetails().publicationId(), publicationId);
         assertEquals(candidate.getTotalPoints(), setScaleAndRoundingMode(totalPoints));
-        assertEquals(candidate.getInstitutionPoints().get(institutionId),
+        assertEquals(candidate.getInstitutionPointsMap().get(institutionId),
                      setScaleAndRoundingMode(getInstitutionPoints(points, institutionId)));
         assertEquals(candidate.getPublicationDetails().publicationDate(), publicationDate);
         assertCorrectCreatorData(creators, candidate);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
@@ -5,8 +5,7 @@ import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertNonCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
-import static no.sikt.nva.nvi.test.TestUtils.randomApproval;
-import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
+import static no.sikt.nva.nvi.test.TestUtils.setupReportedCandidate;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -19,7 +18,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.List;
 import java.util.Map;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
@@ -37,8 +35,8 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 class FetchNviCandidateByPublicationIdHandlerTest extends LocalDynamoTest {
 
-    private static final Context CONTEXT = mock(Context.class);
     public static final URI CUSTOMER_ID = randomUri();
+    private static final Context CONTEXT = mock(Context.class);
     private final DynamoDbClient localDynamo = initializeTestDatabase();
     private ByteArrayOutputStream output;
     private FetchNviCandidateByPublicationIdHandler handler;
@@ -90,8 +88,7 @@ class FetchNviCandidateByPublicationIdHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnCandidateWithReportStatus() throws IOException {
-        var candidate = candidateRepository.create(randomCandidate().copy().reportStatus(ReportStatus.REPORTED).build(),
-                                                   List.of(randomApproval()));
+        var candidate = setupReportedCandidate(candidateRepository);
         var request = requestWithAccessRight(candidate.candidate().publicationId());
 
         handler.handleRequest(request, output, CONTEXT);

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -75,7 +75,7 @@ public final class IndexDocumentTestUtils {
     }
 
     private static BigDecimal getPoints(Candidate candidate, URI institutionId) {
-        return candidate.getInstitutionPoints()
+        return candidate.getInstitutionPointsMap()
                    .entrySet()
                    .stream()
                    .filter(entry -> entry.getKey().equals(institutionId))

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -40,6 +40,7 @@ import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.NviPeriodDao.DbNviPeriod;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.db.ReportStatus;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.db.model.InstanceType;
 import no.sikt.nva.nvi.common.db.model.Username;
@@ -413,6 +414,15 @@ public final class TestUtils {
 
     public static DbCandidate randomCandidateWithYear(String year) {
         return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
+    }
+
+    public static CandidateDao setupReportedCandidate(CandidateRepository repository) {
+        var institutionId = randomUri();
+        return repository.create(randomCandidateBuilder(true, institutionId).build()
+                                     .copy()
+                                     .reportStatus(ReportStatus.REPORTED)
+                                     .build(),
+                                 List.of(randomApproval(institutionId)));
     }
 
     private static DbPublicationDate publicationDate(String year) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -141,8 +141,12 @@ public final class TestUtils {
                                                                      CandidateRepository repository) {
         return IntStream.range(0, number)
                    .mapToObj(i -> randomCandidateWithYear(year))
-                   .map(candidate -> repository.create(candidate, List.of()))
+                   .map(candidate -> createCandidateDao(repository, candidate))
                    .toList();
+    }
+
+    public static CandidateDao createCandidateDao(CandidateRepository repository, DbCandidate candidate) {
+        return repository.create(candidate, List.of());
     }
 
     public static DbNviPeriod.Builder randomNviPeriodBuilder() {
@@ -400,7 +404,7 @@ public final class TestUtils {
         return new CreateNoteRequest(text, username, randomUri());
     }
 
-    private static DbCandidate randomCandidateWithYear(String year) {
+    public static DbCandidate randomCandidateWithYear(String year) {
         return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
     }
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -83,8 +83,7 @@ public final class TestUtils {
         return UriWrapper.fromHost(API_HOST).addChild(PUBLICATION_API_PATH).addChild(identifier.toString()).getUri();
     }
 
-    public static DbCandidate.Builder randomCandidateBuilder(boolean applicable) {
-        var institutionId = randomUri();
+    public static DbCandidate.Builder randomCandidateBuilder(boolean applicable, URI institutionId) {
         var creatorId = randomUri();
         var institutionPoints = randomBigDecimal();
         return DbCandidate.builder()
@@ -102,6 +101,10 @@ public final class TestUtils {
                    .createdDate(Instant.now())
                    .modifiedDate(Instant.now())
                    .creators(List.of(new DbCreator(creatorId, List.of(institutionId))));
+    }
+
+    public static DbCandidate.Builder randomCandidateBuilder(boolean applicable) {
+        return randomCandidateBuilder(applicable, randomUri());
     }
 
     public static InstanceType randomInstanceType() {
@@ -128,13 +131,17 @@ public final class TestUtils {
         return randomCandidateBuilder(true).build();
     }
 
-    public static DbApprovalStatus randomApproval() {
-        return new DbApprovalStatus(randomUri(),
+    public static DbApprovalStatus randomApproval(URI institutionId) {
+        return new DbApprovalStatus(institutionId,
                                     randomElement(DbStatus.values()),
                                     randomUsername(),
                                     randomUsername(),
                                     randomInstant(),
                                     randomString());
+    }
+
+    public static DbApprovalStatus randomApproval() {
+        return randomApproval(randomUri());
     }
 
     public static List<CandidateDao> createNumberOfCandidatesForYear(String year, int number,


### PR DESCRIPTION
To avoid loosing information about `NviCandidate` `CreatorAffiliationPoints` in case of a RequeueDLQ situation. Added test `shouldRequeueCandidateWithoutLossOfInformation`