### PR TITLE
Np 46528 SearchNviCandidatesHandler, format nested aggregations

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
@@ -8,23 +8,54 @@ import java.util.Map;
 import no.unit.nva.commons.json.JsonUtils;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.NestedAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
 
 public final class AggregationFormatter {
+
+    public static final String DOC_COUNT = "docCount";
 
     private AggregationFormatter() {
     }
 
     public static JsonNode format(Map<String, Aggregate> aggregations) {
-        ObjectNode root = new ObjectNode(JsonUtils.dtoObjectMapper.getNodeFactory());
-
-        aggregations.forEach((key, value) -> {
-            root.set(key, formatAggregation(value));
-        });
-
+        var root = new ObjectNode(JsonUtils.dtoObjectMapper.getNodeFactory());
+        aggregations.forEach((key, value) -> root.set(key, format(value)));
         return root;
     }
 
-    private static JsonNode formatAggregation(Aggregate aggregate) {
+    private static JsonNode format(Aggregate aggregate) {
+        var aggregateNode = new ObjectNode(JsonUtils.dtoObjectMapper.getNodeFactory());
+        var aggregateVariant = aggregate._get();
+        if (aggregateVariant instanceof NestedAggregate nestedAggregate) {
+            addAggregations(aggregateNode, nestedAggregate.docCount(), nestedAggregate.aggregations());
+        } else if (aggregateVariant instanceof StringTermsAggregate stringTermsAggregate) {
+            addBucketNodes(aggregateNode, stringTermsAggregate);
+        } else {
+            return serialize(aggregate);
+        }
+        return aggregateNode;
+    }
+
+    private static void addBucketNodes(ObjectNode aggregateNode, StringTermsAggregate stringTermsAggregate) {
+        stringTermsAggregate.buckets()
+            .array()
+            .forEach(bucket -> aggregateNode.set(bucket.key(), generateBucketNode(bucket)));
+    }
+
+    private static ObjectNode generateBucketNode(StringTermsBucket bucket) {
+        var node = new ObjectNode(JsonUtils.dtoObjectMapper.getNodeFactory());
+        addAggregations(node, bucket.docCount(), bucket.aggregations());
+        return node;
+    }
+
+    private static void addAggregations(ObjectNode aggregateNode, long docCount, Map<String, Aggregate> aggregateMap) {
+        aggregateNode.put(DOC_COUNT, docCount);
+        aggregateMap.forEach((key, value) -> aggregateNode.set(key, format(value)));
+    }
+
+    private static JsonNode serialize(Aggregate aggregate) {
         var writer = new StringWriter();
         var mapper = new JsonbJsonpMapper();
         try (var generator = mapper.jsonProvider().createGenerator(writer)) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
@@ -61,6 +61,14 @@ public final class AggregationFormatter {
         try (var generator = mapper.jsonProvider().createGenerator(writer)) {
             mapper.serialize(aggregate, generator);
         }
-        return attempt(() -> JsonUtils.dtoObjectMapper.readTree(writer.toString())).orElseThrow();
+        var aggregateNode = attempt(() -> JsonUtils.dtoObjectMapper.readTree(writer.toString())).orElseThrow();
+        return replaceDocCount(aggregateNode);
+    }
+
+    private static ObjectNode replaceDocCount(JsonNode jsonNode) {
+        var object = (ObjectNode) jsonNode;
+        object.set(DOC_COUNT, jsonNode.get("doc_count"));
+        object.remove("doc_count");
+        return object;
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
@@ -1,0 +1,64 @@
+package no.sikt.nva.nvi.index.utils;
+
+import static nva.commons.core.attempt.Try.attempt;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.StringWriter;
+import java.util.Map;
+import java.util.Optional;
+import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
+import no.unit.nva.commons.json.JsonUtils;
+import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
+import org.opensearch.client.opensearch.core.SearchResponse;
+
+public final class AggregationFormatter {
+
+    private static final String WORD_ENDING_WITH_HASHTAG_REGEX = "[A-za-z0-9]*#";
+    private static final Map<String, String> AGGREGATION_FIELDS_TO_CHANGE = Map.of(
+        "doc_count_error_upper_bound", "docCountErrorUpperBound",
+        "sum_other_doc_count", "sumOtherDocCount",
+        "doc_count", "docCount");
+
+    private AggregationFormatter() {
+    }
+
+    public static JsonNode format(SearchResponse<NviCandidateIndexDocument> searchResponse) {
+        var writer = new StringWriter();
+        var mapper = new JsonbJsonpMapper();
+
+        try (var generator = mapper.jsonProvider().createGenerator(writer)) {
+            mapper.serialize(searchResponse, generator);
+        }
+
+        var json = attempt(() -> JsonUtils.dtoObjectMapper.readTree(writer.toString())).orElseThrow();
+        var aggregations = (ObjectNode) json.get("aggregations");
+
+        if (aggregations == null) {
+            return null;
+        }
+
+        return formatAggregations(aggregations);
+    }
+
+    private static JsonNode formatAggregations(JsonNode aggregations) {
+        var outputAggregationNode = JsonUtils.dtoObjectMapper.createObjectNode();
+
+        var iterator = aggregations.fields();
+        while (iterator.hasNext()) {
+            var nodeEntry = iterator.next();
+            var fieldName = nodeEntry.getKey();
+
+            var newName = Optional.ofNullable(AGGREGATION_FIELDS_TO_CHANGE.get(fieldName));
+            if (newName.isEmpty()) {
+                newName = Optional.of(fieldName.replaceFirst(WORD_ENDING_WITH_HASHTAG_REGEX, ""));
+            }
+
+            var value = nodeEntry.getValue().isValueNode()
+                            ? nodeEntry.getValue() : formatAggregations(nodeEntry.getValue());
+
+            outputAggregationNode.set(newName.get(), value);
+        }
+
+        return outputAggregationNode;
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
@@ -67,8 +67,10 @@ public final class AggregationFormatter {
 
     private static ObjectNode replaceDocCount(JsonNode jsonNode) {
         var object = (ObjectNode) jsonNode;
-        object.set(DOC_COUNT, jsonNode.get("doc_count"));
-        object.remove("doc_count");
+        if (jsonNode.has("doc_count")) {
+            object.set(DOC_COUNT, jsonNode.get("doc_count"));
+            object.remove("doc_count");
+        }
         return object;
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
@@ -55,7 +55,7 @@ public final class PaginatedResultConverter {
             extractTotalNumberOfHits(searchResponse),
             extractsHits(searchResponse),
             getQueryParameters(candidateSearchParameters),
-            AggregationFormatter.format(searchResponse));
+            AggregationFormatter.format(searchResponse.aggregations()));
 
         LOGGER.info("Returning paginatedSearchResult with id: {}", paginatedSearchResult.getId().toString());
         return paginatedSearchResult;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
@@ -34,11 +34,6 @@ public final class PaginatedResultConverter {
     private static final String HOST = ENVIRONMENT.readEnv("API_HOST");
     private static final String CUSTOM_DOMAIN_BASE_PATH = ENVIRONMENT.readEnv("CUSTOM_DOMAIN_BASE_PATH");
     private static final String CANDIDATE_PATH = "candidate";
-    private static final String WORD_ENDING_WITH_HASHTAG_REGEX = "[A-za-z0-9]*#";
-    private static final Map<String, String> AGGREGATION_FIELDS_TO_CHANGE = Map.of(
-        "doc_count_error_upper_bound", "docCountErrorUpperBound",
-        "sum_other_doc_count", "sumOtherDocCount",
-        "doc_count", "docCount");
 
     private PaginatedResultConverter() {
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -242,25 +242,18 @@ public class SearchNviCandidatesHandlerTest {
         var actualNestedAggregation = aggregations.get(aggregationName);
         var expectedNestedAggregation = """
             {
-              "doc_count": 3,
-              "status": {
-                "buckets": [
-                  {
-                    "key": "Pending",
-                    "doc_count": 3,
-                    "organizations": {
-                      "buckets": [
-                        {
-                          "key": "someOrgId",
-                          "doc_count": 2
-                        }
-                      ]
+              "docCount" : 3,
+              "status" : {
+                "Pending" : {
+                  "docCount" : 3,
+                  "organizations" : {
+                    "someOrgId" : {
+                      "docCount" : 2
                     }
                   }
-                ]
+                }
               }
-            }
-            """;
+            }""";
         assertEquals(expectedNestedAggregation, objectMapper.writeValueAsString(actualNestedAggregation));
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -230,7 +230,7 @@ public class SearchNviCandidatesHandlerTest {
 
     @Test
     void shouldReturnPaginatedSearchResultWithNestedAggregations() throws IOException {
-        var documents = generateNumberOfIndexDocuments(10);
+        var documents = generateNumberOfIndexDocuments(3);
         var aggregationName = randomString();
         when(openSearchClient.search(any()))
             .thenReturn(createSearchResponse(documents, aggregationName, nestedAggregate()));
@@ -242,7 +242,7 @@ public class SearchNviCandidatesHandlerTest {
         var actualNestedAggregation = aggregations.get(aggregationName);
         var expectedNestedAggregation = """
             {
-              "doc_count": 1,
+              "doc_count": 3,
               "status": {
                 "buckets": [
                   {
@@ -344,6 +344,7 @@ public class SearchNviCandidatesHandlerTest {
         var statusAggregation = createTermsAggregateWithBuckets(statusBuckets);
         return new NestedAggregate.Builder().docCount(randomInteger())
                    .aggregations("status", statusAggregation)
+                   .docCount(3)
                    .build()._toAggregate();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -39,10 +39,10 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import no.sikt.nva.nvi.index.aws.OpenSearchClient;
 import no.sikt.nva.nvi.index.aws.SearchClient;
-import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.document.PublicationDate;
 import no.sikt.nva.nvi.index.model.document.PublicationDetails;
+import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
 import no.unit.nva.commons.json.JsonUtils;
@@ -55,12 +55,17 @@ import nva.commons.core.ioutils.IoUtils;
 import nva.commons.core.paths.UriWrapper;
 import nva.commons.logutils.LogUtils;
 import org.hamcrest.Matchers;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.opensearch.client.opensearch._types.ShardStatistics;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.Buckets;
 import org.opensearch.client.opensearch._types.aggregations.FilterAggregate;
+import org.opensearch.client.opensearch._types.aggregations.NestedAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
+import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
 import org.opensearch.client.opensearch.core.SearchResponse;
 import org.opensearch.client.opensearch.core.SearchResponse.Builder;
 import org.opensearch.client.opensearch.core.search.Hit;
@@ -209,18 +214,54 @@ public class SearchNviCandidatesHandlerTest {
     }
 
     @Test
-    void shouldReturnPaginatedSearchResultWithAggregations() throws IOException {
+    void shouldReturnPaginatedSearchResultWithFilterAggregations() throws IOException {
         var documents = generateNumberOfIndexDocuments(10);
         var aggregationName = randomString();
         var docCount = randomInteger();
         when(openSearchClient.search(any()))
-            .thenReturn(createSearchResponse(documents, 10, aggregationName, docCount));
+            .thenReturn(createSearchResponse(documents, aggregationName, randomFilterAggregate(docCount)));
         handler.handleRequest(emptyRequest(), output, context);
         var response =
             GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
         var paginatedResult = objectMapper.readValue(response.getBody(), TYPE_REF);
 
         assertThat(paginatedResult.getHits(), hasSize(10));
+    }
+
+    @Test
+    void shouldReturnPaginatedSearchResultWithNestedAggregations() throws IOException {
+        var documents = generateNumberOfIndexDocuments(10);
+        var aggregationName = randomString();
+        when(openSearchClient.search(any()))
+            .thenReturn(createSearchResponse(documents, aggregationName, nestedAggregate()));
+        handler.handleRequest(emptyRequest(), output, context);
+        var response =
+            GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var paginatedResult = objectMapper.readValue(response.getBody(), TYPE_REF);
+        var aggregations = paginatedResult.getAggregations();
+        var actualNestedAggregation = aggregations.get(aggregationName);
+        var expectedNestedAggregation = """
+            {
+              "doc_count": 1,
+              "status": {
+                "buckets": [
+                  {
+                    "key": "Pending",
+                    "doc_count": 3,
+                    "organizations": {
+                      "buckets": [
+                        {
+                          "key": "someOrgId",
+                          "doc_count": 2
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+            """;
+        assertEquals(expectedNestedAggregation, objectMapper.writeValueAsString(actualNestedAggregation));
     }
 
     @Test
@@ -294,6 +335,40 @@ public class SearchNviCandidatesHandlerTest {
                                   + "topLevelCristinOrg " + TOP_LEVEL_CRISTIN_ORG));
     }
 
+    private static Aggregate nestedAggregate() {
+        var orgBucket = getStringTermsBucket("someOrgId", Map.of(), 2);
+        var orgBuckets = createBuckets(orgBucket);
+        var orgAggregation = createTermsAggregateWithBuckets(orgBuckets);
+        var pendingBucket = getStringTermsBucket("Pending", Map.of("organizations", orgAggregation), 3);
+        var statusBuckets = createBuckets(pendingBucket);
+        var statusAggregation = createTermsAggregateWithBuckets(statusBuckets);
+        return new NestedAggregate.Builder().docCount(randomInteger())
+                   .aggregations("status", statusAggregation)
+                   .build()._toAggregate();
+    }
+
+    private static Aggregate createTermsAggregateWithBuckets(Buckets<StringTermsBucket> buckets) {
+        return new StringTermsAggregate.Builder().buckets(buckets).sumOtherDocCount(2).build()._toAggregate();
+    }
+
+    private static StringTermsBucket getStringTermsBucket(String key, Map<String, Aggregate> aggregateMap,
+                                                          int docCount) {
+        return new StringTermsBucket.Builder()
+                   .key(key)
+                   .aggregations(aggregateMap)
+                   .docCount(docCount)
+                   .build();
+    }
+
+    private static Buckets<StringTermsBucket> createBuckets(StringTermsBucket bucket) {
+        return new Buckets.Builder<StringTermsBucket>().array(List.of(bucket)).build();
+    }
+
+    @NotNull
+    private static Aggregate randomFilterAggregate(Integer docCount) {
+        return new Aggregate(new FilterAggregate.Builder().docCount(docCount).build());
+    }
+
     private static void mockOpenSearchClient() throws IOException {
         when(openSearchClient.search(any()))
             .thenReturn(createSearchResponse(singleNviCandidateIndexDocument()));
@@ -308,13 +383,13 @@ public class SearchNviCandidatesHandlerTest {
     }
 
     private static SearchResponse<NviCandidateIndexDocument> createSearchResponse(
-        List<NviCandidateIndexDocument> documents, int total, String aggregateName, int docCount) {
+        List<NviCandidateIndexDocument> documents, String aggregateName, Aggregate aggregate) {
         return new Builder<NviCandidateIndexDocument>()
                    .hits(constructHitsMetadata(documents))
                    .took(10)
                    .timedOut(false)
-                   .shards(new ShardStatistics.Builder().failed(0).successful(1).total(total).build())
-                   .aggregations(aggregateName, new Aggregate(new FilterAggregate.Builder().docCount(docCount).build()))
+                   .shards(new ShardStatistics.Builder().failed(0).successful(1).total(10).build())
+                   .aggregations(aggregateName, aggregate)
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -262,11 +262,11 @@ public class SearchNviCandidatesHandlerTest {
         var expectedNestedAggregation = """
             {
               "docCount" : 3,
-              "status" : {
-                "Pending" : {
+              "organizations" : {
+                "someOrgId" : {
                   "docCount" : 3,
-                  "organizations" : {
-                    "someOrgId" : {
+                  "status" : {
+                    "Pending" : {
                       "docCount" : 2
                     }
                   }
@@ -348,14 +348,14 @@ public class SearchNviCandidatesHandlerTest {
     }
 
     private static Aggregate nestedAggregate() {
-        var orgBucket = getStringTermsBucket("someOrgId", Map.of(), 2);
-        var orgBuckets = createBuckets(orgBucket);
-        var orgAggregation = createTermsAggregateWithBuckets(orgBuckets);
-        var pendingBucket = getStringTermsBucket("Pending", Map.of("organizations", orgAggregation), 3);
+        var pendingBucket = getStringTermsBucket("Pending", Map.of(), 2);
         var statusBuckets = createBuckets(pendingBucket);
         var statusAggregation = createTermsAggregateWithBuckets(statusBuckets);
+        var orgBucket = getStringTermsBucket("someOrgId", Map.of("status", statusAggregation), 3);
+        var orgBuckets = createBuckets(orgBucket);
+        var orgAggregation = createTermsAggregateWithBuckets(orgBuckets);
         return new NestedAggregate.Builder().docCount(randomInteger())
-                   .aggregations("status", statusAggregation)
+                   .aggregations("organizations", orgAggregation)
                    .docCount(3)
                    .build()._toAggregate();
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -231,7 +231,7 @@ public class SearchNviCandidatesHandlerTest {
     @Test
     void shouldReturnPaginatedSearchResultWithNestedAggregations() throws IOException {
         var documents = generateNumberOfIndexDocuments(3);
-        var aggregationName = randomString();
+        var aggregationName = "someNestedAggregation";
         when(openSearchClient.search(any()))
             .thenReturn(createSearchResponse(documents, aggregationName, nestedAggregate()));
         handler.handleRequest(emptyRequest(), output, context);


### PR DESCRIPTION
- Added `AggregationFormatter`
- Did not find a nice way to generically serialize all `Aggregate` variants, therefore added custom formatting for nested and string terms aggregation. Feel free to suggest better implementation here
