### PR TITLE
Np 46529 Index document, Points for creator affiliation

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Approval.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/Approval.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.math.BigDecimal;
 import java.util.Map;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
@@ -16,7 +15,7 @@ import java.util.Map;
 public record Approval(String institutionId,
                        Map<String, String> labels,
                        ApprovalStatus approvalStatus,
-                       BigDecimal points,
+                       InstitutionPoints points,
                        String assignee) {
 
     public static Builder builder() {
@@ -28,7 +27,7 @@ public record Approval(String institutionId,
         private String institutionId;
         private Map<String, String> labels;
         private ApprovalStatus approvalStatus;
-        private BigDecimal points;
+        private InstitutionPoints points;
         private String assignee;
 
         private Builder() {
@@ -49,7 +48,7 @@ public record Approval(String institutionId,
             return this;
         }
 
-        public Builder withPoints(BigDecimal points) {
+        public Builder withPoints(InstitutionPoints points) {
             this.points = points;
             return this;
         }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/InstitutionPoints.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/InstitutionPoints.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.index.model;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -15,7 +14,7 @@ import java.util.List;
 @JsonTypeName("InstitutionPoints")
 public record InstitutionPoints(URI institutionId,
                                 BigDecimal institutionPoints,
-                                @JsonProperty("breakdown") List<CreatorAffiliationPoints> creatorAffiliationPoints) {
+                                List<CreatorAffiliationPoints> creatorAffiliationPoints) {
 
     public static InstitutionPoints from(no.sikt.nva.nvi.common.service.model.InstitutionPoints institutionPoints) {
         return new InstitutionPoints(institutionPoints.institutionId(),

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/InstitutionPoints.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/InstitutionPoints.java
@@ -1,0 +1,42 @@
+package no.sikt.nva.nvi.index.model;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.util.List;
+
+@JsonSerialize
+@JsonTypeInfo(
+    use = JsonTypeInfo.Id.NAME,
+    property = "type")
+@JsonTypeName("InstitutionPoints")
+public record InstitutionPoints(URI institutionId,
+                                BigDecimal institutionPoints,
+                                @JsonProperty("breakdown") List<CreatorAffiliationPoints> creatorAffiliationPoints) {
+
+    public static InstitutionPoints from(no.sikt.nva.nvi.common.service.model.InstitutionPoints institutionPoints) {
+        return new InstitutionPoints(institutionPoints.institutionId(),
+                                     institutionPoints.institutionPoints(),
+                                     institutionPoints.creatorAffiliationPoints().stream()
+                                         .map(CreatorAffiliationPoints::from)
+                                         .toList());
+    }
+
+    @JsonSerialize
+    @JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "type")
+    @JsonTypeName("CreatorAffiliationPoints")
+    public record CreatorAffiliationPoints(URI nviCreator, URI affiliationId, BigDecimal points) {
+
+        public static CreatorAffiliationPoints from(
+            no.sikt.nva.nvi.common.service.model.InstitutionPoints.CreatorAffiliationPoints creatorAffiliationPoints) {
+            return new CreatorAffiliationPoints(creatorAffiliationPoints.nviCreator(),
+                                                creatorAffiliationPoints.affiliationId(),
+                                                creatorAffiliationPoints.points());
+        }
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -22,7 +22,6 @@ import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import java.math.BigDecimal;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -40,6 +39,7 @@ import no.sikt.nva.nvi.common.service.model.Username;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.Contributor;
 import no.sikt.nva.nvi.index.model.ContributorType;
+import no.sikt.nva.nvi.index.model.InstitutionPoints;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.NviContributor;
 import no.sikt.nva.nvi.index.model.NviOrganization;
@@ -73,8 +73,8 @@ public final class NviCandidateIndexDocumentGenerator {
             () -> dtoObjectMapper.readValue(response, no.sikt.nva.nvi.common.model.Organization.class)).orElseThrow();
     }
 
-    private static BigDecimal getInstitutionPoints(Approval approval, Candidate candidate) {
-        return candidate.getInstitutionPointsMap().get(approval.getInstitutionId());
+    private static InstitutionPoints getInstitutionPoints(Approval approval, Candidate candidate) {
+        return InstitutionPoints.from(candidate.getInstitutionPoints(approval.getInstitutionId()));
     }
 
     private NviCandidateIndexDocument buildCandidate(JsonNode resource, Candidate candidate,

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -14,8 +14,7 @@ import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandPublicationDetai
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEvent;
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEventWithOneInvalidRecord;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
-import static no.sikt.nva.nvi.test.TestUtils.randomApproval;
-import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
+import static no.sikt.nva.nvi.test.TestUtils.setupReportedCandidate;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.s3.S3Driver.S3_SCHEME;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
@@ -43,7 +42,6 @@ import java.util.UUID;
 import no.sikt.nva.nvi.common.S3StorageReader;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
-import no.sikt.nva.nvi.common.db.ReportStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.index.aws.S3StorageWriter;
 import no.sikt.nva.nvi.index.model.ConsumptionAttributes;
@@ -120,8 +118,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     void shouldBuildIndexDocumentWithReportedPeriodWhenCandidateIsReported() {
         //Using repository to create reported candidate because setting Candidate as reported is not implemented yet
         //TODO: Use Candidate.setReported when implemented
-        var dao = candidateRepository.create(randomCandidate().copy().reportStatus(ReportStatus.REPORTED).build(),
-                                             List.of(randomApproval()));
+        var dao = setupReportedCandidate(candidateRepository);
         var candidate = Candidate.fetch(dao::identifier, candidateRepository, periodRepository);
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(
             candidate).indexDocument();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -49,6 +49,8 @@ import no.sikt.nva.nvi.index.model.Approval;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.Contributor;
+import no.sikt.nva.nvi.index.model.InstitutionPoints;
+import no.sikt.nva.nvi.index.model.InstitutionPoints.CreatorAffiliationPoints;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.Organization;
 import no.sikt.nva.nvi.index.model.PublicationDate;
@@ -537,7 +539,7 @@ public class OpenSearchClientTest {
     }
 
     private static Approval randomApprovalWithCustomerAndAssignee(String affiliation, String assignee) {
-        return new Approval(affiliation, Map.of(), randomStatus(), randomBigDecimal(SCALE), assignee);
+        return new Approval(affiliation, Map.of(), randomStatus(), randomInstitutionPoints(), assignee);
     }
 
     private static List<Approval> randomApprovalList() {
@@ -545,7 +547,15 @@ public class OpenSearchClientTest {
     }
 
     private static Approval randomApproval() {
-        return new Approval(randomString(), Map.of(), randomStatus(), randomBigDecimal(SCALE), null);
+        return new Approval(randomString(), Map.of(), randomStatus(), randomInstitutionPoints(), null);
+    }
+
+    private static InstitutionPoints randomInstitutionPoints() {
+        return new InstitutionPoints(randomUri(), randomBigDecimal(SCALE), randomCreatorAffiliationPoints());
+    }
+
+    private static List<CreatorAffiliationPoints> randomCreatorAffiliationPoints() {
+        return List.of(new CreatorAffiliationPoints(randomUri(), randomUri(), randomBigDecimal(SCALE)));
     }
 
     private static ApprovalStatus randomStatus() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -199,10 +199,13 @@ public final class Candidate {
         return institutionPoints;
     }
 
-    public BigDecimal getPointsForInstitution(URI institutionId) {
+    public BigDecimal getPointValueForInstitution(URI institutionId) {
+        return getInstitutionPoints(institutionId).institutionPoints();
+    }
+
+    public InstitutionPoints getInstitutionPoints(URI institutionId) {
         return institutionPoints.stream()
                    .filter(institutionPoints -> institutionPoints.institutionId().equals(institutionId))
-                   .map(InstitutionPoints::institutionPoints)
                    .findFirst()
                    .orElseThrow();
     }
@@ -642,7 +645,7 @@ public final class Candidate {
                    .withAssignee(mapToUsernameString(approval.getAssignee()))
                    .withFinalizedBy(mapToUsernameString(approval.getFinalizedBy()))
                    .withFinalizedDate(approval.getFinalizedDate())
-                   .withPoints(getPointsForInstitution(approval.getInstitutionId()))
+                   .withPoints(getPointValueForInstitution(approval.getInstitutionId()))
                    .withReason(approval.getReason())
                    .build();
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -351,7 +351,7 @@ class CandidateTest extends LocalDynamoTest {
         assertEquals(candidate.isApplicable(), isApplicable);
         assertEquals(candidate.getPublicationDetails().publicationId(), publicationId);
         assertEquals(candidate.getTotalPoints(), setScaleAndRoundingMode(totalPoints));
-        assertEquals(setScaleAndRoundingMode(candidate.getPointsForInstitution(institutionId)), institutionPoints);
+        assertEquals(setScaleAndRoundingMode(candidate.getPointValueForInstitution(institutionId)), institutionPoints);
         assertEquals(candidate.getInstitutionPointsMap().get(institutionId), institutionPoints);
         assertEquals(candidate.getInstitutionPoints(), points);
         assertEquals(candidate.getPublicationDetails().publicationDate(), publicationDate);

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -21,6 +21,7 @@ import no.sikt.nva.nvi.common.utils.JsonUtils;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.Contributor;
 import no.sikt.nva.nvi.index.model.ContributorType;
+import no.sikt.nva.nvi.index.model.InstitutionPoints;
 import no.sikt.nva.nvi.index.model.NviContributor;
 import no.sikt.nva.nvi.index.model.NviOrganization;
 import no.sikt.nva.nvi.index.model.Organization;
@@ -69,7 +70,7 @@ public final class IndexDocumentTestUtils {
                    .withInstitutionId(approvalEntry.getKey().toString())
                    .withApprovalStatus(ApprovalStatus.fromValue(approvalEntry.getValue().getStatus().getValue()))
                    .withAssignee(Objects.nonNull(assignee) ? assignee.value() : null)
-                   .withPoints(getPoints(candidate, approvalEntry.getKey()))
+                   .withPoints(InstitutionPoints.from(candidate.getInstitutionPoints(approvalEntry.getKey())))
                    .withLabels(Map.of(EN_FIELD, HARDCODED_ENGLISH_LABEL, NB_FIELD, HARDCODED_NORWEGIAN_LABEL))
                    .build();
     }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -7,7 +7,6 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.NB_FIELD;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractAffiliations;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -73,15 +72,6 @@ public final class IndexDocumentTestUtils {
                    .withPoints(InstitutionPoints.from(candidate.getInstitutionPoints(approvalEntry.getKey())))
                    .withLabels(Map.of(EN_FIELD, HARDCODED_ENGLISH_LABEL, NB_FIELD, HARDCODED_NORWEGIAN_LABEL))
                    .build();
-    }
-
-    private static BigDecimal getPoints(Candidate candidate, URI institutionId) {
-        return candidate.getInstitutionPointsMap()
-                   .entrySet()
-                   .stream()
-                   .filter(entry -> entry.getKey().equals(institutionId))
-                   .findFirst()
-                   .map(Entry::getValue).orElse(null);
     }
 
     private static PublicationDate mapToPublicationDate(


### PR DESCRIPTION
Jira task: NP-46529, Refactor points for affiliation calculation, persist in db.

Part 1 -> https://github.com/BIBSYSDEV/nva-nvi/pull/279
Part 2 -> https://github.com/BIBSYSDEV/nva-nvi/pull/283
Part 3 -> https://github.com/BIBSYSDEV/nva-nvi/pull/287

This is the last part: add creator affiliation points in index document, so it can be used for export in data-report-api