### PR TITLE
removing security from openapi schema

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -349,12 +349,6 @@ paths:
           required: true
           schema:
             type: string
-      security:
-        - CognitoUserPool: [
-          'https://api.nva.unit.no/scopes/backend',
-          'https://api.nva.unit.no/scopes/frontend',
-          'aws.cognito.signin.user.admin',
-        ]
       x-amazon-apigateway-integration:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchNviCandidateByPublicationIdHandler.Arn}:live/invocations


### PR DESCRIPTION
Det endepunktet skal være åpent for at ikke innloggede brukere får se om publikasjon er nvi-rapportert eller ikke.