### PR TITLE
Np 46528 Index document, approval involved orgs: Add top level org

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -111,10 +111,13 @@ public final class NviCandidateIndexDocumentGenerator {
     }
 
     private static Set<URI> extractInvolvedOrganizations(Candidate candidate, Approval approval) {
-        return candidate.getInstitutionPoints(approval.getInstitutionId())
-                   .map(no.sikt.nva.nvi.common.service.model.InstitutionPoints::creatorAffiliationPoints)
-                   .map(NviCandidateIndexDocumentGenerator::getAffiliationsWithPoints)
-                   .orElse(Set.of());
+        var creatorAffiliations = candidate.getInstitutionPoints(approval.getInstitutionId())
+                                      .map(
+                                          no.sikt.nva.nvi.common.service.model.InstitutionPoints::creatorAffiliationPoints)
+                                      .map(NviCandidateIndexDocumentGenerator::getAffiliationsWithPoints)
+                                      .orElse(Set.of());
+        creatorAffiliations.add(approval.getInstitutionId());
+        return creatorAffiliations;
     }
 
     private static Set<URI> getAffiliationsWithPoints(List<CreatorAffiliationPoints> creatorAffiliationPoints) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.index.utils;
 
+import static java.util.Collections.emptySet;
 import static java.util.Objects.isNull;
 import static no.sikt.nva.nvi.common.utils.GraphUtils.PART_OF_PROPERTY;
 import static no.sikt.nva.nvi.common.utils.GraphUtils.createModel;
@@ -115,7 +116,7 @@ public final class NviCandidateIndexDocumentGenerator {
                                       .map(
                                           no.sikt.nva.nvi.common.service.model.InstitutionPoints::creatorAffiliationPoints)
                                       .map(NviCandidateIndexDocumentGenerator::getAffiliationsWithPoints)
-                                      .orElse(Set.of());
+                                      .orElse(emptySet());
         creatorAffiliations.add(approval.getInstitutionId());
         return creatorAffiliations;
     }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -86,10 +86,13 @@ public final class IndexDocumentTestUtils {
     }
 
     private static Set<URI> extractInvolvedOrganizations(Approval approval, Candidate candidate) {
-        return candidate.getInstitutionPoints(approval.getInstitutionId())
-                   .map(no.sikt.nva.nvi.common.service.model.InstitutionPoints::creatorAffiliationPoints)
-                   .map(IndexDocumentTestUtils::getAffiliationsWithPoints)
-                   .orElse(Set.of());
+        var creatorAffiliations = candidate.getInstitutionPoints(approval.getInstitutionId())
+                                      .map(
+                                          no.sikt.nva.nvi.common.service.model.InstitutionPoints::creatorAffiliationPoints)
+                                      .map(IndexDocumentTestUtils::getAffiliationsWithPoints)
+                                      .orElse(Set.of());
+        creatorAffiliations.add(approval.getInstitutionId());
+        return creatorAffiliations;
     }
 
     private static Set<URI> getAffiliationsWithPoints(List<CreatorAffiliationPoints> creatorAffiliationPoints) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.test;
 
+import static java.util.Collections.emptySet;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.EN_FIELD;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_LABEL;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
@@ -90,7 +91,7 @@ public final class IndexDocumentTestUtils {
                                       .map(
                                           no.sikt.nva.nvi.common.service.model.InstitutionPoints::creatorAffiliationPoints)
                                       .map(IndexDocumentTestUtils::getAffiliationsWithPoints)
-                                      .orElse(Set.of());
+                                      .orElse(emptySet());
         creatorAffiliations.add(approval.getInstitutionId());
         return creatorAffiliations;
     }


### PR DESCRIPTION
`involvedOrganizations` in `Approval` (index document) should also contain top level org (`Approval.institutionId`). Aggregations are made for all uris in `involvedOrganizations`.