### PR TITLE
CandidateDto, Approval status New

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/dto/ApprovalDto.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/dto/ApprovalDto.java
@@ -8,14 +8,15 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.time.Instant;
-import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
+import no.sikt.nva.nvi.common.service.model.Approval;
+import no.sikt.nva.nvi.common.service.model.Username;
 
 @JsonTypeName(ApprovalDto.APPROVAL)
 @JsonTypeInfo(use = Id.NAME, property = "type")
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
 public record ApprovalDto(URI institutionId,
-                          ApprovalStatus status,
+                          ApprovalStatusDto status,
                           BigDecimal points,
                           String assignee,
                           String finalizedBy,
@@ -28,10 +29,26 @@ public record ApprovalDto(URI institutionId,
         return new Builder();
     }
 
+    public static ApprovalDto fromApprovalAndInstitutionPoints(Approval approval, BigDecimal points) {
+        return ApprovalDto.builder()
+                   .withInstitutionId(approval.getInstitutionId())
+                   .withStatus(ApprovalStatusDto.from(approval.getStatus(), approval.isAssigned()))
+                   .withPoints(points)
+                   .withAssignee(mapToUsernameString(approval.getAssignee()))
+                   .withFinalizedBy(mapToUsernameString(approval.getFinalizedBy()))
+                   .withFinalizedDate(approval.getFinalizedDate())
+                   .withReason(approval.getReason())
+                   .build();
+    }
+
+    private static String mapToUsernameString(Username assignee) {
+        return assignee != null ? assignee.value() : null;
+    }
+
     public static final class Builder {
 
         private URI institutionId;
-        private ApprovalStatus status;
+        private ApprovalStatusDto status;
         private BigDecimal points;
         private String assignee;
         private String finalizedBy;
@@ -46,7 +63,7 @@ public record ApprovalDto(URI institutionId,
             return this;
         }
 
-        public Builder withStatus(ApprovalStatus status) {
+        public Builder withStatus(ApprovalStatusDto status) {
             this.status = status;
             return this;
         }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/dto/ApprovalStatusDto.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/dto/ApprovalStatusDto.java
@@ -1,0 +1,28 @@
+package no.sikt.nva.nvi.common.service.dto;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
+
+public enum ApprovalStatusDto {
+
+    NEW("New"), PENDING("Pending"), APPROVED("Approved"), REJECTED("Rejected");
+
+    @JsonValue
+    private final String value;
+
+    ApprovalStatusDto(String value) {
+        this.value = value;
+    }
+
+    public static ApprovalStatusDto from(ApprovalStatus status, boolean approvalHasAssignee) {
+        return switch (status) {
+            case PENDING -> approvalHasAssignee ? PENDING : NEW;
+            case APPROVED -> APPROVED;
+            case REJECTED -> REJECTED;
+        };
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -575,9 +575,7 @@ public final class Candidate {
                    .build();
     }
 
-    private static String mapToUsernameString(Username assignee) {
-        return assignee != null ? assignee.value() : null;
-    }
+
 
     private void setUserAsAssigneeIfApprovalIsUnassigned(String username, URI institutionId) {
         approvals.computeIfPresent(institutionId, (uri, approval) -> updateAssigneeIfUnassigned(username, approval));
@@ -636,18 +634,11 @@ public final class Candidate {
     }
 
     private List<ApprovalDto> mapToApprovalDtos() {
-        return streamApprovals().map(this::mapToApprovalDto).toList();
+        return streamApprovals().map(this::toApprovalDto).toList();
     }
 
-    private ApprovalDto mapToApprovalDto(Approval approval) {
-        return ApprovalDto.builder()
-                   .withInstitutionId(approval.getInstitutionId())
-                   .withStatus(approval.getStatus())
-                   .withAssignee(mapToUsernameString(approval.getAssignee()))
-                   .withFinalizedBy(mapToUsernameString(approval.getFinalizedBy()))
-                   .withFinalizedDate(approval.getFinalizedDate())
-                   .withPoints(getPointValueForInstitution(approval.getInstitutionId()))
-                   .withReason(approval.getReason())
-                   .build();
+    private ApprovalDto toApprovalDto(Approval approval) {
+        var points = getPointValueForInstitution(approval.getInstitutionId());
+        return ApprovalDto.fromApprovalAndInstitutionPoints(approval, points);
     }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalDtoTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalDtoTest.java
@@ -72,11 +72,9 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         var institutionId = randomUri();
         var upsertCandidateRequest = createUpsertCandidateRequest(institutionId);
         var candidate = Candidate.upsert(upsertCandidateRequest, candidateRepository, periodRepository)
-                            .orElseThrow()
-                            .toDto();
-        assertThat(candidate.approvals().size(), is(equalTo(1)));
-        assertThat(candidate.approvals().get(0).status(), is(equalTo(ApprovalStatus.PENDING)));
-        assertThat(candidate.approvals().get(0).institutionId(), is(equalTo(institutionId)));
+                            .orElseThrow();
+        assertThat(candidate.getApprovals().size(), is(equalTo(1)));
+        assertThat(candidate.getApprovals().get(institutionId).getStatus(), is(equalTo(ApprovalStatus.PENDING)));
     }
 
     @ParameterizedTest(name = "Should update from old status {0} to new status {1}")
@@ -91,7 +89,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         var updatedCandidate = existingCandidate.updateApproval(
             createUpdateStatusRequest(newStatus, institutionId, randomString()));
 
-        var actualNewStatus = updatedCandidate.toDto().approvals().get(0).status();
+        var actualNewStatus = updatedCandidate.getApprovals().get(institutionId).getStatus();
         assertThat(actualNewStatus, is(equalTo(newStatus)));
     }
 
@@ -112,11 +110,11 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         candidateBO.updateApproval(new UpdateAssigneeRequest(institutionId, assignee))
             .updateApproval(createUpdateStatusRequest(oldStatus, institutionId, randomString()))
             .updateApproval(createUpdateStatusRequest(ApprovalStatus.PENDING, institutionId, randomString()));
-        var approvalStatus = candidateBO.toDto().approvals().get(0);
-        assertThat(approvalStatus.status(), is(equalTo(ApprovalStatus.PENDING)));
-        assertThat(approvalStatus.assignee(), is(assignee));
-        assertThat(approvalStatus.finalizedBy(), is(nullValue()));
-        assertThat(approvalStatus.finalizedDate(), is(nullValue()));
+        var approvalStatus = candidateBO.getApprovals().get(institutionId);
+        assertThat(approvalStatus.getStatus(), is(equalTo(ApprovalStatus.PENDING)));
+        assertThat(approvalStatus.getAssignee().value(), is(assignee));
+        assertThat(approvalStatus.getFinalizedBy(), is(nullValue()));
+        assertThat(approvalStatus.getFinalizedDate(), is(nullValue()));
     }
 
     @ParameterizedTest
@@ -131,10 +129,10 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
                                                                   randomString()));
 
         var updatedCandidate = rejectedCandidate.updateApproval(
-            createUpdateStatusRequest(newStatus, institutionId, randomString())).toDto();
-        assertThat(updatedCandidate.approvals().size(), is(equalTo(1)));
-        assertThat(updatedCandidate.approvals().get(0).status(), is(equalTo(newStatus)));
-        assertThat(updatedCandidate.approvals().get(0).reason(), is(nullValue()));
+            createUpdateStatusRequest(newStatus, institutionId, randomString()));
+        assertThat(updatedCandidate.getApprovals().size(), is(equalTo(1)));
+        assertThat(updatedCandidate.getApprovals().get(institutionId).getStatus(), is(equalTo(newStatus)));
+        assertThat(updatedCandidate.getApprovals().get(institutionId).getReason(), is(nullValue()));
     }
 
     @Test
