### PR TITLE
Np 46528 OpenSearchClient, organizationApprovalStatusAggregations: filter approvals for topLevelCristinOrg

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/Aggregations.java
@@ -55,13 +55,13 @@ public final class Aggregations {
         return mustMatch(rangeFromQuery(NUMBER_OF_APPROVALS, MULTIPLE));
     }
 
-    public static Query statusQuery(String customer, ApprovalStatus status) {
-        final var query = mustMatch(statusForInstitution(customer, status));
+    public static Query statusQuery(String topLevelCristinOrg, ApprovalStatus status) {
+        final var query = mustMatch(statusForInstitution(topLevelCristinOrg, status));
         return nestedQuery(APPROVALS, query);
     }
 
-    public static Query assignmentsQuery(String username, String customer) {
-        final var query = mustMatch(assigneeForInstitution(customer, username));
+    public static Query assignmentsQuery(String username, String topLevelCristinOrg) {
+        final var query = mustMatch(assigneeForInstitution(topLevelCristinOrg, username));
         return nestedQuery(APPROVALS, query
         );
     }
@@ -82,8 +82,8 @@ public final class Aggregations {
                    .build();
     }
 
-    public static Aggregation totalCountAggregation(String customer) {
-        final var fieldValueQuery = approvalInstitutionIdQuery(customer);
+    public static Aggregation totalCountAggregation(String topLevelCristinOrg) {
+        final var fieldValueQuery = approvalInstitutionIdQuery(topLevelCristinOrg);
         final var query = mustMatch(fieldValueQuery);
         return filterAggregation(mustMatch(nestedQuery(APPROVALS, query)));
     }
@@ -92,34 +92,34 @@ public final class Aggregations {
         return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status)));
     }
 
-    public static Aggregation completedAggregation(String customer) {
+    public static Aggregation completedAggregation(String topLevelCristinOrg) {
         final var queries = new Query[]{
-            approvalInstitutionIdQuery(customer),
+            approvalInstitutionIdQuery(topLevelCristinOrg),
             mustNotMatch(PENDING.getValue(), APPROVAL_STATUS_PATH),
             mustNotMatch(NEW.getValue(), APPROVAL_STATUS_PATH)};
         var notPendingQuery = nestedQuery(APPROVALS, mustMatch(queries));
         return filterAggregation(mustMatch(notPendingQuery));
     }
 
-    public static Aggregation assignmentsAggregation(String username, String customer) {
-        return filterAggregation(mustMatch(assignmentsQuery(username, customer)));
+    public static Aggregation assignmentsAggregation(String username, String topLevelCristinOrg) {
+        return filterAggregation(mustMatch(assignmentsQuery(username, topLevelCristinOrg)));
     }
 
-    public static Aggregation finalizedCollaborationAggregation(String customer, ApprovalStatus status) {
-        return filterAggregation(mustMatch(statusQuery(customer, status), containsPendingStatusQuery(),
+    public static Aggregation finalizedCollaborationAggregation(String topLevelCristinOrg, ApprovalStatus status) {
+        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status), containsPendingStatusQuery(),
                                            multipleApprovalsQuery()));
     }
 
-    public static Aggregation collaborationAggregation(String customer, ApprovalStatus status) {
-        return filterAggregation(mustMatch(statusQuery(customer, status), multipleApprovalsQuery()));
+    public static Aggregation collaborationAggregation(String topLevelCristinOrg, ApprovalStatus status) {
+        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status), multipleApprovalsQuery()));
     }
 
     private static Query statusQuery(ApprovalStatus approvalStatus) {
         return fieldValueQuery(APPROVAL_STATUS_PATH, approvalStatus.getValue());
     }
 
-    private static Query approvalInstitutionIdQuery(String customer) {
-        return fieldValueQuery(INSTITUTION_ID_PATH, customer);
+    private static Query approvalInstitutionIdQuery(String topLevelCristinOrg) {
+        return fieldValueQuery(INSTITUTION_ID_PATH, topLevelCristinOrg);
     }
 
     private static Query[] assigneeForInstitution(String institutionId, String username) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/Aggregations.java
@@ -66,16 +66,19 @@ public final class Aggregations {
         );
     }
 
