### PR TITLE
Np 46914 Index document, involved organizations should contain all partOf levels

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
@@ -153,13 +153,12 @@ public class CandidateQuery {
     }
 
     private static Query contributorQueryIncludingSubUnits(List<String> organizations) {
-        var institutionIdentifiers = extractIdentifiers(organizations);
         return nestedQuery(jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS),
                            QueryBuilders.bool().must(
                                matchAtLeastOne(
                                    termsQuery(organizations,
                                               jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, AFFILIATIONS, ID)),
-                                   termsQuery(institutionIdentifiers,
+                                   termsQuery(organizations,
                                               jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, AFFILIATIONS, PART_OF))
                                ),
                                matchQuery(CREATOR_ROLE, jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, ROLE))

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/CandidateQuery.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
-import nva.commons.core.paths.UriWrapper;
 import org.opensearch.client.json.JsonData;
 import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
@@ -164,14 +163,6 @@ public class CandidateQuery {
                                matchQuery(CREATOR_ROLE, jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, ROLE))
                            ).build()._toQuery()
         );
-    }
-
-    private static List<String> extractIdentifiers(List<String> organizations) {
-        return organizations.stream().map(CandidateQuery::getLastPathElement).toList();
-    }
-
-    private static String getLastPathElement(String organization) {
-        return UriWrapper.fromUri(organization).getLastPathElement();
     }
 
     private static Query contributorQueryExcludingSubUnits(List<String> organizations) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Approval.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Approval.java
@@ -6,10 +6,8 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URI;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
-import nva.commons.core.JacocoGenerated;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Approval.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Approval.java
@@ -6,8 +6,10 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URI;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
+import nva.commons.core.JacocoGenerated;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviContributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviContributor.java
@@ -5,9 +5,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviContributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviContributor.java
@@ -30,7 +30,7 @@ public record NviContributor(@JsonProperty("id") String id,
         return partOfIds;
     }
 
