### PR TITLE
NP-46527 Index document, supplement partOf

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
@@ -152,12 +152,12 @@ public class CandidateQuery {
                    .build()._toQuery();
     }
 
-    private static Query contributorQueryIncludingSubUnits(List<String> institutions) {
-        var institutionIdentifiers = extractIdentifiers(institutions);
+    private static Query contributorQueryIncludingSubUnits(List<String> organizations) {
+        var institutionIdentifiers = extractIdentifiers(organizations);
         return nestedQuery(jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS),
                            QueryBuilders.bool().must(
                                matchAtLeastOne(
-                                   termsQuery(institutions,
+                                   termsQuery(organizations,
                                               jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, AFFILIATIONS, ID)),
                                    termsQuery(institutionIdentifiers,
                                               jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, AFFILIATIONS, PART_OF))
@@ -167,18 +167,18 @@ public class CandidateQuery {
         );
     }
 
-    private static List<String> extractIdentifiers(List<String> institutions) {
-        return institutions.stream().map(CandidateQuery::getLastPathElement).toList();
+    private static List<String> extractIdentifiers(List<String> organizations) {
+        return organizations.stream().map(CandidateQuery::getLastPathElement).toList();
     }
 
     private static String getLastPathElement(String institution) {
         return UriWrapper.fromUri(institution).getLastPathElement();
     }
 
-    private static Query contributorQueryExcludingSubUnits(List<String> institutions) {
+    private static Query contributorQueryExcludingSubUnits(List<String> organizations) {
         return nestedQuery(jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS),
                            QueryBuilders.bool().must(
-                               termsQuery(institutions,
+                               termsQuery(organizations,
                                           jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, AFFILIATIONS, ID)),
                                matchQuery(CREATOR_ROLE, jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, ROLE))
                            ).build()._toQuery()

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
@@ -171,8 +171,8 @@ public class CandidateQuery {
         return organizations.stream().map(CandidateQuery::getLastPathElement).toList();
     }
 
-    private static String getLastPathElement(String institution) {
-        return UriWrapper.fromUri(institution).getLastPathElement();
+    private static String getLastPathElement(String organization) {
+        return UriWrapper.fromUri(organization).getLastPathElement();
     }
 
     private static Query contributorQueryExcludingSubUnits(List<String> organizations) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
+import nva.commons.core.paths.UriWrapper;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -79,8 +80,8 @@ public class CandidateQuery {
 
     public static Query matchAtLeastOne(Query... queries) {
         return new Query.Builder()
-            .bool(new BoolQuery.Builder().should(Arrays.stream(queries).toList()).build())
-            .build();
+                   .bool(new BoolQuery.Builder().should(Arrays.stream(queries).toList()).build())
+                   .build();
     }
 
     public Query toQuery() {
@@ -89,8 +90,8 @@ public class CandidateQuery {
 
     private static Query mustMatch(Query... queries) {
         return new Query.Builder()
-            .bool(new BoolQuery.Builder().must(Arrays.stream(queries).toList()).build())
-            .build();
+                   .bool(new BoolQuery.Builder().must(Arrays.stream(queries).toList()).build())
+                   .build();
     }
 
     private static Query multipleApprovalsQuery() {
@@ -99,9 +100,9 @@ public class CandidateQuery {
 
     private static Query nestedQuery(String path, Query... queries) {
         return new NestedQuery.Builder()
-            .path(path)
-            .query(mustMatch(queries))
-            .build()._toQuery();
+                   .path(path)
+                   .query(mustMatch(queries))
+                   .build()._toQuery();
     }
 
     private static Query statusQuery(String customer, ApprovalStatus status) {
@@ -112,10 +113,10 @@ public class CandidateQuery {
 
     private static Query termQuery(String value, String field) {
         return nonNull(value)
-                   ?  new TermQuery.Builder()
-                          .value(new FieldValue.Builder().stringValue(value).build())
-                          .field(field)
-                          .build()._toQuery()
+                   ? new TermQuery.Builder()
+                         .value(new FieldValue.Builder().stringValue(value).build())
+                         .field(field)
+                         .build()._toQuery()
                    : new MatchAllQuery.Builder().build()._toQuery();
     }
 
@@ -140,29 +141,38 @@ public class CandidateQuery {
     private static Query termsQuery(List<String> values, String field) {
         var termsFields = values.stream().map(FieldValue::of).toList();
         return new TermsQuery.Builder()
-            .field(field)
-            .terms(new TermsQueryField.Builder().value(termsFields).build())
-            .build()._toQuery();
+                   .field(field)
+                   .terms(new TermsQueryField.Builder().value(termsFields).build())
+                   .build()._toQuery();
     }
 
     private static Query matchQuery(String value, String field) {
         return new MatchQuery.Builder().field(field)
-            .query(new FieldValue.Builder().stringValue(value).build())
-            .build()._toQuery();
+                   .query(new FieldValue.Builder().stringValue(value).build())
+                   .build()._toQuery();
     }
 
     private static Query contributorQueryIncludingSubUnits(List<String> institutions) {
+        var institutionIdentifiers = extractIdentifiers(institutions);
         return nestedQuery(jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS),
                            QueryBuilders.bool().must(
                                matchAtLeastOne(
                                    termsQuery(institutions,
                                               jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, AFFILIATIONS, ID)),
-                                   termsQuery(institutions,
+                                   termsQuery(institutionIdentifiers,
                                               jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, AFFILIATIONS, PART_OF))
                                ),
                                matchQuery(CREATOR_ROLE, jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, ROLE))
                            ).build()._toQuery()
         );
+    }
+
+    private static List<String> extractIdentifiers(List<String> institutions) {
+        return institutions.stream().map(CandidateQuery::getLastPathElement).toList();
+    }
+
+    private static String getLastPathElement(String institution) {
+        return UriWrapper.fromUri(institution).getLastPathElement();
     }
 
     private static Query contributorQueryExcludingSubUnits(List<String> institutions) {
@@ -182,8 +192,8 @@ public class CandidateQuery {
 
     private static Query categoryQuery(String category) {
         return Optional.ofNullable(category)
-            .map(c -> termQuery(c, jsonPathOf(PUBLICATION_DETAILS, TYPE, KEYWORD)))
-            .orElse(null);
+                   .map(c -> termQuery(c, jsonPathOf(PUBLICATION_DETAILS, TYPE, KEYWORD)))
+                   .orElse(null);
     }
 
     private static Query statusQueryWithAssignee(String customer, ApprovalStatus status, boolean hasAssignee) {
@@ -197,14 +207,14 @@ public class CandidateQuery {
 
     private static Query notExistsQuery(String field) {
         return new BoolQuery.Builder()
-            .mustNot(new ExistsQuery.Builder().field(field).build()._toQuery())
-            .build()._toQuery();
+                   .mustNot(new ExistsQuery.Builder().field(field).build()._toQuery())
+                   .build()._toQuery();
     }
 
     private static Query existsQuery(String field) {
         return new BoolQuery.Builder()
-            .must(new ExistsQuery.Builder().field(field).build()._toQuery())
-            .build()._toQuery();
+                   .must(new ExistsQuery.Builder().field(field).build()._toQuery())
+                   .build()._toQuery();
     }
 
     private List<Query> specificMatch() {
@@ -220,9 +230,9 @@ public class CandidateQuery {
         return Stream.of(searchTermQuery, institutionQuery, filterQuery, yearQuery, categoryQuery, titleQuery,
                          contributorQuery,
                          assigneeQuery)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .toList();
+                   .filter(Optional::isPresent)
+                   .map(Optional::get)
+                   .toList();
     }
 
     private Optional<Query> constructQueryWithFilter() {
@@ -278,29 +288,29 @@ public class CandidateQuery {
 
     private Optional<Query> createTitleQuery(String title) {
         return Optional.ofNullable(title)
-            .map(t -> new MatchPhraseQuery.Builder()
-                .field(jsonPathOf(PUBLICATION_DETAILS, TITLE))
-                .query(t)
-                .build()
-                ._toQuery());
+                   .map(t -> new MatchPhraseQuery.Builder()
+                                 .field(jsonPathOf(PUBLICATION_DETAILS, TITLE))
+                                 .query(t)
+                                 .build()
+                                 ._toQuery());
     }
 
     private Optional<Query> createContributorQuery(String contributor) {
         return Optional.ofNullable(contributor)
-            .map(c -> new MatchPhraseQuery.Builder()
-                .field(jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, NAME))
-                .query(c)
-                .build()
-                ._toQuery());
+                   .map(c -> new MatchPhraseQuery.Builder()
+                                 .field(jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, NAME))
+                                 .query(c)
+                                 .build()
+                                 ._toQuery());
     }
 
     private Optional<Query> createAssigneeQuery(String assignee) {
         return Optional.ofNullable(assignee)
-            .map(a -> new MatchPhraseQuery.Builder()
-                .field(jsonPathOf(APPROVALS, ASSIGNEE))
-                .query(a)
-                .build()
-                ._toQuery());
+                   .map(a -> new MatchPhraseQuery.Builder()
+                                 .field(jsonPathOf(APPROVALS, ASSIGNEE))
+                                 .query(a)
+                                 .build()
+                                 ._toQuery());
     }
 
     public enum QueryFilterType {
@@ -325,8 +335,8 @@ public class CandidateQuery {
         public static Optional<QueryFilterType> parse(String candidate) {
             var testValue = isNull(candidate) ? "" : candidate;
             return Arrays.stream(values())
-                .filter(item -> item.getFilter().equalsIgnoreCase(testValue))
-                .findAny();
+                       .filter(item -> item.getFilter().equalsIgnoreCase(testValue))
+                       .findAny();
         }
 
         @JsonValue

--- a/index-handlers/src/test/resources/document_approved.json
+++ b/index-handlers/src/test/resources/document_approved.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_approved_collaboration.json
+++ b/index-handlers/src/test/resources/document_approved_collaboration.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_assigned.json
+++ b/index-handlers/src/test/resources/document_assigned.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_assigned_collaboration.json
+++ b/index-handlers/src/test/resources/document_assigned_collaboration.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_pending.json
+++ b/index-handlers/src/test/resources/document_pending.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_pending_category_degree_bachelor.json
+++ b/index-handlers/src/test/resources/document_pending_category_degree_bachelor.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_pending_collaboration.json
+++ b/index-handlers/src/test/resources/document_pending_collaboration.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_rejected.json
+++ b/index-handlers/src/test/resources/document_rejected.json
@@ -19,7 +19,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_rejected_collaboration.json
+++ b/index-handlers/src/test/resources/document_rejected_collaboration.json
@@ -19,7 +19,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_with_contributor_from_ntnu_subunit.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_ntnu_subunit.json
@@ -16,7 +16,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.1",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
+          "partOf": ["194.0.0.0"]
         } ],
         "role" : "Creator"
       } ]

--- a/index-handlers/src/test/resources/document_with_contributor_from_sikt.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_sikt.json
@@ -16,7 +16,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.1",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"]
+          "partOf": ["20754.0.0.0"]
         } ],
         "role" : "Creator"
       } ]

--- a/index-handlers/src/test/resources/document_with_contributor_from_sikt_but_not_creator.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_sikt_but_not_creator.json
@@ -16,7 +16,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.1",
-          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"]
+          "partOf": ["20754.0.0.0"]
         } ],
         "role" : "Editor"
       } ]

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -69,8 +69,9 @@ public final class Candidate {
     public static final URI CONTEXT_URI = UriWrapper.fromHost(API_DOMAIN)
                                               .addChild(BASE_PATH, "context")
                                               .getUri();
+    private static final String CONTEXT = stringFromResources(Path.of("nviCandidateContext.json"))
+                                              .replace("__REPLACE_WITH_API_DOMAIN__", API_DOMAIN);
     private static final String CANDIDATE_PATH = "candidate";
-    private static final String CONTEXT = stringFromResources(Path.of("nviCandidateContext.json"));
     private static final String PERIOD_CLOSED_MESSAGE = "Period is closed, perform actions on candidate is forbidden!";
     private static final String PERIOD_NOT_OPENED_MESSAGE = "Period is not opened yet, perform actions on candidate is"
                                                             + " forbidden!";

--- a/nvi-commons/src/main/resources/nviCandidateContext.json
+++ b/nvi-commons/src/main/resources/nviCandidateContext.json
@@ -31,8 +31,11 @@
       "@type": "xsd:dateTime"
     },
     "partOf": {
-      "@type": "@id",
-      "@container": "@set"
+      "@container": "@set",
+      "@context": {
+        "@base": "__REPLACE_WITH_API_DOMAIN__/cristin/organization"
+      },
+      "@type": "@id"
     }
   }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -490,7 +490,8 @@ class CandidateTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnNviCandidateContextAsString() {
-        var expectedContext = stringFromResources(Path.of("nviCandidateContext.json"));
+        var expectedContext = stringFromResources(Path.of("nviCandidateContext.json")).replace(
+            "__REPLACE_WITH_API_DOMAIN__", new Environment().readEnv("API_HOST"));
         assertThat(Candidate.getJsonLdContext(), is(equalTo(expectedContext)));
     }
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -28,6 +28,7 @@ import no.sikt.nva.nvi.index.model.OrganizationType;
 import no.sikt.nva.nvi.index.model.PublicationDate;
 import no.sikt.nva.nvi.index.model.PublicationDetails;
 import nva.commons.core.paths.UnixPath;
+import nva.commons.core.paths.UriWrapper;
 
 public final class IndexDocumentTestUtils {
 
@@ -141,8 +142,7 @@ public final class IndexDocumentTestUtils {
     }
 
     private static OrganizationType toAffiliationWithPartOf(URI uri, boolean isNviAffiliation) {
-        return isNviAffiliation ? generateNviOrganization(uri)
-                   : generateOrganization(uri);
+        return isNviAffiliation ? generateNviOrganization(uri) : generateOrganization(uri);
     }
 
     private static OrganizationType generateOrganization(URI uri) {
@@ -155,7 +155,7 @@ public final class IndexDocumentTestUtils {
     private static OrganizationType generateNviOrganization(URI uri) {
         return NviOrganization.builder()
                    .withId(uri.toString())
-                   .withPartOf(List.of(HARD_CODED_PART_OF))
+                   .withPartOf(List.of(HARD_CODED_PART_OF, UriWrapper.fromUri(HARD_CODED_PART_OF).getLastPathElement()))
                    .build();
     }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -155,7 +155,7 @@ public final class IndexDocumentTestUtils {
     private static OrganizationType generateNviOrganization(URI uri) {
         return NviOrganization.builder()
                    .withId(uri.toString())
-                   .withPartOf(List.of(HARD_CODED_PART_OF, UriWrapper.fromUri(HARD_CODED_PART_OF).getLastPathElement()))
+                   .withPartOf(List.of(UriWrapper.fromUri(HARD_CODED_PART_OF).getLastPathElement()))
                    .build();
     }
 }


### PR DESCRIPTION
Jira issue: NP-46527 Index document, supplement partOf

For aggregation purposes, modify partOf-list to only contain identifiers (not whole URI): Example:
```
"contributors": [
  {
    "type": "NviContributor",
    "id": "https://example.org/person/997998",
    "affiliations": [
      {
        "type": "NviOrganization",
        "id": "https://example.org/organization/194.1.1.1”,
        "partOf": ["194.0.0.0”, "194.1.0.0", "194.1.1.0"]
        ]
      }
    ]
  }
]
```

Also, updated nvi context with the following:
```
"partOf": {
    "@container": "@set",
    "@context": {
      "@base": "__REPLACE_WITH_API_DOMAIN__/cristin/organization"
    },
    "@type": "@id"
  }
```

This change required an update of the OpenSearch `Query` `contributorQueryIncludingSubUnits`