@@ -238,11 +236,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         candidateBO.updateApproval(createUpdateStatusRequest(ApprovalStatus.APPROVED, institutionId, randomString()));
 
         var status = Candidate.fetch(candidateBO::getIdentifier, candidateRepository, periodRepository)
-                         .toDto()
-                         .approvals()
-                         .get(0)
-                         .status();
-
+                                  .getApprovals().get(institutionId).getStatus();
         assertThat(status, is(equalTo(ApprovalStatus.APPROVED)));
     }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -33,6 +33,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigDecimal;
@@ -64,6 +65,7 @@ import no.sikt.nva.nvi.common.db.model.InstanceType;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.dto.ApprovalDto;
+import no.sikt.nva.nvi.common.service.dto.ApprovalStatusDto;
 import no.sikt.nva.nvi.common.service.dto.PeriodStatusDto;
 import no.sikt.nva.nvi.common.service.exception.CandidateNotFoundException;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
@@ -315,9 +317,11 @@ class CandidateTest extends LocalDynamoTest {
             assertThat(dto.identifier(), is(equalTo(candidateBO.getIdentifier())));
             var periodStatus = getDefaultPeriodStatus();
             assertThat(dto.period().status(), is(equalTo(periodStatus.status())));
-            assertThat(approvalMap.get(institutionToApprove).status(), is(equalTo(ApprovalStatus.APPROVED)));
+            var approvalDto = approvalMap.get(institutionToApprove);
+            assertThat(approvalDto.status().getValue(), is(equalTo(ApprovalStatusDto.APPROVED.getValue())));
+            assertNotNull(approvalDto.finalizedDate());
             var rejectedAP = approvalMap.get(institutionToReject);
-            assertThat(rejectedAP.status(), is(equalTo(ApprovalStatus.REJECTED)));
+            assertThat(rejectedAP.status(), is(equalTo(ApprovalStatusDto.REJECTED)));
             assertThat(rejectedAP.reason(), is(notNullValue()));
             assertThat(rejectedAP.points(),
                        is(setScaleAndRoundingMode(createRequest.getPointsForInstitution(rejectedAP.institutionId()))));
@@ -486,7 +490,7 @@ class CandidateTest extends LocalDynamoTest {
         var updatedCandidate = Candidate.upsert(newUpsertRequest, candidateRepository, periodRepository)
                                    .orElseThrow();
         var updatedApproval = updatedCandidate.toDto().approvals().get(0);
-        assertThat(updatedApproval.status(), is(equalTo(ApprovalStatus.PENDING)));
+        assertThat(updatedApproval.status(), is(equalTo(ApprovalStatusDto.NEW)));
     }
 
     @Test

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest.upsert;
 
+import static java.util.Objects.nonNull;
 import static java.util.UUID.randomUUID;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
@@ -27,6 +28,7 @@ import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
+import no.sikt.nva.nvi.common.service.dto.ApprovalStatusDto;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
@@ -153,8 +155,9 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
         var candidateResponse = response.getBodyObject(CandidateDto.class);
-
-        assertThat(candidateResponse.approvals().get(0).status().getValue(), is(equalTo(newStatus.getValue())));
+        var actualApproval = candidateResponse.approvals().get(0);
+        var expectedStatus = ApprovalStatusDto.from(newStatus, nonNull(actualApproval.assignee()));
+        assertThat(actualApproval.status().getValue(), is(equalTo(expectedStatus.getValue())));
     }
 
     @ParameterizedTest