-    public List<URI> affiliationsIdsPartOf(URI topLevelOrg) {
+    private List<URI> affiliationsIdsPartOf(URI topLevelOrg) {
         return affiliationsPartOf(topLevelOrg)
                    .map(NviOrganization::id)
                    .toList();

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviContributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviContributor.java
@@ -22,13 +22,11 @@ public record NviContributor(@JsonProperty("id") String id,
     }
 
     public List<URI> organizationsPartOf(URI topLevelOrg) {
-        var topLevelOrgIdentifier = UriWrapper.fromUri(topLevelOrg).getLastPathElement();
         return affiliations.stream()
                    .filter(organization -> organization instanceof NviOrganization)
                    .map(organizationType -> (NviOrganization) organizationType)
-                   .filter(organization -> organization.partOf().contains(topLevelOrgIdentifier))
-                   .flatMap(nviOrganization -> nviOrganization.partOf().stream())
-                   .map(identifier -> URI.create("https://api.nvi.no/organizations/" + identifier))//TODO: FIX THIS
+                   .filter(organization -> organization.partOfIds().contains(topLevelOrg))
+                   .flatMap(nviOrganization -> nviOrganization.partOfIds().stream())
                    .toList();
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviOrganization.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviOrganization.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.index.model.document;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -13,7 +14,8 @@ import java.util.List;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonTypeName("Organization")
 public record NviOrganization(@JsonProperty("id") URI id,
-                              @JsonProperty("partOf") List<String> partOf) implements OrganizationType {
+                              @JsonProperty("partOf") List<String> partOf,
+                              @JsonIgnore List<URI> partOfIds) implements OrganizationType {
 
     public static Builder builder() {
         return new Builder();
@@ -23,6 +25,7 @@ public record NviOrganization(@JsonProperty("id") URI id,
 
         private URI id;
         private List<String> partOf;
+        List<URI> partOfIds;
 
         private Builder() {
         }
@@ -37,8 +40,13 @@ public record NviOrganization(@JsonProperty("id") URI id,
             return this;
         }
 
+        public Builder withPartOfIds(List<URI> partOfIds) {
+            this.partOfIds = partOfIds;
+            return this;
+        }
+
         public NviOrganization build() {
-            return new NviOrganization(id, partOf);
+            return new NviOrganization(id, partOf, partOfIds);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviOrganization.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviOrganization.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.nvi.index.model.document;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -14,8 +13,7 @@ import java.util.List;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonTypeName("Organization")
 public record NviOrganization(@JsonProperty("id") URI id,
-                              @JsonProperty("partOf") List<String> partOf,
-                              @JsonIgnore List<URI> partOfIds) implements OrganizationType {
+                              @JsonProperty("partOf") List<URI> partOf) implements OrganizationType {
 
     public static Builder builder() {
         return new Builder();
@@ -24,8 +22,7 @@ public record NviOrganization(@JsonProperty("id") URI id,
     public static final class Builder {
 
         private URI id;
-        private List<String> partOf;
-        List<URI> partOfIds;
+        private List<URI> partOf;
 
         private Builder() {
         }
@@ -35,18 +32,13 @@ public record NviOrganization(@JsonProperty("id") URI id,
             return this;
         }
 
-        public Builder withPartOf(List<String> partOf) {
+        public Builder withPartOf(List<URI> partOf) {
             this.partOf = partOf;
             return this;
         }
 
-        public Builder withPartOfIds(List<URI> partOfIds) {
-            this.partOfIds = partOfIds;
-            return this;
-        }
-
         public NviOrganization build() {
-            return new NviOrganization(id, partOf, partOfIds);
+            return new NviOrganization(id, partOf);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Organization.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Organization.java
@@ -12,7 +12,7 @@ import java.util.List;
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
 @JsonTypeName("Organization")
 public record Organization(URI id,
-                           List<String> partOf) implements OrganizationType {
+                           List<URI> partOf) implements OrganizationType {
 
     public static Builder builder() {
         return new Builder();
@@ -21,7 +21,7 @@ public record Organization(URI id,
     public static final class Builder {
 
         private URI id;
-        private List<String> partOf;
+        private List<URI> partOf;
 
         private Builder() {
         }
@@ -31,7 +31,7 @@ public record Organization(URI id,
             return this;
         }
 
-        public Builder withPartOf(List<String> partOf) {
+        public Builder withPartOf(List<URI> partOf) {
             this.partOf = partOf;
             return this;
         }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/OrganizationType.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/OrganizationType.java
@@ -16,5 +16,5 @@ public sealed interface OrganizationType permits Organization, NviOrganization {
 
     URI id();
 
-    List<String> partOf();
+    List<URI> partOf();
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -132,8 +132,8 @@ public final class NviCandidateIndexDocumentGenerator {
     private static Set<URI> extractInvolvedOrganizations(Approval approval,
                                                          List<ContributorType> expandedContributors) {
         return expandedContributors.stream()
-                   .filter(contributorType -> contributorType instanceof NviContributor)
-                   .map(contributorType -> (NviContributor) contributorType)
+                   .filter(NviContributor.class::isInstance)
+                   .map(NviContributor.class::cast)
                    .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
                    .collect(Collectors.toCollection(HashSet::new));
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -135,7 +135,7 @@ public final class NviCandidateIndexDocumentGenerator {
                    .filter(NviContributor.class::isInstance)
                    .map(NviContributor.class::cast)
                    .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
-                   .collect(Collectors.toCollection(HashSet::new));
+                   .collect(Collectors.toSet());
     }
 
     private PublicationDetails expandPublicationDetails(JsonNode expandedResource, List<ContributorType> contributors) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -104,10 +104,13 @@ public final class NviCandidateIndexDocumentGenerator {
     }
 
     private static NviOrganization buildNviOrganization(URI id, Stream<String> rdfNodes) {
-        var partOfIdentifiers = rdfNodes.map(NviCandidateIndexDocumentGenerator::getLastPathElement).toList();
+        var partOf = rdfNodes.map(URI::create).toList();
+        var partOfIdentifiers = partOf.stream().map(UriWrapper::fromUri).map(UriWrapper::getLastPathElement)
+                                    .collect(Collectors.toList());
         return NviOrganization.builder()
                    .withId(id)
                    .withPartOf(partOfIdentifiers)
+                   .withPartOfIds(partOf)
                    .build();
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -134,7 +134,7 @@ public final class NviCandidateIndexDocumentGenerator {
         return expandedContributors.stream()
                    .filter(contributorType -> contributorType instanceof NviContributor)
                    .map(contributorType -> (NviContributor) contributorType)
-                   .flatMap(contributor -> contributor.organizationsPartOf(approval.getInstitutionId()).stream())
+                   .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
                    .collect(Collectors.toCollection(HashSet::new));
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -135,7 +135,6 @@ public final class NviCandidateIndexDocumentGenerator {
                                       .filter(contributorType -> contributorType instanceof NviContributor)
                                       .map(contributorType -> (NviContributor) contributorType)
                                       .flatMap(contributor -> contributor.organizationsPartOf(topLevelOrg).stream())
-                                      .map(OrganizationType::id)
                                       .collect(Collectors.toCollection(HashSet::new));
         creatorAffiliations.add(topLevelOrg);
         return creatorAffiliations;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -7,8 +7,8 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_L
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.createExpandedResource;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.GZIP_ENDING;
-import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_PART_OF_MEDIUM_LEVEL;
-import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_PART_OF_TOP_LEVEL;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_MEDIUM_LEVEL_ORG;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_TOP_LEVEL_ORG;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.NVI_CANDIDATES_FOLDER;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandApprovals;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandPublicationDetails;
@@ -107,7 +107,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldBuildIndexDocumentAndPersistInS3WhenReceivingSqsEvent() {
-        var candidate = randomApplicableCandidate(HARD_CODED_PART_OF_TOP_LEVEL, randomUri());
+        var candidate = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(
             candidate).indexDocument();
         var event = createEvent(candidate.getIdentifier());
@@ -134,7 +134,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldFetchOrganizationLabelsFromCristinApiWhenExpandedResourceIsMissingTopLevelOrganization() {
-        var candidate = randomApplicableCandidate(HARD_CODED_PART_OF_TOP_LEVEL, randomUri());
+        var candidate = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
         var expandedResource = createExpandedResource(candidate);
         setupResourceMissingTopLevelOrganizationsInS3(expandedResource, candidate);
         var expectedIndexDocument = IndexDocumentWithConsumptionAttributes.from(
@@ -292,7 +292,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldNotFailForWholeBatchWhenFailingToFetchOneCandidate() {
-        var candidateToSucceed = randomApplicableCandidate(HARD_CODED_PART_OF_TOP_LEVEL, randomUri());
+        var candidateToSucceed = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(
             candidateToSucceed);
         var event = createEvent(List.of(UUID.randomUUID(), candidateToSucceed.getIdentifier()));
@@ -304,7 +304,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldNotFailForWholeBatchWhenFailingParseOneEventRecord() {
-        var candidateToSucceed = randomApplicableCandidate(HARD_CODED_PART_OF_TOP_LEVEL, randomUri());
+        var candidateToSucceed = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(
             candidateToSucceed);
         var event = createEventWithOneInvalidRecord(candidateToSucceed.getIdentifier());
@@ -385,9 +385,9 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     private static ObjectNode orgWithThreeLevels(URI affiliationId) {
         var lowLevel = generateOrganizationNode(affiliationId.toString());
         var partOfArrayNode = dtoObjectMapper.createArrayNode();
-        var mediumLevel = generateOrganizationNode(HARD_CODED_PART_OF_MEDIUM_LEVEL.toString());
+        var mediumLevel = generateOrganizationNode(HARD_CODED_MEDIUM_LEVEL_ORG.toString());
         var mediumLevelPartOfArrayNode = dtoObjectMapper.createArrayNode();
-        var topLevel = generateOrganizationNode(HARD_CODED_PART_OF_TOP_LEVEL.toString());
+        var topLevel = generateOrganizationNode(HARD_CODED_TOP_LEVEL_ORG.toString());
         mediumLevelPartOfArrayNode.add(topLevel);
         mediumLevel.set("partOf", mediumLevelPartOfArrayNode);
         partOfArrayNode.add(mediumLevel);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -7,7 +7,7 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_L
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.createExpandedResource;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.GZIP_ENDING;
-import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_MEDIUM_LEVEL_ORG;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_INTERMEDIATE_ORGANIZATION;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_TOP_LEVEL_ORG;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.NVI_CANDIDATES_FOLDER;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandApprovals;
@@ -385,12 +385,12 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     private static ObjectNode orgWithThreeLevels(URI affiliationId) {
         var lowLevel = generateOrganizationNode(affiliationId.toString());
         var partOfArrayNode = dtoObjectMapper.createArrayNode();
-        var mediumLevel = generateOrganizationNode(HARD_CODED_MEDIUM_LEVEL_ORG.toString());
-        var mediumLevelPartOfArrayNode = dtoObjectMapper.createArrayNode();
+        var intermediateLevel = generateOrganizationNode(HARD_CODED_INTERMEDIATE_ORGANIZATION.toString());
+        var intermediateLevelPartOfArrayNode = dtoObjectMapper.createArrayNode();
         var topLevel = generateOrganizationNode(HARD_CODED_TOP_LEVEL_ORG.toString());
-        mediumLevelPartOfArrayNode.add(topLevel);
-        mediumLevel.set("partOf", mediumLevelPartOfArrayNode);
-        partOfArrayNode.add(mediumLevel);
+        intermediateLevelPartOfArrayNode.add(topLevel);
+        intermediateLevel.set("partOf", intermediateLevelPartOfArrayNode);
+        partOfArrayNode.add(intermediateLevel);
         lowLevel.set("partOf", partOfArrayNode);
         return lowLevel;
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -7,7 +7,8 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_L
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.createExpandedResource;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.GZIP_ENDING;
-import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_PART_OF;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_PART_OF_MEDIUM_LEVEL;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.HARD_CODED_PART_OF_TOP_LEVEL;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.NVI_CANDIDATES_FOLDER;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandApprovals;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandPublicationDetails;
@@ -106,7 +107,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldBuildIndexDocumentAndPersistInS3WhenReceivingSqsEvent() {
-        var candidate = randomApplicableCandidate(HARD_CODED_PART_OF, randomUri());
+        var candidate = randomApplicableCandidate(HARD_CODED_PART_OF_TOP_LEVEL, randomUri());
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(
             candidate).indexDocument();
         var event = createEvent(candidate.getIdentifier());
@@ -133,7 +134,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldFetchOrganizationLabelsFromCristinApiWhenExpandedResourceIsMissingTopLevelOrganization() {
-        var candidate = randomApplicableCandidate(HARD_CODED_PART_OF, randomUri());
+        var candidate = randomApplicableCandidate(HARD_CODED_PART_OF_TOP_LEVEL, randomUri());
         var expandedResource = createExpandedResource(candidate);
         setupResourceMissingTopLevelOrganizationsInS3(expandedResource, candidate);
         var expectedIndexDocument = IndexDocumentWithConsumptionAttributes.from(
@@ -291,7 +292,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldNotFailForWholeBatchWhenFailingToFetchOneCandidate() {
-        var candidateToSucceed = randomApplicableCandidate(HARD_CODED_PART_OF, randomUri());
+        var candidateToSucceed = randomApplicableCandidate(HARD_CODED_PART_OF_TOP_LEVEL, randomUri());
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(
             candidateToSucceed);
         var event = createEvent(List.of(UUID.randomUUID(), candidateToSucceed.getIdentifier()));
@@ -303,7 +304,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldNotFailForWholeBatchWhenFailingParseOneEventRecord() {
-        var candidateToSucceed = randomApplicableCandidate(HARD_CODED_PART_OF, randomUri());
+        var candidateToSucceed = randomApplicableCandidate(HARD_CODED_PART_OF_TOP_LEVEL, randomUri());
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(
             candidateToSucceed);
         var event = createEventWithOneInvalidRecord(candidateToSucceed.getIdentifier());
@@ -381,6 +382,19 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
                    .getLastPathElement();
     }
 
+    private static ObjectNode orgWithThreeLevels(URI affiliationId) {
+        var lowLevel = generateOrganizationNode(affiliationId.toString());
+        var partOfArrayNode = dtoObjectMapper.createArrayNode();
+        var mediumLevel = generateOrganizationNode(HARD_CODED_PART_OF_MEDIUM_LEVEL.toString());
+        var mediumLevelPartOfArrayNode = dtoObjectMapper.createArrayNode();
+        var topLevel = generateOrganizationNode(HARD_CODED_PART_OF_TOP_LEVEL.toString());
+        mediumLevelPartOfArrayNode.add(topLevel);
+        mediumLevel.set("partOf", mediumLevelPartOfArrayNode);
+        partOfArrayNode.add(mediumLevel);
+        lowLevel.set("partOf", partOfArrayNode);
+        return lowLevel;
+    }
+
     private ConsumptionAttributes setUpExistingResourceWithNonNviCreatorAffiliations(Candidate candidate) {
         var expandedResource = createExpandedResource(candidate, List.of(randomUri()));
         var resourceIndexDocument = createResourceIndexDocument(expandedResource);
@@ -439,18 +453,9 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     }
 
     private void mockOrganizationResponse(URI affiliationId) {
-        var httpResponse = generateResponse(affiliationId);
+        var httpResponse = Optional.of(createResponse(
+            attempt(() -> dtoObjectMapper.writeValueAsString(orgWithThreeLevels(affiliationId))).orElseThrow()));
         when(uriRetriever.fetchResponse(eq(affiliationId), eq(MEDIA_TYPE_JSON_V2))).thenReturn(httpResponse);
-    }
-
-    private Optional<HttpResponse<String>> generateResponse(URI affiliation) {
-        var affiliationOrganizationNode = generateOrganizationNode(affiliation.toString());
-        var partOfArrayNode = dtoObjectMapper.createArrayNode();
-        var partOfOrganizationNode = generateOrganizationNode(HARD_CODED_PART_OF.toString());
-        partOfArrayNode.add(partOfOrganizationNode);
-        affiliationOrganizationNode.set("partOf", partOfArrayNode);
-        return Optional.of(createResponse(
-            attempt(() -> dtoObjectMapper.writeValueAsString(affiliationOrganizationNode)).orElseThrow()));
     }
 
     private IndexDocumentWithConsumptionAttributes setUpExistingResourceInS3AndGenerateExpectedDocument(
@@ -481,14 +486,15 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     }
 
     private NviCandidateIndexDocument createExpectedNviIndexDocument(JsonNode expandedResource, Candidate candidate) {
+        var expandedPublicationDetails = expandPublicationDetails(candidate, expandedResource);
         return NviCandidateIndexDocument.builder()
                    .withContext(Candidate.getContextUri())
                    .withId(candidate.getId())
                    .withIsApplicable(candidate.isApplicable())
                    .withIdentifier(candidate.getIdentifier())
-                   .withApprovals(expandApprovals(candidate))
+                   .withApprovals(expandApprovals(candidate, expandedPublicationDetails.contributors()))
                    .withPoints(candidate.getTotalPoints())
-                   .withPublicationDetails(expandPublicationDetails(candidate, expandedResource))
+                   .withPublicationDetails(expandedPublicationDetails)
                    .withNumberOfApprovals(candidate.getApprovals().size())
                    .withCreatorShareCount(candidate.getCreatorShareCount())
                    .withReported(candidate.isReported())

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
@@ -165,7 +165,7 @@ class UpdateIndexHandlerTest extends LocalDynamoTest {
         var indexDocument =
             NviCandidateIndexDocument.builder()
                 .withContext(NVI_CONTEXT)
-                .withApprovals(expandApprovals(candidate))
+                .withApprovals(expandApprovals(candidate, expandedPublicationDetails.contributors()))
                 .withIdentifier(candidate.getIdentifier())
                 .withPublicationDetails(expandedPublicationDetails)
                 .withPoints(randomBigDecimal())

--- a/index-handlers/src/test/resources/document_approved.json
+++ b/index-handlers/src/test/resources/document_approved.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": []
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_approved_collaboration.json
+++ b/index-handlers/src/test/resources/document_approved_collaboration.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": []
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_new.json
+++ b/index-handlers/src/test/resources/document_new.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": []
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_new_collaboration.json
+++ b/index-handlers/src/test/resources/document_new_collaboration.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": []
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_organization_aggregation_dispute.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_dispute.json
@@ -20,7 +20,7 @@
           {
             "type": "NviOrganization",
             "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.0.0",
-            "partOf": ["20754.0.0.0"]
+            "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"]
           },
           {
             "type": "NviOrganization",

--- a/index-handlers/src/test/resources/document_organization_aggregation_new.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_new.json
@@ -29,7 +29,7 @@
         "affiliations" : [ {
           "type": "NviOrganization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.0.0",
-          "partOf": ["20754.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_organization_aggregation_pending.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_pending.json
@@ -20,7 +20,7 @@
             "type": "NviOrganization",
             "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.0.0",
             "partOf": [
-              "20754.0.0.0"
+              "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
             ]
           }
         ],
@@ -35,8 +35,8 @@
             "type": "NviOrganization",
             "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.1.0",
             "partOf": [
-              "20754.0.0.0",
-              "20754.1.0.0"
+              "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+              "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.0.0"
             ]
           }
         ],

--- a/index-handlers/src/test/resources/document_pending.json
+++ b/index-handlers/src/test/resources/document_pending.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_pending_category_degree_bachelor.json
+++ b/index-handlers/src/test/resources/document_pending_category_degree_bachelor.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_pending_collaboration.json
+++ b/index-handlers/src/test/resources/document_pending_collaboration.json
@@ -18,7 +18,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_rejected.json
+++ b/index-handlers/src/test/resources/document_rejected.json
@@ -19,7 +19,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_rejected_collaboration.json
+++ b/index-handlers/src/test/resources/document_rejected_collaboration.json
@@ -19,7 +19,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
-          "partOf": ["194.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
         } ],
         "role" : "Creator"
       }

--- a/index-handlers/src/test/resources/document_with_contributor_from_ntnu_subunit.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_ntnu_subunit.json
@@ -16,7 +16,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.1",
-          "partOf": ["194.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0"]
         } ],
         "role" : "Creator"
       } ]

--- a/index-handlers/src/test/resources/document_with_contributor_from_sikt.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_sikt.json
@@ -16,7 +16,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.1",
-          "partOf": ["20754.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"]
         } ],
         "role" : "Creator"
       } ]

--- a/index-handlers/src/test/resources/document_with_contributor_from_sikt_but_not_creator.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_sikt_but_not_creator.json
@@ -16,7 +16,7 @@
         "affiliations" : [ {
           "type": "Organization",
           "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.1",
-          "partOf": ["20754.0.0.0"]
+          "partOf": ["https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"]
         } ],
         "role" : "Editor"
       } ]

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -69,8 +69,7 @@ public final class Candidate {
     public static final URI CONTEXT_URI = UriWrapper.fromHost(API_DOMAIN)
                                               .addChild(BASE_PATH, "context")
                                               .getUri();
-    private static final String CONTEXT = stringFromResources(Path.of("nviCandidateContext.json"))
-                                              .replace("__REPLACE_WITH_API_DOMAIN__", API_DOMAIN);
+    private static final String CONTEXT = stringFromResources(Path.of("nviCandidateContext.json"));
     private static final String CANDIDATE_PATH = "candidate";
     private static final String PERIOD_CLOSED_MESSAGE = "Period is closed, perform actions on candidate is forbidden!";
     private static final String PERIOD_NOT_OPENED_MESSAGE = "Period is not opened yet, perform actions on candidate is"
@@ -580,8 +579,6 @@ public final class Candidate {
                    .periodYear(null)
                    .build();
     }
-
-
 
     private void setUserAsAssigneeIfApprovalIsUnassigned(String username, URI institutionId) {
         approvals.computeIfPresent(institutionId, (uri, approval) -> updateAssigneeIfUnassigned(username, approval));

--- a/nvi-commons/src/main/resources/nviCandidateContext.json
+++ b/nvi-commons/src/main/resources/nviCandidateContext.json
@@ -30,12 +30,9 @@
     "modifiedDate": {
       "@type": "xsd:dateTime"
     },
-    "partOf": {
-      "@container": "@set",
-      "@context": {
-        "@base": "__REPLACE_WITH_API_DOMAIN__/cristin/organization"
-      },
-      "@type": "@id"
+    "involvedOrganizations": {
+      "@id": "involvedOrganization",
+      "@container": "@set"
     }
   }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -493,8 +493,7 @@ class CandidateTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnNviCandidateContextAsString() {
-        var expectedContext = stringFromResources(Path.of("nviCandidateContext.json")).replace(
-            "__REPLACE_WITH_API_DOMAIN__", new Environment().readEnv("API_HOST"));
+        var expectedContext = stringFromResources(Path.of("nviCandidateContext.json"));
         assertThat(Candidate.getJsonLdContext(), is(equalTo(expectedContext)));
     }
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -8,7 +8,6 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractAffiliations
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -95,7 +94,7 @@ public final class IndexDocumentTestUtils {
                    .filter(NviContributor.class::isInstance)
                    .map(NviContributor.class::cast)
                    .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
-                   .collect(Collectors.toCollection(HashSet::new));
+                   .collect(Collectors.toSet());
     }
 
     private static ApprovalStatus getApprovalStatus(Approval approval) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -92,8 +92,8 @@ public final class IndexDocumentTestUtils {
     private static Set<URI> extractInvolvedOrganizations(Approval approval,
                                                          List<ContributorType> expandedContributors) {
         return expandedContributors.stream()
-                   .filter(contributorType -> contributorType instanceof NviContributor)
-                   .map(contributorType -> (NviContributor) contributorType)
+                   .filter(NviContributor.class::isInstance)
+                   .map(NviContributor.class::cast)
                    .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
                    .collect(Collectors.toCollection(HashSet::new));
     }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.test;
 
-import static java.util.Collections.emptySet;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.EN_FIELD;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_LABEL;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
@@ -9,6 +8,7 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractAffiliations
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -33,9 +33,11 @@ import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import nva.commons.core.paths.UnixPath;
 
 public final class IndexDocumentTestUtils {
-
     public static final String HARD_CODED_TOP_LEVEL_ORG = "hardCodedPartOf";
-    public static final URI HARD_CODED_PART_OF = URI.create(
+    public static final String HARD_CODED_MEDIUM_LEVEL_ORG = "hardCodedMediumLevelOrg";
+    public static final URI HARD_CODED_PART_OF_MEDIUM_LEVEL = URI.create(
+        "https://example.org/organization/" + HARD_CODED_MEDIUM_LEVEL_ORG);
+    public static final URI HARD_CODED_PART_OF_TOP_LEVEL = URI.create(
         "https://example.org/organization/" + HARD_CODED_TOP_LEVEL_ORG);
     public static final URI NVI_CONTEXT = URI.create("https://bibsysdev.github.io/src/nvi-context.json");
     public static final String NVI_CANDIDATES_FOLDER = "nvi-candidates";
@@ -48,18 +50,19 @@ public final class IndexDocumentTestUtils {
         return UnixPath.of(NVI_CANDIDATES_FOLDER).addChild(candidate.getIdentifier().toString() + GZIP_ENDING);
     }
 
-    public static List<no.sikt.nva.nvi.index.model.document.Approval> expandApprovals(Candidate candidate) {
+    public static List<no.sikt.nva.nvi.index.model.document.Approval> expandApprovals(Candidate candidate,
+                                                                                      List<ContributorType> contributors) {
         return candidate.getApprovals()
                    .values()
                    .stream()
-                   .map(approval -> toApproval(approval, candidate))
+                   .map(approval -> toApproval(approval, candidate, contributors))
                    .toList();
     }
 
     public static PublicationDetails expandPublicationDetails(Candidate candidate, JsonNode expandedResource) {
         return PublicationDetails.builder()
                    .withType(ExpandedResourceGenerator.extractType(expandedResource))
-                   .withId(candidate.getPublicationId().toString())
+                   .withId(candidate.getPublicationDetails().publicationId().toString())
                    .withTitle(ExpandedResourceGenerator.extractTitle(expandedResource))
                    .withPublicationDate(mapToPublicationDate(candidate.getPublicationDetails().publicationDate()))
                    .withContributors(
@@ -67,14 +70,15 @@ public final class IndexDocumentTestUtils {
                    .build();
     }
 
-    private static no.sikt.nva.nvi.index.model.document.Approval toApproval(Approval approval, Candidate candidate) {
+    private static no.sikt.nva.nvi.index.model.document.Approval toApproval(Approval approval, Candidate candidate,
+                                                                            List<ContributorType> contributors) {
         var assignee = approval.getAssignee();
         return no.sikt.nva.nvi.index.model.document.Approval.builder()
                    .withInstitutionId(approval.getInstitutionId())
                    .withApprovalStatus(getApprovalStatus(approval))
                    .withAssignee(Objects.nonNull(assignee) ? assignee.value() : null)
                    .withPoints(getInstitutionPoints(approval, candidate))
-                   .withInvolvedOrganizations(extractInvolvedOrganizations(approval, candidate))
+                   .withInvolvedOrganizations(extractInvolvedOrganizations(approval, contributors))
                    .withLabels(Map.of(EN_FIELD, HARDCODED_ENGLISH_LABEL, NB_FIELD,
                                       HARDCODED_NORWEGIAN_LABEL))
                    .withGlobalApprovalStatus(candidate.getGlobalApprovalStatus())
@@ -87,13 +91,15 @@ public final class IndexDocumentTestUtils {
                    .orElse(null);
     }
 
-    private static Set<URI> extractInvolvedOrganizations(Approval approval, Candidate candidate) {
-        var creatorAffiliations = candidate.getInstitutionPoints(approval.getInstitutionId())
-                                      .map(
-                                          no.sikt.nva.nvi.common.service.model.InstitutionPoints::creatorAffiliationPoints)
-                                      .map(IndexDocumentTestUtils::getAffiliationsWithPoints)
-                                      .orElse(emptySet());
-        creatorAffiliations.add(approval.getInstitutionId());
+    private static Set<URI> extractInvolvedOrganizations(Approval approval,
+                                                         List<ContributorType> expandedContributors) {
+        var topLevelOrg = approval.getInstitutionId();
+        var creatorAffiliations = expandedContributors.stream()
+                                      .filter(contributorType -> contributorType instanceof NviContributor)
+                                      .map(contributorType -> (NviContributor) contributorType)
+                                      .flatMap(contributor -> contributor.organizationsPartOf(topLevelOrg).stream())
+                                      .collect(Collectors.toCollection(HashSet::new));
+        creatorAffiliations.add(topLevelOrg);
         return creatorAffiliations;
     }
 
@@ -194,7 +200,7 @@ public final class IndexDocumentTestUtils {
     private static OrganizationType generateNviOrganization(URI id) {
         return NviOrganization.builder()
                    .withId(id)
-                   .withPartOf(List.of(HARD_CODED_TOP_LEVEL_ORG))
+                   .withPartOf(List.of(HARD_CODED_TOP_LEVEL_ORG, HARD_CODED_MEDIUM_LEVEL_ORG))
                    .build();
     }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -33,12 +33,11 @@ import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import nva.commons.core.paths.UnixPath;
 
 public final class IndexDocumentTestUtils {
-    public static final String HARD_CODED_TOP_LEVEL_ORG = "hardCodedPartOf";
-    public static final String HARD_CODED_MEDIUM_LEVEL_ORG = "hardCodedMediumLevelOrg";
-    public static final URI HARD_CODED_PART_OF_MEDIUM_LEVEL = URI.create(
-        "https://example.org/organization/" + HARD_CODED_MEDIUM_LEVEL_ORG);
-    public static final URI HARD_CODED_PART_OF_TOP_LEVEL = URI.create(
-        "https://example.org/organization/" + HARD_CODED_TOP_LEVEL_ORG);
+
+    public static final URI HARD_CODED_MEDIUM_LEVEL_ORG = URI.create(
+        "https://example.org/organization/hardCodedMediumLevelOrg");
+    public static final URI HARD_CODED_TOP_LEVEL_ORG = URI.create(
+        "https://example.org/organization/hardCodedPartOf");
     public static final URI NVI_CONTEXT = URI.create("https://bibsysdev.github.io/src/nvi-context.json");
     public static final String NVI_CANDIDATES_FOLDER = "nvi-candidates";
     public static final String GZIP_ENDING = ".gz";
@@ -93,20 +92,11 @@ public final class IndexDocumentTestUtils {
 
     private static Set<URI> extractInvolvedOrganizations(Approval approval,
                                                          List<ContributorType> expandedContributors) {
-        var topLevelOrg = approval.getInstitutionId();
-        var creatorAffiliations = expandedContributors.stream()
-                                      .filter(contributorType -> contributorType instanceof NviContributor)
-                                      .map(contributorType -> (NviContributor) contributorType)
-                                      .flatMap(contributor -> contributor.organizationsPartOf(topLevelOrg).stream())
-                                      .collect(Collectors.toCollection(HashSet::new));
-        creatorAffiliations.add(topLevelOrg);
-        return creatorAffiliations;
-    }
-
-    private static Set<URI> getAffiliationsWithPoints(List<CreatorAffiliationPoints> creatorAffiliationPoints) {
-        return creatorAffiliationPoints.stream()
-                   .map(CreatorAffiliationPoints::affiliationId)
-                   .collect(Collectors.toSet());
+        return expandedContributors.stream()
+                   .filter(contributorType -> contributorType instanceof NviContributor)
+                   .map(contributorType -> (NviContributor) contributorType)
+                   .flatMap(contributor -> contributor.organizationsPartOf(approval.getInstitutionId()).stream())
+                   .collect(Collectors.toCollection(HashSet::new));
     }
 
     private static ApprovalStatus getApprovalStatus(Approval approval) {
@@ -200,7 +190,7 @@ public final class IndexDocumentTestUtils {
     private static OrganizationType generateNviOrganization(URI id) {
         return NviOrganization.builder()
                    .withId(id)
-                   .withPartOf(List.of(HARD_CODED_TOP_LEVEL_ORG, HARD_CODED_MEDIUM_LEVEL_ORG))
+                   .withPartOf(List.of(HARD_CODED_MEDIUM_LEVEL_ORG, HARD_CODED_TOP_LEVEL_ORG))
                    .build();
     }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import no.sikt.nva.nvi.common.service.model.Approval;
 import no.sikt.nva.nvi.common.service.model.Candidate;
-import no.sikt.nva.nvi.common.service.model.InstitutionPoints.CreatorAffiliationPoints;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.Creator;
 import no.sikt.nva.nvi.common.utils.JsonUtils;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -94,7 +94,7 @@ public final class IndexDocumentTestUtils {
         return expandedContributors.stream()
                    .filter(contributorType -> contributorType instanceof NviContributor)
                    .map(contributorType -> (NviContributor) contributorType)
-                   .flatMap(contributor -> contributor.organizationsPartOf(approval.getInstitutionId()).stream())
+                   .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
                    .collect(Collectors.toCollection(HashSet::new));
     }
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -33,8 +33,8 @@ import nva.commons.core.paths.UnixPath;
 
 public final class IndexDocumentTestUtils {
 
-    public static final URI HARD_CODED_MEDIUM_LEVEL_ORG = URI.create(
-        "https://example.org/organization/hardCodedMediumLevelOrg");
+    public static final URI HARD_CODED_INTERMEDIATE_ORGANIZATION = URI.create(
+        "https://example.org/organization/hardCodedIntermediateOrg");
     public static final URI HARD_CODED_TOP_LEVEL_ORG = URI.create(
         "https://example.org/organization/hardCodedPartOf");
     public static final URI NVI_CONTEXT = URI.create("https://bibsysdev.github.io/src/nvi-context.json");
@@ -189,7 +189,7 @@ public final class IndexDocumentTestUtils {
     private static OrganizationType generateNviOrganization(URI id) {
         return NviOrganization.builder()
                    .withId(id)
-                   .withPartOf(List.of(HARD_CODED_MEDIUM_LEVEL_ORG, HARD_CODED_TOP_LEVEL_ORG))
+                   .withPartOf(List.of(HARD_CODED_INTERMEDIATE_ORGANIZATION, HARD_CODED_TOP_LEVEL_ORG))
                    .build();
     }
 }


### PR DESCRIPTION
Jira task: NP-46914 _Nvi institution status aggregations missing parts of org structure_
Aggragations for institution status is made for all orgs in Index document -> `approvals.involvedOrganizations`.
Bug: `approvals.involvedOrganizations` was missing intermidiate levels.

Changes:
- Add all organizations (`contributor.affiliationId` + all orgs in `partOf`-list of the affiliation) in `approvals.involvedOrganizations`
- Make `partOf`-list contain URIs again instead of identifiers. (Mixing uris and identifiers in the model was a hassle)
- Make nvi contributors in tests affiliated to a org with two levels above in the org hierarchy to test this
