### PR TITLE
Np 46632 Index document, global approval status in approvals

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Approval.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Approval.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
+import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
@@ -19,7 +20,8 @@ public record Approval(URI institutionId,
                        ApprovalStatus approvalStatus,
                        InstitutionPoints points,
                        Set<URI> involvedOrganizations,
-                       String assignee) {
+                       String assignee,
+                       GlobalApprovalStatus globalApprovalStatus) {
 
     public static Builder builder() {
         return new Builder();
@@ -33,6 +35,7 @@ public record Approval(URI institutionId,
         private InstitutionPoints points;
         private Set<URI> involvedOrganizations;
         private String assignee;
+        private GlobalApprovalStatus globalApprovalStatus;
 
         private Builder() {
         }
@@ -67,8 +70,14 @@ public record Approval(URI institutionId,
             return this;
         }
 
+        public Builder withGlobalApprovalStatus(GlobalApprovalStatus globalApprovalStatus) {
+            this.globalApprovalStatus = globalApprovalStatus;
+            return this;
+        }
+
         public Approval build() {
-            return new Approval(institutionId, labels, approvalStatus, points, involvedOrganizations, assignee);
+            return new Approval(institutionId, labels, approvalStatus, points, involvedOrganizations, assignee,
+                                globalApprovalStatus);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -181,6 +181,7 @@ public final class NviCandidateIndexDocumentGenerator {
                    .withPoints(getInstitutionPoints(approval, candidate))
                    .withInvolvedOrganizations(extractInvolvedOrganizations(candidate, approval))
                    .withAssignee(extractAssignee(approval))
+                   .withGlobalApprovalStatus(candidate.getGlobalApprovalStatus())
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -52,6 +52,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
 import no.sikt.nva.nvi.index.aws.CandidateQuery.QueryFilterType;
 import no.sikt.nva.nvi.index.aws.OpenSearchClient;
 import no.sikt.nva.nvi.index.model.document.Approval;
@@ -665,7 +666,8 @@ public class OpenSearchClientTest {
     }
 
     private static Approval randomApprovalWithCustomerAndAssignee(URI affiliation, String assignee) {
-        return new Approval(affiliation, Map.of(), randomStatus(), randomInstitutionPoints(), Set.of(), assignee);
+        return new Approval(affiliation, Map.of(), randomStatus(), randomInstitutionPoints(), Set.of(), assignee,
+                            randomGlobalApprovalStatus());
     }
 
     private static List<Approval> randomApprovalList() {
@@ -673,7 +675,8 @@ public class OpenSearchClientTest {
     }
 
     private static Approval randomApproval() {
-        return new Approval(randomUri(), Map.of(), randomStatus(), randomInstitutionPoints(), Set.of(), null);
+        return new Approval(randomUri(), Map.of(), randomStatus(), randomInstitutionPoints(), Set.of(), null,
+                            randomGlobalApprovalStatus());
     }
 
     private static InstitutionPoints randomInstitutionPoints() {
@@ -689,6 +692,10 @@ public class OpenSearchClientTest {
         var size = values.size();
         var random = new Random();
         return values.get(random.nextInt(size));
+    }
+
+    private static GlobalApprovalStatus randomGlobalApprovalStatus() {
+        return randomElement(GlobalApprovalStatus.values());
     }
 
     private static PublicationDetails randomPublicationDetails() {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -77,6 +77,7 @@ public final class IndexDocumentTestUtils {
                    .withInvolvedOrganizations(extractInvolvedOrganizations(approval, candidate))
                    .withLabels(Map.of(EN_FIELD, HARDCODED_ENGLISH_LABEL, NB_FIELD,
                                       HARDCODED_NORWEGIAN_LABEL))
+                   .withGlobalApprovalStatus(candidate.getGlobalApprovalStatus())
                    .build();
     }
 


### PR DESCRIPTION
Jira task: NP-46632 Aggregations for disputes
Work-around suggestion to ble able to aggregate disputes for all organizations in `involvedOrganizations` (in `Approval`s): denormalization of global approval status.

- Add `globalApprovalStatus` on all `Approval`s in index document