### PR TITLE
ReEvaluateNviCandidatesHandler: filter out reported candidates

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -108,9 +108,10 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
     }
 
     private ListingResult<CandidateDao> getListingResultWithNonReportedCandidates(ReEvaluateRequest input) {
-        return nviService.fetchNonReportedCandidatesByYear(input.year(),
-                                                           input.pageSize(),
-                                                           input.startMarker());
+        var includeReportedCandidates = false;
+        return nviService.fetchCandidatesByYear(input.year(),
+                                                includeReportedCandidates, input.pageSize(),
+                                                input.startMarker());
     }
 
     private Stream<List<URI>> splitIntoBatches(List<URI> fileUris) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -69,7 +69,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
                                 Context context) {
         validateInput(input);
         LOGGER.info(QUERY_STARTING_POINT_MESSAGE, input.startMarker());
-        var result = getListingResultWithCandidates(input);
+        var result = getListingResultWithNonReportedCandidates(input);
         logResult(result);
         splitIntoBatches(mapToFileUris(result)).forEach(fileUriList -> sendBatch(createMessages(fileUriList)));
         if (result.shouldContinueScan()) {
@@ -107,10 +107,10 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
         LOGGER.info(PUT_EVENT_RESPONSE_MESSAGE, response.toString());
     }
 
-    private ListingResult<CandidateDao> getListingResultWithCandidates(ReEvaluateRequest input) {
-        return nviService.fetchCandidatesByYear(input.year(),
-                                                input.pageSize(),
-                                                input.startMarker());
+    private ListingResult<CandidateDao> getListingResultWithNonReportedCandidates(ReEvaluateRequest input) {
+        return nviService.fetchNonReportedCandidatesByYear(input.year(),
+                                                           input.pageSize(),
+                                                           input.startMarker());
     }
 
     private Stream<List<URI>> splitIntoBatches(List<URI> fileUris) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -81,11 +81,11 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
         var year = randomYear();
         var pageSizeBiggerThanMaxPageSize = MAX_PAGE_SIZE + randomIntBetween(1, 100);
         var mockedNviService = mock(NviService.class);
-        when(mockedNviService.fetchCandidatesByYear(year, DEFAULT_PAGE_SIZE, null))
+        when(mockedNviService.fetchNonReportedCandidatesByYear(year, DEFAULT_PAGE_SIZE, null))
             .thenReturn(new ListingResult<>(false, null, 0, List.of()));
         var handler = new ReEvaluateNviCandidatesHandler(mockedNviService, sqsClient, environment, eventBridgeClient);
         handler.handleRequest(eventStream(createRequest(year, pageSizeBiggerThanMaxPageSize)), outputStream, context);
-        verify(mockedNviService, times(1)).fetchCandidatesByYear(year, DEFAULT_PAGE_SIZE, null);
+        verify(mockedNviService, times(1)).fetchNonReportedCandidatesByYear(year, DEFAULT_PAGE_SIZE, null);
     }
 
     @Test

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -81,11 +81,11 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTest {
         var year = randomYear();
         var pageSizeBiggerThanMaxPageSize = MAX_PAGE_SIZE + randomIntBetween(1, 100);
         var mockedNviService = mock(NviService.class);
-        when(mockedNviService.fetchNonReportedCandidatesByYear(year, DEFAULT_PAGE_SIZE, null))
+        when(mockedNviService.fetchCandidatesByYear(year, false, DEFAULT_PAGE_SIZE, null))
             .thenReturn(new ListingResult<>(false, null, 0, List.of()));
         var handler = new ReEvaluateNviCandidatesHandler(mockedNviService, sqsClient, environment, eventBridgeClient);
         handler.handleRequest(eventStream(createRequest(year, pageSizeBiggerThanMaxPageSize)), outputStream, context);
-        verify(mockedNviService, times(1)).fetchNonReportedCandidatesByYear(year, DEFAULT_PAGE_SIZE, null);
+        verify(mockedNviService, times(1)).fetchCandidatesByYear(year, false, DEFAULT_PAGE_SIZE, null);
     }
 
     @Test

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -14,6 +14,7 @@ import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandPublicationDetai
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEvent;
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.createEventWithOneInvalidRecord;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
+import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.sikt.nva.nvi.test.TestUtils.setupReportedCandidate;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.s3.S3Driver.S3_SCHEME;
@@ -118,7 +119,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     void shouldBuildIndexDocumentWithReportedPeriodWhenCandidateIsReported() {
         //Using repository to create reported candidate because setting Candidate as reported is not implemented yet
         //TODO: Use Candidate.setReported when implemented
-        var dao = setupReportedCandidate(candidateRepository);
+        var dao = setupReportedCandidate(candidateRepository, randomYear());
         var candidate = Candidate.fetch(dao::identifier, candidateRepository, periodRepository);
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(
             candidate).indexDocument();

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -188,6 +188,16 @@ public final class CandidateDao extends Dao {
         return attempt(() -> JsonUtils.dtoObjectMapper.writeValueAsString(this)).orElseThrow();
     }
 
+    @DynamoDbIgnore
+    public boolean isReported() {
+        return ReportStatus.REPORTED.equals(candidate.reportStatus);
+    }
+
+    @DynamoDbIgnore
+    public boolean isNotReported() {
+        return !isReported();
+    }
+
     @Deprecated
     private String migratePeriodYear() {
         return isApplicableAndMissingPeriodYear() ? candidate.publicationDate().year() : periodYear;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -93,14 +93,14 @@ public class CandidateRepository extends DynamoRepository {
         batches.forEach(batch -> dynamoDbRetryClient.batchWriteItem(toBatchRequest(batch)));
     }
 
-    public ListingResult<CandidateDao> fetchCandidatesByYear(String year,
-                                                             Integer pageSize, Map<String, String> startMarker) {
+    public ListingResult<CandidateDao> fetchNonReportedCandidatesByYear(String year,
+                                                                        Integer pageSize, Map<String, String> startMarker) {
         var page = queryYearIndex(year, pageSize, startMarker);
         return new ListingResult<>(thereAreMorePagesToScan(page),
                                    nonNull(page.lastEvaluatedKey())
                                        ? toStringMap(page.lastEvaluatedKey()) : emptyMap(),
                                    page.items().size(),
-                                   page.items());
+                                   filterOutReportedCandidates(page));
     }
 
     public CandidateDao create(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses) {
@@ -199,6 +199,13 @@ public class CandidateRepository extends DynamoRepository {
     protected static QueryConditional queryCandidateParts(UUID id, String type) {
         return sortBeginsWith(
             Key.builder().partitionValue(CandidateDao.createPartitionKey(id.toString())).sortValue(type).build());
+    }
+
+    private static List<CandidateDao> filterOutReportedCandidates(Page<CandidateDao> page) {
+        return page.items()
+                   .stream()
+                   .filter(CandidateDao::isNotReported)
+                   .collect(Collectors.toList());
     }
 
     private static <T> Stream<List<T>> getBatches(List<T> scanResult) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -93,14 +93,15 @@ public class CandidateRepository extends DynamoRepository {
         batches.forEach(batch -> dynamoDbRetryClient.batchWriteItem(toBatchRequest(batch)));
     }
 
-    public ListingResult<CandidateDao> fetchNonReportedCandidatesByYear(String year,
-                                                                        Integer pageSize, Map<String, String> startMarker) {
+    public ListingResult<CandidateDao> fetchCandidatesByYear(String year,
+                                                             boolean includeReportedCandidates,
+                                                             Integer pageSize, Map<String, String> startMarker) {
         var page = queryYearIndex(year, pageSize, startMarker);
         return new ListingResult<>(thereAreMorePagesToScan(page),
                                    nonNull(page.lastEvaluatedKey())
                                        ? toStringMap(page.lastEvaluatedKey()) : emptyMap(),
                                    page.items().size(),
-                                   filterOutReportedCandidates(page));
+                                   includeReportedCandidates ? page.items() : filterOutReportedCandidates(page));
     }
 
     public CandidateDao create(DbCandidate dbCandidate, List<DbApprovalStatus> approvalStatuses) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
@@ -66,15 +66,17 @@ public class NviService {
         return periodRepository.getPeriods();
     }
 
-    public ListingResult<Dao> migrateAndUpdateVersion(int pageSize, Map<String, String> startMarker, List<KeyField> types) {
+    public ListingResult<Dao> migrateAndUpdateVersion(int pageSize, Map<String, String> startMarker,
+                                                      List<KeyField> types) {
         var scanResult = candidateRepository.scanEntries(pageSize, startMarker, types);
         candidateRepository.writeEntries(scanResult.getDatabaseEntries());
         return scanResult;
     }
 
-    public ListingResult<CandidateDao> fetchNonReportedCandidatesByYear(String year, Integer pageSize,
-                                                                        Map<String, String> startMarker) {
-        return candidateRepository.fetchNonReportedCandidatesByYear(year, pageSize, startMarker);
+    public ListingResult<CandidateDao> fetchCandidatesByYear(String year,
+                                                             boolean includeReportedCandidates, Integer pageSize,
+                                                             Map<String, String> startMarker) {
+        return candidateRepository.fetchCandidatesByYear(year, includeReportedCandidates, pageSize, startMarker);
     }
 
     private static boolean isInteger(String value) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviService.java
@@ -72,9 +72,9 @@ public class NviService {
         return scanResult;
     }
 
-    public ListingResult<CandidateDao> fetchCandidatesByYear(String year, Integer pageSize,
-                                                             Map<String, String> startMarker) {
-        return candidateRepository.fetchCandidatesByYear(year, pageSize, startMarker);
+    public ListingResult<CandidateDao> fetchNonReportedCandidatesByYear(String year, Integer pageSize,
+                                                                        Map<String, String> startMarker) {
+        return candidateRepository.fetchNonReportedCandidatesByYear(year, pageSize, startMarker);
     }
 
     private static boolean isInteger(String value) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -13,6 +13,7 @@ import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
 import static no.sikt.nva.nvi.test.TestUtils.randomInstanceTypeExcluding;
 import static no.sikt.nva.nvi.test.TestUtils.randomLevelExcluding;
+import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.sikt.nva.nvi.test.TestUtils.setupReportedCandidate;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
@@ -502,7 +503,7 @@ class CandidateTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnCandidateWithReportStatus() {
-        var dao = setupReportedCandidate(candidateRepository);
+        var dao = setupReportedCandidate(candidateRepository, randomYear());
         var candidate = Candidate.fetch(dao::identifier, candidateRepository, periodRepository);
         assertThat(candidate.toDto().status(), is(equalTo(ReportStatus.REPORTED.getValue())));
         assertThat(candidate.toDto().status(), is(equalTo(ReportStatus.REPORTED.getValue())));

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
@@ -88,7 +88,7 @@ public class NviServiceTest extends LocalDynamoTest {
         var firstCandidateInIndex = expectedCandidates.get(0);
         var secondCandidateInIndex = expectedCandidates.get(1);
         var startMarker = getYearIndexStartMarker(firstCandidateInIndex);
-        var results = nviService.fetchCandidatesByYear(year, null, startMarker).getDatabaseEntries();
+        var results = nviService.fetchNonReportedCandidatesByYear(year, null, startMarker).getDatabaseEntries();
         assertThat(results.size(), is(equalTo(1)));
         assertEquals(secondCandidateInIndex, results.get(0));
     }
@@ -100,7 +100,7 @@ public class NviServiceTest extends LocalDynamoTest {
         createNumberOfCandidatesForYear("2022", 10, candidateRepository);
         int pageSize = 5;
         var expectedCandidates = sortByIdentifier(candidates, pageSize);
-        var results = nviService.fetchCandidatesByYear(searchYear, pageSize, null).getDatabaseEntries();
+        var results = nviService.fetchNonReportedCandidatesByYear(searchYear, pageSize, null).getDatabaseEntries();
         assertThat(results.size(), is(equalTo(pageSize)));
         assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
     }
@@ -111,7 +111,7 @@ public class NviServiceTest extends LocalDynamoTest {
         int numberOfCandidates = DEFAULT_PAGE_SIZE + randomIntBetween(1, 10);
         var candidates = createNumberOfCandidatesForYear(year, numberOfCandidates, candidateRepository);
         var expectedCandidates = sortByIdentifier(candidates, DEFAULT_PAGE_SIZE);
-        var results = nviService.fetchCandidatesByYear(year, null, null).getDatabaseEntries();
+        var results = nviService.fetchNonReportedCandidatesByYear(year, null, null).getDatabaseEntries();
         assertThat(results.size(), is(equalTo(DEFAULT_PAGE_SIZE)));
         assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviServiceTest.java
@@ -6,6 +6,7 @@ import static no.sikt.nva.nvi.test.TestUtils.getYearIndexStartMarker;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
 import static no.sikt.nva.nvi.test.TestUtils.randomIntBetween;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
+import static no.sikt.nva.nvi.test.TestUtils.setupReportedCandidate;
 import static no.sikt.nva.nvi.test.TestUtils.sortByIdentifier;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -88,7 +89,7 @@ public class NviServiceTest extends LocalDynamoTest {
         var firstCandidateInIndex = expectedCandidates.get(0);
         var secondCandidateInIndex = expectedCandidates.get(1);
         var startMarker = getYearIndexStartMarker(firstCandidateInIndex);
-        var results = nviService.fetchNonReportedCandidatesByYear(year, null, startMarker).getDatabaseEntries();
+        var results = nviService.fetchCandidatesByYear(year, true, null, startMarker).getDatabaseEntries();
         assertThat(results.size(), is(equalTo(1)));
         assertEquals(secondCandidateInIndex, results.get(0));
     }
@@ -100,7 +101,7 @@ public class NviServiceTest extends LocalDynamoTest {
         createNumberOfCandidatesForYear("2022", 10, candidateRepository);
         int pageSize = 5;
         var expectedCandidates = sortByIdentifier(candidates, pageSize);
-        var results = nviService.fetchNonReportedCandidatesByYear(searchYear, pageSize, null).getDatabaseEntries();
+        var results = nviService.fetchCandidatesByYear(searchYear, true, pageSize, null).getDatabaseEntries();
         assertThat(results.size(), is(equalTo(pageSize)));
         assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
     }
@@ -111,9 +112,21 @@ public class NviServiceTest extends LocalDynamoTest {
         int numberOfCandidates = DEFAULT_PAGE_SIZE + randomIntBetween(1, 10);
         var candidates = createNumberOfCandidatesForYear(year, numberOfCandidates, candidateRepository);
         var expectedCandidates = sortByIdentifier(candidates, DEFAULT_PAGE_SIZE);
-        var results = nviService.fetchNonReportedCandidatesByYear(year, null, null).getDatabaseEntries();
+        var results = nviService.fetchCandidatesByYear(year, true, null, null).getDatabaseEntries();
         assertThat(results.size(), is(equalTo(DEFAULT_PAGE_SIZE)));
         assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
+    }
+
+    @Test
+    void shouldNotFetchReportedCandidatesWhenIncludeReportedCandidatesIsFalse() {
+        var year = randomYear();
+        var candidates = createNumberOfCandidatesForYear(year, 2, candidateRepository);
+        var reportedCandidate = setupReportedCandidate(candidateRepository, year);
+        var expectedCandidates = sortByIdentifier(candidates, null);
+        var results = nviService.fetchCandidatesByYear(year, false, null, null).getDatabaseEntries();
+        assertThat(results.size(), is(equalTo(2)));
+        assertThat(expectedCandidates, containsInAnyOrder(results.toArray()));
+        assertThat(results, not(containsInAnyOrder(reportedCandidate)));
     }
 
     private static Map<String, String> getStartMarker(CandidateDao dao) {

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
@@ -5,6 +5,7 @@ import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertNonCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
+import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.sikt.nva.nvi.test.TestUtils.setupReportedCandidate;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -88,7 +89,7 @@ class FetchNviCandidateByPublicationIdHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnCandidateWithReportStatus() throws IOException {
-        var candidate = setupReportedCandidate(candidateRepository);
+        var candidate = setupReportedCandidate(candidateRepository, randomYear());
         var request = requestWithAccessRight(candidate.candidate().publicationId());
 
         handler.handleRequest(request, output, CONTEXT);

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -416,10 +416,10 @@ public final class TestUtils {
         return randomCandidateBuilder(true).publicationDate(publicationDate(year)).build();
     }
 
-    public static CandidateDao setupReportedCandidate(CandidateRepository repository) {
+    public static CandidateDao setupReportedCandidate(CandidateRepository repository, String year) {
         var institutionId = randomUri();
-        return repository.create(randomCandidateBuilder(true, institutionId).build()
-                                     .copy()
+        return repository.create(randomCandidateBuilder(true, institutionId)
+                                     .publicationDate(DbPublicationDate.builder().year(year).build())
                                      .reportStatus(ReportStatus.REPORTED)
                                      .build(),
                                  List.of(randomApproval(institutionId)));


### PR DESCRIPTION
`ReEvaluateNviCandidatesHandler` is a tool to re-evalute and/or re-calculate points if requirements have changed in `EvaluateNviCandidatesHandler`

New case: I want to re-calculate points for all nvi canidates in database, except for the ones that are imported from cristin.
Solution: Filter out reported candidates for re-evaluation