-    public static Aggregation organizationApprovalStatusAggregations() {
+    public static Aggregation organizationApprovalStatusAggregations(String topLevelCristinOrg) {
         var statusAggregation = termsAggregation(APPROVALS, APPROVAL_STATUS)._toAggregation();
         var organizationAggregation = new Aggregation.Builder()
                                           .terms(termsAggregation(APPROVALS, INVOLVED_ORGS))
                                           .aggregations(Map.of(STATUS_AGGREGATION, statusAggregation))
                                           .build();
+        var filterAggregation = filterAggregation(
+            mustMatch(approvalInstitutionIdQuery(topLevelCristinOrg)),
+            Map.of(APPROVAL_ORGANIZATIONS_AGGREGATION, organizationAggregation));
 
         return new Aggregation.Builder()
                    .nested(nestedAggregation(APPROVALS))
-                   .aggregations(Map.of(APPROVAL_ORGANIZATIONS_AGGREGATION, organizationAggregation))
+                   .aggregations(Map.of(topLevelCristinOrg, filterAggregation))
                    .build();
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/Aggregations.java
@@ -78,7 +78,7 @@ public final class Aggregations {
 
         return new Aggregation.Builder()
                    .nested(nestedAggregation(APPROVALS))
-                   .aggregations(Map.of(topLevelCristinOrg, filterAggregation))
+                   .aggregations(isNull(topLevelCristinOrg) ? Map.of() : Map.of(topLevelCristinOrg, filterAggregation))
                    .build();
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchAggregation.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchAggregation.java
@@ -36,7 +36,7 @@ public enum SearchAggregation {
     TOTAL_COUNT_AGGREGATION_AGG("totalCount",
                                 (username, topLevelCristinOrg) -> totalCountAggregation(topLevelCristinOrg)),
     ORGANIZATION_APPROVAL_STATUS_AGGREGATION("organizationApprovalStatuses",
-                                             (username, topLevelCristinOrg) -> organizationApprovalStatusAggregations());
+                                             (username, topLevelCristinOrg) -> organizationApprovalStatusAggregations(topLevelCristinOrg));
 
     private final String aggregationName;
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFormatter.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import no.unit.nva.commons.json.JsonUtils;
 import org.opensearch.client.json.jsonb.JsonbJsonpMapper;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
+import org.opensearch.client.opensearch._types.aggregations.FilterAggregate;
 import org.opensearch.client.opensearch._types.aggregations.NestedAggregate;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
@@ -32,6 +33,8 @@ public final class AggregationFormatter {
             addAggregations(aggregateNode, nestedAggregate.docCount(), nestedAggregate.aggregations());
         } else if (aggregateVariant instanceof StringTermsAggregate stringTermsAggregate) {
             addBucketNodes(aggregateNode, stringTermsAggregate);
+        } else if (aggregateVariant instanceof FilterAggregate filterAggregate) {
+            addAggregations(aggregateNode, filterAggregate.docCount(), filterAggregate.aggregations());
         } else {
             return serialize(aggregate);
         }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFunctions.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFunctions.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.index.utils;
 
 import static java.util.Objects.nonNull;
 import java.util.Arrays;
+import java.util.Map;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
@@ -54,6 +55,13 @@ public final class AggregationFunctions {
     public static Aggregation filterAggregation(Query filterQuery) {
         return new Aggregation.Builder()
                    .filter(filterQuery)
+                   .build();
+    }
+
+    public static Aggregation filterAggregation(Query filterQuery, Map<String, Aggregation> aggregations) {
+        return new Aggregation.Builder()
+                   .filter(filterQuery)
+                   .aggregations(aggregations)
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -494,11 +494,11 @@ public class OpenSearchClientTest {
         var searchParameters = defaultSearchParameters().withAggregationType(aggregation).build();
         var searchResponse = openSearchClient.search(searchParameters);
         var actualAggregate = searchResponse.aggregations().get(aggregation);
-        assertEquals(Kind.Nested, actualAggregate._kind());
         var actualOrganizationAggregation = ((NestedAggregate) actualAggregate._get()).aggregations()
-                                                .get("organizations");
-        assertEquals(Kind.Sterms, actualOrganizationAggregation._kind());
-        var actualOrgBuckets = ((StringTermsAggregate) actualOrganizationAggregation._get()).buckets();
+                                                .get(SIKT_INSTITUTION_ID.toString());
+        var filterAggregate = ((FilterAggregate) actualOrganizationAggregation._get()).aggregations()
+                                  .get("organizations");
+        var actualOrgBuckets = ((StringTermsAggregate) filterAggregate._get()).buckets();
         assertExpectedOrganizationAggregationForEachStatus(actualOrgBuckets);
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -84,6 +84,7 @@ import org.opensearch.client.opensearch._types.OpenSearchException;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate;
 import org.opensearch.client.opensearch._types.aggregations.Aggregate.Kind;
 import org.opensearch.client.opensearch._types.aggregations.Buckets;
+import org.opensearch.client.opensearch._types.aggregations.FilterAggregate;
 import org.opensearch.client.opensearch._types.aggregations.NestedAggregate;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
@@ -513,8 +514,10 @@ public class OpenSearchClientTest {
         var searchResponse = openSearchClient.search(searchParameters);
         var actualAggregate = searchResponse.aggregations().get(aggregation);
         var actualOrganizationAggregation = ((NestedAggregate) actualAggregate._get()).aggregations()
-                                                .get("organizations");
-        var actualOrgBuckets = ((StringTermsAggregate) actualOrganizationAggregation._get()).buckets();
+                                                .get(SIKT_INSTITUTION_ID.toString());
+        var filterAggregate = ((FilterAggregate) actualOrganizationAggregation._get()).aggregations()
+                                 .get("organizations");
+        var actualOrgBuckets = ((StringTermsAggregate) filterAggregate._get()).buckets();
         var orgIds = actualOrgBuckets.array().stream().map(StringTermsBucket::key).toList();
         assertThat(orgIds, containsInAnyOrder(SIKT_INSTITUTION_ID.toString()));
         assertThat(orgIds, not(containsInAnyOrder(NTNU_INSTITUTION_ID.toString())));

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -262,7 +262,7 @@ public class SearchNviCandidatesHandlerTest {
         var expectedNestedAggregation = """
             {
               "docCount" : 3,
-              "someOrgId" : {
+              "someTopLevelOrgId" : {
                 "docCount" : 3,
                 "organizations" : {
                   "someOrgId" : {
@@ -376,13 +376,12 @@ public class SearchNviCandidatesHandlerTest {
         var pendingBucket = getStringTermsBucket("Pending", Map.of(), 2);
         var statusBuckets = createBuckets(pendingBucket);
         var statusAggregation = createTermsAggregateWithBuckets(statusBuckets);
-        var someOrgId = "someOrgId";
-        var orgBucket = getStringTermsBucket(someOrgId, Map.of("status", statusAggregation), 3);
+        var orgBucket = getStringTermsBucket("someOrgId", Map.of("status", statusAggregation), 3);
         var orgBuckets = createBuckets(orgBucket);
         var orgAggregation = createTermsAggregateWithBuckets(orgBuckets);
         var filterAggregate = getFilterAggregate(3, Map.of("organizations", orgAggregation));
         return new NestedAggregate.Builder().docCount(randomInteger())
-                   .aggregations(someOrgId, filterAggregate)
+                   .aggregations("someTopLevelOrgId", filterAggregate)
                    .docCount(3)
                    .build()._toAggregate();
     }

--- a/index-handlers/src/test/resources/document_organization_aggregation_collaboration.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_collaboration.json
@@ -1,0 +1,54 @@
+{
+  "@context": "https://bibsysdev.github.io/src/nvi-context.json",
+  "type": "NviCandidate",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e57100",
+  "numberOfApprovals": 1,
+  "publicationDetails": {
+    "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
+    "type": "AcademicArticle",
+    "title": "SomeTitle",
+    "publicationDate": {
+      "year": "2023"
+    },
+    "contributors": [
+      {
+        "type": "NviContributor",
+        "id": "https://api.dev.nva.aws.unit.no/cristin/person/1136326",
+        "name": "Mona",
+        "affiliations": [
+          {
+            "type": "NviOrganization",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+            "partOf": []
+          },
+          {
+            "type": "NviOrganization",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
+            "partOf": []
+          }
+        ],
+        "role": "Creator"
+      }
+    ]
+  },
+  "approvals": [
+    {
+      "type": "Approval",
+      "assignee": "user1",
+      "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+      "involvedOrganizations": [
+        "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+      ],
+      "approvalStatus": "New"
+    },
+    {
+      "type": "Approval",
+      "assignee": "user1",
+      "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
+      "involvedOrganizations": [
+        "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"
+      ],
+      "approvalStatus": "New"
+    }
+  ]
+}


### PR DESCRIPTION
To avoid aggregations for approvals that do not belong to requested top level org (in co-publishing cases), add a filter aggregation for top level org.