### PR TITLE
Np 46661 Fix: Too many points for authors with more than one affiliation to one institution

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
@@ -98,7 +98,7 @@ public class PointCalculator {
                                                                                   BigDecimal institutionPoints,
                                                                                   Long institutionCreatorCount) {
         var pointsForCreator = divide(institutionCreatorCount, institutionPoints);
-        int numberOfAffiliations = nviCreator.getValue().size();
+        var numberOfAffiliations = nviCreator.getValue().size();
         var pointsForAffiliation = divide(numberOfAffiliations, pointsForCreator);
         return nviCreator.getValue().stream()
                    .map(affiliationId -> new CreatorAffiliationPoints(affiliationId, nviCreator.getKey(),

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
@@ -94,9 +94,9 @@ public class PointCalculator {
                    .count();
     }
 
-    private Stream<CreatorAffiliationPoints> calculatePointsForAffiliation(Entry<URI, List<URI>> nviCreator,
-                                                                           BigDecimal institutionPoints,
-                                                                           Long institutionCreatorCount) {
+    private static Stream<CreatorAffiliationPoints> calculatePointsForAffiliation(Entry<URI, List<URI>> nviCreator,
+                                                                                  BigDecimal institutionPoints,
+                                                                                  Long institutionCreatorCount) {
         var pointsForCreator = divide(institutionCreatorCount, institutionPoints);
         int numberOfAffiliations = nviCreator.getValue().size();
         var pointsForAffiliation = divide(numberOfAffiliations, pointsForCreator);

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/PointCalculator.java
@@ -117,8 +117,7 @@ public class PointCalculator {
 
     private static Long countCreators(URI institutionId, List<VerifiedNviCreator> nviCreators) {
         return nviCreators.stream()
-                   .flatMap(creator -> creator.nviAffiliations().stream())
-                   .filter(affiliation -> isPartOf(affiliation, institutionId))
+                   .filter(creator -> creator.isAffiliatedWith(institutionId))
                    .count();
     }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
@@ -17,6 +17,10 @@ public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations) 
                    .collect(Collectors.toList());
     }
 
+    public boolean isAffiliatedWith(URI institutionId) {
+        return nviAffiliations.stream().anyMatch(affiliation -> affiliation.isPartOf(institutionId));
+    }
+
     public static final class Builder {
 
         private URI id;
@@ -50,6 +54,10 @@ public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations) 
         @Override
         public NviOrganization topLevelOrganization() {
             return Objects.isNull(topLevelOrganization) ? this : topLevelOrganization;
+        }
+
+        public boolean isPartOf(URI institutionId) {
+            return topLevelOrganization().id().equals(institutionId);
         }
 
         public static final class Builder {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
@@ -21,6 +21,13 @@ public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations) 
         return nviAffiliations.stream().anyMatch(affiliation -> affiliation.isPartOf(institutionId));
     }
 
+    public List<URI> getAffiliationsPartOf(URI institutionId) {
+        return nviAffiliations.stream()
+                   .filter(affiliation -> affiliation.isPartOf(institutionId))
+                   .map(NviOrganization::id)
+                   .collect(Collectors.toList());
+    }
+
     public static final class Builder {
 
         private URI id;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
@@ -256,8 +256,7 @@ class PointServiceTest {
 
     @Test
     void shouldCalculatePointsForCreatorAffiliations() {
-        var creatorShareCount = 2;
-        var parameters = new PointParameters("AcademicArticle", "Journal", "LevelOne", false, creatorShareCount,
+        var parameters = new PointParameters("AcademicArticle", "Journal", "LevelOne", false, 2,
                                              asBigDecimal("1"), null,
                                              asBigDecimal("1"));
         var creator1 = randomUri();
@@ -270,15 +269,9 @@ class PointServiceTest {
         var creator1Affiliations = List.of(someSubUnitId);
         var creator2Affiliations = List.of(someSubUnitId, someOtherSubUnitId);
         var expandedResource = createExpandedResourceWithManyCreators(parameters, creator1, creator2,
-                                                                      creator1Affiliations,
-                                                                      creator2Affiliations);
-        var nviCreators = List.of(creatorWithAffiliations(creator1,
-                                                          List.of(createNviOrganization(someSubUnitId, institutionId))),
-                                  creatorWithAffiliations(creator2,
-                                                          List.of(
-                                                              createNviOrganization(someSubUnitId, institutionId),
-                                                              createNviOrganization(someOtherSubUnitId,
-                                                                                    institutionId))));
+                                                                      creator1Affiliations, creator2Affiliations);
+        var nviCreators = setupNviCreators(creator1, creator2, creator1Affiliations, creator2Affiliations,
+                                           institutionId);
         var pointCalculation = pointService.calculatePoints(expandedResource,
                                                             nviCreators);
         assertThat(getActualAffiliationPoints(pointCalculation, institutionId, someSubUnitId, creator1),
@@ -289,13 +282,19 @@ class PointServiceTest {
                    is(equalTo(BigDecimal.valueOf(0.2500).setScale(RESULT_SCALE, ROUNDING_MODE))));
     }
 
-    private static List<VerifiedNviCreator> setupNviCreators(URI creator1, URI someSubUnitId, URI institutionId,
-                                                             URI creator2) {
-        return List.of(creatorWithAffiliations(creator1,
-                                               List.of(createNviOrganization(someSubUnitId, institutionId))),
-                       creatorWithAffiliations(creator2,
-                                               List.of(
-                                                   createNviOrganization(someSubUnitId, institutionId))));
+    private static List<VerifiedNviCreator> setupNviCreators(URI creator1,
+                                                             URI creator2,
+                                                             List<URI> creator1Affiliations,
+                                                             List<URI> creator2Affiliations,
+                                                             URI institutionId) {
+        return List.of(creatorWithAffiliations(creator1, getNviOrganizationList(creator1Affiliations, institutionId)),
+                       creatorWithAffiliations(creator2, getNviOrganizationList(creator2Affiliations, institutionId)));
+    }
+
+    private static List<NviOrganization> getNviOrganizationList(List<URI> affiliations, URI institutionId) {
+        return affiliations.stream()
+                   .map(affiliation -> createNviOrganization(affiliation, institutionId))
+                   .toList();
     }
 
     private static BigDecimal getActualAffiliationPoints(PointCalculation pointCalculation, URI institutionId,

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
@@ -228,6 +228,33 @@ class PointServiceTest {
     }
 
     @Test
+    void shouldCountOneInstitutionShareForCreatorsWithSeveralAffiliationsInSameInstitution() {
+        int creatorShareCount = 1;
+        var parameters = new PointParameters("AcademicArticle", "Journal", "LevelTwo", false, creatorShareCount,
+                                             asBigDecimal("3"), null,
+                                             asBigDecimal("3"));
+        var creator = randomUri();
+        var someSubUnitId = randomUri();
+        var someOtherSubUnitId = randomUri();
+        var institutionId = randomUri();
+        mockOrganizationResponseForAffiliation(institutionId, someSubUnitId, uriRetriever);
+        mockOrganizationResponseForAffiliation(institutionId, someOtherSubUnitId, uriRetriever);
+        var affiliations = List.of(someSubUnitId, someOtherSubUnitId);
+        var expandedResource = createExpandedResource(parameters, creator, affiliations);
+        var nviCreators = List.of(creatorWithAffiliations(creator,
+                                                          List.of(createNviOrganization(someSubUnitId, institutionId),
+                                                                  createNviOrganization(someOtherSubUnitId,
+                                                                                        institutionId))));
+        var pointCalculation = pointService.calculatePoints(expandedResource, nviCreators);
+        assertThat(getActualPoints(pointCalculation, institutionId), is(equalTo(parameters.institution1Points())));
+        var expectedPointsForAffiliation = parameters.institution1Points()
+                                               .divide(BigDecimal.valueOf(affiliations.size()), ROUNDING_MODE)
+                                               .setScale(RESULT_SCALE, ROUNDING_MODE);
+        assertThat(getActualAffiliationPoints(pointCalculation, institutionId, someSubUnitId, creator),
+                   is(equalTo(expectedPointsForAffiliation)));
+    }
+
+    @Test
     void shouldCalculatePointsForCreatorAffiliations() {
         var creatorShareCount = 2;
         var parameters = new PointParameters("AcademicArticle", "Journal", "LevelOne", false, creatorShareCount,
@@ -263,11 +290,10 @@ class PointServiceTest {
     }
 
     private static BigDecimal getActualAffiliationPoints(PointCalculation pointCalculation, URI institutionId,
-                                                         URI someSubUnitId,
-                                                         URI creator1) {
+                                                         URI someSubUnitId, URI creator) {
         return getInstitutionPoints(pointCalculation, institutionId).creatorAffiliationPoints()
                    .stream()
-                   .filter(affiliationPoints -> isForCreatorAndAffiliation(someSubUnitId, creator1, affiliationPoints))
+                   .filter(affiliationPoints -> isForCreatorAndAffiliation(someSubUnitId, creator, affiliationPoints))
                    .findFirst()
                    .map(CreatorAffiliationPoints::points)
                    .orElseThrow();
@@ -636,6 +662,22 @@ class PointServiceTest {
             createContributorNode(creator1, true, toMapWithCountryCode(creator1Affiliations, COUNTRY_CODE_NO),
                                   ROLE_CREATOR, 0),
             createContributorNode(creator2, true, toMapWithCountryCode(creator2Affiliations, COUNTRY_CODE_NO),
+                                  ROLE_CREATOR, 0),
+            createContributorNode(randomUri(), false,
+                                  toMapWithCountryCode(randomInstitutions,
+                                                       countryCodeForNonNviCreators),
+                                  parameters.creatorShareCount() <= 3 ? SOME_OTHER_ROLE : ROLE_CREATOR, 0)
+        );
+        return createExpandedResource(randomUri(), contributorNodes, getInstanceTypeReference(parameters));
+    }
+
+    private JsonNode createExpandedResource(PointParameters parameters, URI creator, List<URI> creatorAffiliations) {
+        var countryCodeForNonNviCreators = parameters.isInternationalCollaboration()
+                                               ? SOME_INTERNATIONAL_COUNTRY_CODE : COUNTRY_CODE_NO;
+        var randomInstitutions = createRandomInstitutions(parameters, 3);
+        mockOrganizationRetriever(randomInstitutions);
+        var contributorNodes = createContributorNodes(
+            createContributorNode(creator, true, toMapWithCountryCode(creatorAffiliations, COUNTRY_CODE_NO),
                                   ROLE_CREATOR, 0),
             createContributorNode(randomUri(), false,
                                   toMapWithCountryCode(randomInstitutions,

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
@@ -263,21 +263,30 @@ class PointServiceTest {
         var creator1 = randomUri();
         var creator2 = randomUri();
         var someSubUnitId = randomUri();
+        var someOtherSubUnitId = randomUri();
         var institutionId = randomUri();
         mockOrganizationResponseForAffiliation(institutionId, someSubUnitId, uriRetriever);
-        var affiliations = List.of(someSubUnitId);
-        var expandedResource = createExpandedResourceWithManyCreators(parameters, creator1, creator2, affiliations,
-                                                                      affiliations);
-        var nviCreators = setupNviCreators(creator1, someSubUnitId, institutionId, creator2);
+        mockOrganizationResponseForAffiliation(institutionId, someOtherSubUnitId, uriRetriever);
+        var creator1Affiliations = List.of(someSubUnitId);
+        var creator2Affiliations = List.of(someSubUnitId, someOtherSubUnitId);
+        var expandedResource = createExpandedResourceWithManyCreators(parameters, creator1, creator2,
+                                                                      creator1Affiliations,
+                                                                      creator2Affiliations);
+        var nviCreators = List.of(creatorWithAffiliations(creator1,
+                                                          List.of(createNviOrganization(someSubUnitId, institutionId))),
+                                  creatorWithAffiliations(creator2,
+                                                          List.of(
+                                                              createNviOrganization(someSubUnitId, institutionId),
+                                                              createNviOrganization(someOtherSubUnitId,
+                                                                                    institutionId))));
         var pointCalculation = pointService.calculatePoints(expandedResource,
                                                             nviCreators);
-        var expectedPointsForAffiliation = parameters.institution1Points()
-                                               .divide(BigDecimal.valueOf(creatorShareCount), ROUNDING_MODE)
-                                               .setScale(RESULT_SCALE, ROUNDING_MODE);
         assertThat(getActualAffiliationPoints(pointCalculation, institutionId, someSubUnitId, creator1),
-                   is(equalTo(expectedPointsForAffiliation)));
+                   is(equalTo(BigDecimal.valueOf(0.5))));
         assertThat(getActualAffiliationPoints(pointCalculation, institutionId, someSubUnitId, creator2),
-                   is(equalTo(expectedPointsForAffiliation)));
+                   is(equalTo(BigDecimal.valueOf(0.2500))));
+        assertThat(getActualAffiliationPoints(pointCalculation, institutionId, someOtherSubUnitId, creator2),
+                   is(equalTo(BigDecimal.valueOf(0.2500))));
     }
 
     private static List<VerifiedNviCreator> setupNviCreators(URI creator1, URI someSubUnitId, URI institutionId,

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/calculator/PointServiceTest.java
@@ -282,11 +282,11 @@ class PointServiceTest {
         var pointCalculation = pointService.calculatePoints(expandedResource,
                                                             nviCreators);
         assertThat(getActualAffiliationPoints(pointCalculation, institutionId, someSubUnitId, creator1),
-                   is(equalTo(BigDecimal.valueOf(0.5))));
+                   is(equalTo(BigDecimal.valueOf(0.5000).setScale(RESULT_SCALE, ROUNDING_MODE))));
         assertThat(getActualAffiliationPoints(pointCalculation, institutionId, someSubUnitId, creator2),
-                   is(equalTo(BigDecimal.valueOf(0.2500))));
+                   is(equalTo(BigDecimal.valueOf(0.2500).setScale(RESULT_SCALE, ROUNDING_MODE))));
         assertThat(getActualAffiliationPoints(pointCalculation, institutionId, someOtherSubUnitId, creator2),
-                   is(equalTo(BigDecimal.valueOf(0.2500))));
+                   is(equalTo(BigDecimal.valueOf(0.2500).setScale(RESULT_SCALE, ROUNDING_MODE))));
     }
 
     private static List<VerifiedNviCreator> setupNviCreators(URI creator1, URI someSubUnitId, URI institutionId,


### PR DESCRIPTION
Jira task: NP-46661 Nvi point calculation: too many points for authors with more than one affiliation to one institution

- Added test `shouldCountOneInstitutionShareForCreatorsWithSeveralAffiliationsInSameInstitution`, fix counting creators for institution in `countCreators` method.
- Fixed calculation in `calculatePointsForAffiliation`: First calculate `pointsForCreator` then divide on `numberOfAffiliations` to get `pointsForAffiliation`.