@@ -170,10 +173,11 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
         var candidateResponse = response.getBodyObject(CandidateDto.class);
-
-        assertThat(candidateResponse.approvals().get(0).finalizedBy(), is(nullValue()));
-        assertThat(candidateResponse.approvals().get(0).finalizedDate(), is(nullValue()));
-        assertThat(candidateResponse.approvals().get(0).status().getValue(), is(equalTo(newStatus.getValue())));
+        var actualApproval = candidateResponse.approvals().get(0);
+        var expectedStatus = ApprovalStatusDto.from(newStatus, nonNull(actualApproval.assignee()));
+        assertThat(actualApproval.finalizedBy(), is(nullValue()));
+        assertThat(actualApproval.finalizedDate(), is(nullValue()));
+        assertThat(actualApproval.status().getValue(), is(equalTo(expectedStatus.getValue())));
     }
 
     @ParameterizedTest
@@ -211,9 +215,10 @@ public class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
         var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
         var candidateResponse = response.getBodyObject(CandidateDto.class);
 
-        var actualApprovalStatus = candidateResponse.approvals().get(0);
-        assertThat(actualApprovalStatus.status().getValue(), is(equalTo(newStatus.getValue())));
-        assertThat(actualApprovalStatus.reason(), is(nullValue()));
+        var actualApproval = candidateResponse.approvals().get(0);
+        var expectedStatus = ApprovalStatusDto.from(newStatus, nonNull(actualApproval.assignee()));
+        assertThat(actualApproval.status().getValue(), is(equalTo(expectedStatus.getValue())));
+        assertThat(actualApproval.reason(), is(nullValue()));
     }
 
     @Test


### PR DESCRIPTION
Follow up after https://github.com/BIBSYSDEV/nva-nvi/pull/293

Following same "logic" as in `publication-api` `TicketDto`. If approval is pending and unassigned, set status New in dto.