### PR TITLE
Np 46551 Index document, approval status New

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
@@ -298,7 +298,6 @@ public class CandidateQuery {
         REJECTED_AGG("rejected"),
         REJECTED_COLLABORATION_AGG("rejectedCollaboration"),
         ASSIGNMENTS_AGG("assignments"),
-
         EMPTY_FILTER("");
 
         private final String filter;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/ApprovalStatus.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/ApprovalStatus.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import nva.commons.core.SingletonCollector;
 
 public enum ApprovalStatus {
+    NEW("New"),
     PENDING("Pending"),
     APPROVED("Approved"),
     REJECTED("Rejected");
@@ -15,15 +16,15 @@ public enum ApprovalStatus {
         this.value = value;
     }
 
-    @JsonValue
-    public String getValue() {
-        return value;
-    }
-
     public static ApprovalStatus fromValue(String candidate) {
         return Arrays.stream(values())
                    .filter(item -> item.getValue().equalsIgnoreCase(candidate))
                    .collect(SingletonCollector.tryCollect())
                    .orElseThrow();
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -46,6 +46,13 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         return new Builder();
     }
 
+    public Approval getApprovalForInstitution(String institutionId) {
+        return approvals.stream()
+                   .filter(approval -> approval.institutionId().equals(institutionId))
+                   .findFirst()
+                   .orElseThrow();
+    }
+
     public static final class Builder {
 
         private URI context;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/NviCandidateIndexDocument.java
@@ -49,7 +49,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
     public Approval getApprovalForInstitution(String institutionId) {
         return approvals.stream()
                    .filter(approval -> approval.institutionId().equals(institutionId))
-                   .findFirst()
+                   .findAny()
                    .orElseThrow();
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -77,6 +77,11 @@ public final class NviCandidateIndexDocumentGenerator {
         return InstitutionPoints.from(candidate.getInstitutionPoints(approval.getInstitutionId()));
     }
 
+    private static ApprovalStatus getApprovalStatus(Approval approval) {
+        return approval.isPendingAndUnassigned() ? ApprovalStatus.NEW
+                   : ApprovalStatus.fromValue(approval.getStatus().getValue());
+    }
+
     private NviCandidateIndexDocument buildCandidate(JsonNode resource, Candidate candidate,
                                                      List<no.sikt.nva.nvi.index.model.Approval> approvals) {
         return NviCandidateIndexDocument.builder()
@@ -126,7 +131,7 @@ public final class NviCandidateIndexDocumentGenerator {
         return no.sikt.nva.nvi.index.model.Approval.builder()
                    .withInstitutionId(approval.getInstitutionId().toString())
                    .withLabels(extractLabels(resource, approval))
-                   .withApprovalStatus(ApprovalStatus.fromValue(approval.getStatus().getValue()))
+                   .withApprovalStatus(getApprovalStatus(approval))
                    .withPoints(getInstitutionPoints(approval, candidate))
                    .withAssignee(extractAssignee(approval))
                    .build();

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchAggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchAggregations.java
@@ -1,0 +1,25 @@
+package no.sikt.nva.nvi.index.utils;
+
+public enum SearchAggregations {
+    NEW_AGG("pending"),
+    NEW_COLLABORATION_AGG("pendingCollaboration"),
+    PENDING_AGG("assigned"),
+    PENDING_COLLABORATION_AGG("assignedCollaboration"),
+    APPROVED_AGG("approved"),
+    APPROVED_COLLABORATION_AGG("approvedCollaboration"),
+    REJECTED_AGG("rejected"),
+    REJECTED_COLLABORATION_AGG("rejectedCollaboration"),
+    ASSIGNMENTS_AGG("assignments"),
+    COMPLETED_AGGREGATION_AGG("completed"),
+    TOTAL_COUNT_AGGREGATION_AGG("totalCount");
+
+    private final String aggregationName;
+
+    SearchAggregations(String aggregationName) {
+        this.aggregationName = aggregationName;
+    }
+
+    public String getAggregationName() {
+        return aggregationName;
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
@@ -16,16 +16,6 @@ import org.opensearch.client.opensearch._types.mapping.TypeMapping;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 
 public final class SearchConstants {
-
-    public static final String NEW_AGG = "pending";
-    public static final String NEW_COLLABORATION_AGG = "pendingCollaboration";
-    public static final String PENDING_AGG = "assigned";
-    public static final String PENDING_COLLABORATION_AGG = "assignedCollaboration";
-    public static final String APPROVED_AGG = "approved";
-    public static final String APPROVED_COLLABORATION_AGG = "approvedCollaboration";
-    public static final String REJECTED_AGG = "rejected";
-    public static final String REJECTED_COLLABORATION_AGG = "rejectedCollaboration";
-    public static final String ASSIGNMENTS_AGG = "assignments";
     public static final String ID = "id";
     public static final String INSTITUTION_ID = "institutionId";
     public static final String ASSIGNEE = "assignee";

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
@@ -17,10 +17,10 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 
 public final class SearchConstants {
 
-    public static final String PENDING_AGG = "pending";
-    public static final String PENDING_COLLABORATION_AGG = "pendingCollaboration";
-    public static final String ASSIGNED_AGG = "assigned";
-    public static final String ASSIGNED_COLLABORATION_AGG = "assignedCollaboration";
+    public static final String NEW_AGG = "pending";
+    public static final String NEW_COLLABORATION_AGG = "pendingCollaboration";
+    public static final String PENDING_AGG = "assigned";
+    public static final String PENDING_COLLABORATION_AGG = "assignedCollaboration";
     public static final String APPROVED_AGG = "approved";
     public static final String APPROVED_COLLABORATION_AGG = "approvedCollaboration";
     public static final String REJECTED_AGG = "rejected";

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -44,6 +44,7 @@ import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.index.aws.S3StorageWriter;
+import no.sikt.nva.nvi.index.model.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.ConsumptionAttributes;
 import no.sikt.nva.nvi.index.model.IndexDocumentWithConsumptionAttributes;
 import no.sikt.nva.nvi.index.model.NviCandidateIndexDocument;
@@ -153,6 +154,19 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, CONTEXT);
         var actualIndexDocument = parseJson(s3Writer.getFile(createPath(candidate)));
         assertEquals(expectedConsumptionAttributes, actualIndexDocument.consumptionAttributes());
+    }
+
+    @Test
+    void shouldSetApprovalStatusNewWhenApprovalIsPendingAndUnassigned(){
+        var institutionId = randomUri();
+        var candidate = randomApplicableCandidate(institutionId);
+        setUpExistingResourceInS3AndGenerateExpectedDocument(candidate);
+        var event = createEvent(candidate.getIdentifier());
+        mockUriRetrieverOrgResponse(candidate);
+        handler.handleRequest(event, CONTEXT);
+        var actualIndexDocument = parseJson(s3Writer.getFile(createPath(candidate))).indexDocument();
+        assertEquals(ApprovalStatus.NEW,
+                     actualIndexDocument.getApprovalForInstitution(institutionId.toString()).approvalStatus());
     }
 
     @Test
@@ -488,6 +502,12 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     private Candidate randomApplicableCandidate() {
         return Candidate.upsert(createUpsertCandidateRequest(SOME_REPORTING_YEAR), candidateRepository,
+                                periodRepository)
+                   .orElseThrow();
+    }
+
+    private Candidate randomApplicableCandidate(URI institutionId) {
+        return Candidate.upsert(createUpsertCandidateRequest(institutionId), candidateRepository,
                                 periodRepository)
                    .orElseThrow();
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -157,7 +157,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     }
 
     @Test
-    void shouldSetApprovalStatusNewWhenApprovalIsPendingAndUnassigned(){
+    void shouldSetApprovalStatusNewWhenApprovalIsPendingAndUnassigned() {
         var institutionId = randomUri();
         var candidate = randomApplicableCandidate(institutionId);
         setUpExistingResourceInS3AndGenerateExpectedDocument(candidate);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -1,16 +1,16 @@
 package no.sikt.nva.nvi.index;
 
-import static no.sikt.nva.nvi.index.Aggregations.COMPLETED_AGGREGATION_AGG;
-import static no.sikt.nva.nvi.index.Aggregations.TOTAL_COUNT_AGGREGATION_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVED_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVED_COLLABORATION_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.PENDING_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.PENDING_COLLABORATION_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.ASSIGNMENTS_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.NEW_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.NEW_COLLABORATION_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.REJECTED_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.REJECTED_COLLABORATION_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.APPROVED_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.APPROVED_COLLABORATION_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.ASSIGNMENTS_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.COMPLETED_AGGREGATION_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.NEW_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.NEW_COLLABORATION_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.PENDING_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.PENDING_COLLABORATION_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.REJECTED_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.REJECTED_COLLABORATION_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchAggregations.TOTAL_COUNT_AGGREGATION_AGG;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -44,6 +44,7 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import no.sikt.nva.nvi.index.aws.CandidateQuery.QueryFilterType;
 import no.sikt.nva.nvi.index.aws.OpenSearchClient;
 import no.sikt.nva.nvi.index.model.Approval;
 import no.sikt.nva.nvi.index.model.ApprovalStatus;
@@ -578,31 +579,31 @@ public class OpenSearchClientTest {
 
     private static Stream<Entry<String, Integer>> aggregationNameAndExpectedCountProvider() {
         var map = new HashMap<String, Integer>();
-        map.put(NEW_AGG, 2);
-        map.put(NEW_COLLABORATION_AGG, 1);
-        map.put(PENDING_AGG, 2);
-        map.put(PENDING_COLLABORATION_AGG, 1);
-        map.put(APPROVED_AGG, 2);
-        map.put(APPROVED_COLLABORATION_AGG, 1);
-        map.put(REJECTED_AGG, 2);
-        map.put(REJECTED_COLLABORATION_AGG, 1);
-        map.put(ASSIGNMENTS_AGG, 4);
-        map.put(COMPLETED_AGGREGATION_AGG, 4);
-        map.put(TOTAL_COUNT_AGGREGATION_AGG, 8);
+        map.put(NEW_AGG.getAggregationName(), 2);
+        map.put(NEW_COLLABORATION_AGG.getAggregationName(), 1);
+        map.put(PENDING_AGG.getAggregationName(), 2);
+        map.put(PENDING_COLLABORATION_AGG.getAggregationName(), 1);
+        map.put(APPROVED_AGG.getAggregationName(), 2);
+        map.put(APPROVED_COLLABORATION_AGG.getAggregationName(), 1);
+        map.put(REJECTED_AGG.getAggregationName(), 2);
+        map.put(REJECTED_COLLABORATION_AGG.getAggregationName(), 1);
+        map.put(ASSIGNMENTS_AGG.getAggregationName(), 4);
+        map.put(COMPLETED_AGGREGATION_AGG.getAggregationName(), 4);
+        map.put(TOTAL_COUNT_AGGREGATION_AGG.getAggregationName(), 8);
         return map.entrySet().stream();
     }
 
     private static Stream<Entry<String, Integer>> filterNameProvider() {
         var map = new HashMap<String, Integer>();
-        map.put(NEW_AGG, 2);
-        map.put(NEW_COLLABORATION_AGG, 1);
-        map.put(PENDING_AGG, 2);
-        map.put(PENDING_COLLABORATION_AGG, 1);
-        map.put(APPROVED_AGG, 2);
-        map.put(APPROVED_COLLABORATION_AGG, 1);
-        map.put(REJECTED_AGG, 2);
-        map.put(REJECTED_COLLABORATION_AGG, 1);
-        map.put(ASSIGNMENTS_AGG, 4);
+        map.put(QueryFilterType.NEW_AGG.getFilter(), 2);
+        map.put(QueryFilterType.NEW_COLLABORATION_AGG.getFilter(), 1);
+        map.put(QueryFilterType.PENDING_AGG.getFilter(), 2);
+        map.put(QueryFilterType.PENDING_COLLABORATION_AGG.getFilter(), 1);
+        map.put(QueryFilterType.APPROVED_AGG.getFilter(), 2);
+        map.put(QueryFilterType.APPROVED_COLLABORATION_AGG.getFilter(), 1);
+        map.put(QueryFilterType.REJECTED_AGG.getFilter(), 2);
+        map.put(QueryFilterType.REJECTED_COLLABORATION_AGG.getFilter(), 1);
+        map.put(QueryFilterType.ASSIGNMENTS_AGG.getFilter(), 4);
         return map.entrySet().stream();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -4,11 +4,11 @@ import static no.sikt.nva.nvi.index.Aggregations.COMPLETED_AGGREGATION_AGG;
 import static no.sikt.nva.nvi.index.Aggregations.TOTAL_COUNT_AGGREGATION_AGG;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVED_AGG;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVED_COLLABORATION_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.ASSIGNED_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.ASSIGNED_COLLABORATION_AGG;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.ASSIGNMENTS_AGG;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.PENDING_AGG;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.PENDING_COLLABORATION_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchConstants.ASSIGNMENTS_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchConstants.NEW_AGG;
+import static no.sikt.nva.nvi.index.utils.SearchConstants.NEW_COLLABORATION_AGG;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.REJECTED_AGG;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.REJECTED_COLLABORATION_AGG;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
@@ -201,10 +201,10 @@ public class OpenSearchClientTest {
     @MethodSource("aggregationNameAndExpectedCountProvider")
     void shouldReturnAggregationsWithExpectedCount(Entry<String, Integer> entry)
         throws IOException, InterruptedException {
-        addDocumentsToIndex(documentFromString("document_pending.json"),
+        addDocumentsToIndex(documentFromString("document_new.json"),
+                            documentFromString("document_new_collaboration.json"),
+                            documentFromString("document_pending.json"),
                             documentFromString("document_pending_collaboration.json"),
-                            documentFromString("document_assigned.json"),
-                            documentFromString("document_assigned_collaboration.json"),
                             documentFromString("document_approved.json"),
                             documentFromString("document_approved_collaboration.json"),
                             documentFromString("document_rejected.json"),
@@ -282,10 +282,10 @@ public class OpenSearchClientTest {
     @MethodSource("filterNameProvider")
     void shouldReturnSearchResultsUsingFilter(Entry<String, Integer> entry)
         throws IOException, InterruptedException {
-        addDocumentsToIndex(documentFromString("document_pending.json"),
+        addDocumentsToIndex(documentFromString("document_new.json"),
+                            documentFromString("document_new_collaboration.json"),
+                            documentFromString("document_pending.json"),
                             documentFromString("document_pending_collaboration.json"),
-                            documentFromString("document_assigned.json"),
-                            documentFromString("document_assigned_collaboration.json"),
                             documentFromString("document_approved.json"),
                             documentFromString("document_approved_collaboration.json"),
                             documentFromString("document_rejected.json"),
@@ -412,10 +412,10 @@ public class OpenSearchClientTest {
     @MethodSource("filterNameProvider")
     void shouldReturnSearchResultsUsingFilterAndSearchTermCombined(Entry<String, Integer> entry)
         throws IOException, InterruptedException {
-        addDocumentsToIndex(documentFromString("document_pending.json"),
+        addDocumentsToIndex(documentFromString("document_new.json"),
+                            documentFromString("document_new_collaboration.json"),
+                            documentFromString("document_pending.json"),
                             documentFromString("document_pending_collaboration.json"),
-                            documentFromString("document_assigned.json"),
-                            documentFromString("document_assigned_collaboration.json"),
                             documentFromString("document_approved.json"),
                             documentFromString("document_approved_collaboration.json"),
                             documentFromString("document_rejected.json"),
@@ -431,7 +431,7 @@ public class OpenSearchClientTest {
 
     @Test
     void shouldReturnSingleDocumentWhenFilteringByCategory() throws InterruptedException, IOException {
-        addDocumentsToIndex(documentFromString("document_pending.json"),
+        addDocumentsToIndex(documentFromString("document_new.json"),
                             documentFromString("document_pending_category_degree_bachelor.json"));
 
         var searchParameters =
@@ -578,10 +578,10 @@ public class OpenSearchClientTest {
 
     private static Stream<Entry<String, Integer>> aggregationNameAndExpectedCountProvider() {
         var map = new HashMap<String, Integer>();
+        map.put(NEW_AGG, 2);
+        map.put(NEW_COLLABORATION_AGG, 1);
         map.put(PENDING_AGG, 2);
         map.put(PENDING_COLLABORATION_AGG, 1);
-        map.put(ASSIGNED_AGG, 2);
-        map.put(ASSIGNED_COLLABORATION_AGG, 1);
         map.put(APPROVED_AGG, 2);
         map.put(APPROVED_COLLABORATION_AGG, 1);
         map.put(REJECTED_AGG, 2);
@@ -594,10 +594,10 @@ public class OpenSearchClientTest {
 
     private static Stream<Entry<String, Integer>> filterNameProvider() {
         var map = new HashMap<String, Integer>();
+        map.put(NEW_AGG, 2);
+        map.put(NEW_COLLABORATION_AGG, 1);
         map.put(PENDING_AGG, 2);
         map.put(PENDING_COLLABORATION_AGG, 1);
-        map.put(ASSIGNED_AGG, 2);
-        map.put(ASSIGNED_COLLABORATION_AGG, 1);
         map.put(APPROVED_AGG, 2);
         map.put(APPROVED_COLLABORATION_AGG, 1);
         map.put(REJECTED_AGG, 2);

--- a/index-handlers/src/test/resources/document_approved.json
+++ b/index-handlers/src/test/resources/document_approved.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e4",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e7",
   "numberOfApprovals": 1,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",

--- a/index-handlers/src/test/resources/document_approved_collaboration.json
+++ b/index-handlers/src/test/resources/document_approved_collaboration.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e5",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e8",
   "numberOfApprovals": 2,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",

--- a/index-handlers/src/test/resources/document_new.json
+++ b/index-handlers/src/test/resources/document_new.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e2",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e0",
   "numberOfApprovals": 1,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
@@ -13,7 +13,7 @@
     "contributors": [
       {
         "type": "Contributor",
-        "id": "https://api.dev.nva.aws.unit.no/cristin/person/1136323555",
+        "id": "https://api.dev.nva.aws.unit.no/cristin/person/1136326",
         "name": "Kir Truhacev",
         "affiliations" : [ {
           "type": "Organization",
@@ -27,13 +27,12 @@
   "approvals": [
     {
       "type": "Approval",
-      "assignee": "user1",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
       "labels": {
         "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",
         "en": "Sikt - Norwegian Agency for Shared Services in Education and Research"
       },
-      "approvalStatus": "Pending"
+      "approvalStatus": "New"
     }
   ]
 }

--- a/index-handlers/src/test/resources/document_new_collaboration.json
+++ b/index-handlers/src/test/resources/document_new_collaboration.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e3",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e1",
   "numberOfApprovals": 2,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
@@ -27,13 +27,12 @@
   "approvals": [
     {
       "type": "Approval",
-      "assignee": "user1",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
       "labels": {
         "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",
         "en": "Sikt - Norwegian Agency for Shared Services in Education and Research"
       },
-      "approvalStatus": "Pending"
+      "approvalStatus": "New"
     },
     {
       "type": "Approval",
@@ -42,7 +41,7 @@
         "nb": "NTNU",
         "en": "NTNU"
       },
-      "approvalStatus": "Pending"
+      "approvalStatus": "New"
     }
   ]
 }

--- a/index-handlers/src/test/resources/document_pending.json
+++ b/index-handlers/src/test/resources/document_pending.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e0",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e2",
   "numberOfApprovals": 1,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
@@ -27,6 +27,7 @@
   "approvals": [
     {
       "type": "Approval",
+      "assignee": "user1",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
       "labels": {
         "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",

--- a/index-handlers/src/test/resources/document_pending_category_degree_bachelor.json
+++ b/index-handlers/src/test/resources/document_pending_category_degree_bachelor.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e8",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e9",
   "numberOfApprovals": 1,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
@@ -26,6 +26,7 @@
   },
   "approvals": [
     {
+      "assignee": "user1",
       "type": "Approval",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
       "labels": {

--- a/index-handlers/src/test/resources/document_pending_collaboration.json
+++ b/index-handlers/src/test/resources/document_pending_collaboration.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e1",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e4",
   "numberOfApprovals": 2,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
@@ -27,6 +27,7 @@
   "approvals": [
     {
       "type": "Approval",
+      "assignee": "user1",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
       "labels": {
         "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",
@@ -36,6 +37,7 @@
     },
     {
       "type": "Approval",
+      "assignee": "user1",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/2333.0.0.0",
       "labels": {
         "nb": "NTNU",

--- a/index-handlers/src/test/resources/document_rejected.json
+++ b/index-handlers/src/test/resources/document_rejected.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e6",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e5",
   "numberOfApprovals": 1,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",

--- a/index-handlers/src/test/resources/document_rejected_collaboration.json
+++ b/index-handlers/src/test/resources/document_rejected_collaboration.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e7",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e6",
   "numberOfApprovals": 2,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Approval.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Approval.java
@@ -68,6 +68,10 @@ public class Approval {
         return nonNull(assignee) && nonNull(assignee.value());
     }
 
+    public boolean isPendingAndUnassigned() {
+        return ApprovalStatus.PENDING.equals(status) && !isAssigned();
+    }
+
     public Approval update(UpdateApprovalRequest input) {
         if (input instanceof UpdateAssigneeRequest request) {
             var newDao = repository.updateApprovalStatusDao(identifier, updateAssignee(request));

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/ApprovalTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/ApprovalTest.java
@@ -1,0 +1,30 @@
+package no.sikt.nva.nvi.common.service.model;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.db.ApprovalStatusDao;
+import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
+import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
+import no.sikt.nva.nvi.common.db.CandidateRepository;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class ApprovalTest {
+
+    @Test
+    void shouldReturnTrueWhenApprovalIsPendingAndUnassigned() {
+        var identifier = UUID.randomUUID();
+        var approval = new Approval(Mockito.mock(CandidateRepository.class), identifier,
+                                    createPendingApproval(identifier));
+        assertTrue(approval.isPendingAndUnassigned());
+    }
+
+    private static ApprovalStatusDao createPendingApproval(UUID identifier) {
+        return new ApprovalStatusDao(identifier, createPendingApproval(), "1");
+    }
+
+    private static DbApprovalStatus createPendingApproval() {
+        return new DbApprovalStatus(randomUri(), DbStatus.PENDING, null, null, null, null);
+    }
+}


### PR DESCRIPTION
Jira task: NP-46551 Index document, logical status `New`. This will make it easier to make aggregations for new feature: Institution report.

Same "logic" as in ticket expansion in publication-api. If approval is _pending and unassigned_, set status `New` in index document.

Updated aggregations, now no longer necessary to check if approval is assigned or not in aggregations `pending`, `pendingCollaboration`, `assigned`, `assignedCollaboration`. 