### PR TITLE
Np 46947 Nvi Search: query params orderBy and sortOrder

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -273,6 +273,21 @@ paths:
           schema:
             type: string
           description: Filters values based on assignee
+        - in: query
+          name: orderBy
+          schema:
+            type: string
+            description: Order by field
+            enum:
+              - createdDate
+        - in: query
+          name: sortOrder
+          schema:
+            type: string
+            description: Order direction
+            enum:
+              - asc
+              - desc
       security:
         - CognitoUserPool: [
           'https://api.nva.unit.no/scopes/backend',

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandler.java
@@ -26,6 +26,7 @@ import no.unit.nva.commons.pagination.PaginatedSearchResult;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
@@ -62,7 +63,7 @@ public class SearchNviCandidatesHandler
     @Override
     protected PaginatedSearchResult<NviCandidateIndexDocument> processInput(Void input, RequestInfo requestInfo,
                                                                             Context context)
-        throws UnauthorizedException {
+        throws UnauthorizedException, BadRequestException {
         validateAccessRights(requestInfo);
         var candidateSearchParameters = CandidateSearchParameters.fromRequestInfo(requestInfo);
         logAggregationType(candidateSearchParameters);

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -192,7 +192,7 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
     }
 
     private static SortOrder getSortOrder(String sortOrder) {
-        return sortOrder.equalsIgnoreCase(ASC) ? SortOrder.Asc : SortOrder.Desc;
+        return ASC.equalsIgnoreCase(sortOrder) ? SortOrder.Asc : SortOrder.Desc;
     }
 
     private TransportOptions getOptions() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -181,11 +181,11 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
     private static SortOptions getSortOptions(CandidateSearchParameters parameters) {
         var resultParameters = parameters.searchResultParameters();
         return new SortOptions.Builder()
-                   .field(FieldSort.of(fieldSOrtBuilderFunction(resultParameters)))
+                   .field(FieldSort.of(fieldSortBuilderFunction(resultParameters)))
                    .build();
     }
 
-    private static Function<Builder, ObjectBuilder<FieldSort>> fieldSOrtBuilderFunction(
+    private static Function<Builder, ObjectBuilder<FieldSort>> fieldSortBuilderFunction(
         SearchResultParameters resultParameters) {
         return builder -> builder.field(resultParameters.orderBy()).order(getSortOrder(resultParameters.sortOrder()));
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -53,7 +53,6 @@ import org.slf4j.LoggerFactory;
 @JacocoGenerated
 public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument> {
 
-    public static final String ASC = "asc";
     private static final String INDEX_NOT_FOUND_EXCEPTION = "index_not_found_exception";
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenSearchClient.class);
     private static final String ERROR_MSG_CREATE_INDEX = "Error while creating index: " + NVI_CANDIDATES_INDEX;
@@ -192,7 +191,7 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
     }
 
     private static SortOrder getSortOrder(String sortOrder) {
-        return ASC.equalsIgnoreCase(sortOrder) ? SortOrder.Asc : SortOrder.Desc;
+        return SortOrder.Asc.jsonValue().equalsIgnoreCase(sortOrder) ? SortOrder.Asc : SortOrder.Desc;
     }
 
     private TransportOptions getOptions() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -188,8 +188,7 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
 
     private static Function<Builder, ObjectBuilder<FieldSort>> fieldSOrtBuilderFunction(
         SearchResultParameters resultParameters) {
-        return builder -> builder.field(resultParameters.orderBy())
-                              .order(getSortOrder(resultParameters.sortOrder()));
+        return builder -> builder.field(resultParameters.orderBy()).order(getSortOrder(resultParameters.sortOrder()));
     }
 
     private static SortOrder getSortOrder(String sortOrder) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/SearchQueryParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/SearchQueryParameters.java
@@ -14,6 +14,7 @@ public final class SearchQueryParameters {
     public static final String QUERY_PARAM_ASSIGNEE = "assignee";
     public static final String QUERY_SIZE_PARAM = "size";
     public static final String QUERY_OFFSET_PARAM = "offset";
+    public static final String QUERY_PARAM_ORDER_BY = "orderBy";
 
     private SearchQueryParameters() {
         // NO-OP

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/SearchQueryParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/SearchQueryParameters.java
@@ -15,6 +15,7 @@ public final class SearchQueryParameters {
     public static final String QUERY_SIZE_PARAM = "size";
     public static final String QUERY_OFFSET_PARAM = "offset";
     public static final String QUERY_PARAM_ORDER_BY = "orderBy";
+    public static final String QUERY_PARAM_SORT_ORDER = "sortOrder";
 
     private SearchQueryParameters() {
         // NO-OP

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -8,10 +8,12 @@ import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_CATE
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_CONTRIBUTOR;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_EXCLUDE_SUB_UNITS;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_FILTER;
+import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_ORDER_BY;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_TITLE;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_YEAR;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_SIZE_PARAM;
+import static no.sikt.nva.nvi.index.model.search.SearchResultParameters.DEFAULT_ORDER_BY_FIELD;
 import static nva.commons.apigateway.RestRequestHandler.COMMA;
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -62,16 +64,25 @@ public record CandidateSearchParameters(String searchTerm,
                    .withContributor(extractQueryParamContributor(requestInfo))
                    .withAssignee(extractQueryParamAssignee(requestInfo))
                    .withAggregationType(aggregationType)
-                   .withSearchResultParameters(SearchResultParameters.builder()
-                                                   .withOffset(extractQueryParamOffsetOrDefault(requestInfo))
-                                                   .withSize(extractQueryParamSizeOrDefault(requestInfo))
-                                                   .build())
+                   .withSearchResultParameters(getResultParameters(requestInfo))
                    .withTopLevelCristinOrg(requestInfo.getTopLevelOrgCristinId().orElse(null))
                    .build();
     }
 
     public String topLevelOrgUriAsString() {
         return Optional.ofNullable(topLevelCristinOrg).map(URI::toString).orElse(null);
+    }
+
+    private static SearchResultParameters getResultParameters(RequestInfo requestInfo) {
+        return SearchResultParameters.builder()
+                   .withOffset(extractQueryParamOffsetOrDefault(requestInfo))
+                   .withSize(extractQueryParamSizeOrDefault(requestInfo))
+                   .withOrderBy(extractQueryParamOrderByOrDefault(requestInfo))
+                   .build();
+    }
+
+    private static String extractQueryParamOrderByOrDefault(RequestInfo requestInfo) {
+        return requestInfo.getQueryParameterOpt(QUERY_PARAM_ORDER_BY).orElse(DEFAULT_ORDER_BY_FIELD);
     }
 
     private static String extractQueryParamAggregationType(RequestInfo requestInfo) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -10,10 +10,12 @@ import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_EXCL
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_FILTER;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_ORDER_BY;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
+import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SORT_ORDER;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_TITLE;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_YEAR;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_SIZE_PARAM;
 import static no.sikt.nva.nvi.index.model.search.SearchResultParameters.DEFAULT_ORDER_BY_FIELD;
+import static no.sikt.nva.nvi.index.model.search.SearchResultParameters.DEFAULT_SORT_ORDER;
 import static nva.commons.apigateway.RestRequestHandler.COMMA;
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -78,7 +80,12 @@ public record CandidateSearchParameters(String searchTerm,
                    .withOffset(extractQueryParamOffsetOrDefault(requestInfo))
                    .withSize(extractQueryParamSizeOrDefault(requestInfo))
                    .withOrderBy(extractQueryParamOrderByOrDefault(requestInfo))
+                   .withSortOrder(extractQueryParamSortOrderOrDefault(requestInfo))
                    .build();
+    }
+
+    private static String extractQueryParamSortOrderOrDefault(RequestInfo requestInfo) {
+        return requestInfo.getQueryParameterOpt(QUERY_PARAM_SORT_ORDER).orElse(DEFAULT_SORT_ORDER);
     }
 
     private static String extractQueryParamOrderByOrDefault(RequestInfo requestInfo) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -14,7 +14,6 @@ import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SORT
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_TITLE;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_YEAR;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_SIZE_PARAM;
-import static no.sikt.nva.nvi.index.model.search.SearchResultParameters.DEFAULT_ORDER_BY_FIELD;
 import static no.sikt.nva.nvi.index.model.search.SearchResultParameters.DEFAULT_SORT_ORDER;
 import static nva.commons.apigateway.RestRequestHandler.COMMA;
 import java.net.URI;
@@ -25,6 +24,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import no.unit.nva.commons.json.JsonSerializable;
 import nva.commons.apigateway.RequestInfo;
+import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.StringUtils;
 
@@ -52,7 +52,7 @@ public record CandidateSearchParameters(String searchTerm,
     }
 
     public static CandidateSearchParameters fromRequestInfo(RequestInfo requestInfo)
-        throws UnauthorizedException {
+        throws UnauthorizedException, BadRequestException {
         var aggregationType = extractQueryParamAggregationType(requestInfo);
         return CandidateSearchParameters.builder()
                    .withSearchTerm(extractQueryParamSearchTermOrDefault(requestInfo))
@@ -75,7 +75,7 @@ public record CandidateSearchParameters(String searchTerm,
         return Optional.ofNullable(topLevelCristinOrg).map(URI::toString).orElse(null);
     }
 
-    private static SearchResultParameters getResultParameters(RequestInfo requestInfo) {
+    private static SearchResultParameters getResultParameters(RequestInfo requestInfo) throws BadRequestException {
         return SearchResultParameters.builder()
                    .withOffset(extractQueryParamOffsetOrDefault(requestInfo))
                    .withSize(extractQueryParamSizeOrDefault(requestInfo))
@@ -88,8 +88,15 @@ public record CandidateSearchParameters(String searchTerm,
         return requestInfo.getQueryParameterOpt(QUERY_PARAM_SORT_ORDER).orElse(DEFAULT_SORT_ORDER);
     }
 
-    private static String extractQueryParamOrderByOrDefault(RequestInfo requestInfo) {
-        return requestInfo.getQueryParameterOpt(QUERY_PARAM_ORDER_BY).orElse(DEFAULT_ORDER_BY_FIELD);
+    private static String extractQueryParamOrderByOrDefault(RequestInfo requestInfo) throws BadRequestException {
+        try {
+            return requestInfo.getQueryParameterOpt(QUERY_PARAM_ORDER_BY)
+                       .map(OrderByFields::parse)
+                       .map(OrderByFields::getValue)
+                       .orElse(OrderByFields.CREATED_DATE.getValue());
+        } catch (IllegalArgumentException exception) {
+            throw new BadRequestException(exception.getMessage());
+        }
     }
 
     private static String extractQueryParamAggregationType(RequestInfo requestInfo) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/OrderByFields.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/OrderByFields.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.index.model.search;
 
 import java.util.Arrays;
+import java.util.List;
 
 public enum OrderByFields {
     CREATED_DATE("createdDate");
@@ -15,7 +16,14 @@ public enum OrderByFields {
         return Arrays.stream(OrderByFields.values())
                    .filter(field -> field.getValue().equalsIgnoreCase(value))
                    .findFirst()
-                   .orElseThrow(() -> new IllegalArgumentException("Invalid OrderByField: " + value));
+                   .orElseThrow(
+                       () -> new IllegalArgumentException("Invalid orderBy field. Valid values are: " + validValues()));
+    }
+
+    public static List<String> validValues() {
+        return Arrays.stream(OrderByFields.values())
+                   .map(OrderByFields::getValue)
+                   .toList();
     }
 
     public String getValue() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/OrderByFields.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/OrderByFields.java
@@ -1,0 +1,24 @@
+package no.sikt.nva.nvi.index.model.search;
+
+import java.util.Arrays;
+
+public enum OrderByFields {
+    CREATED_DATE("createdDate");
+
+    private final String value;
+
+    OrderByFields(String value) {
+        this.value = value;
+    }
+
+    public static OrderByFields parse(String value) {
+        return Arrays.stream(OrderByFields.values())
+                   .filter(field -> field.getValue().equalsIgnoreCase(value))
+                   .findFirst()
+                   .orElseThrow(() -> new IllegalArgumentException("Invalid OrderByField: " + value));
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchResultParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchResultParameters.java
@@ -4,7 +4,7 @@ public record SearchResultParameters(int offset, int size, String orderBy, Strin
 
     public static final int DEFAULT_SIZE = 10;
     public static final int DEFAULT_OFFSET = 0;
-    public static final String DEFAULT_ORDER_BY_FIELD = "createDate";
+    public static final String DEFAULT_ORDER_BY_FIELD = "createdDate";
     public static final String DEFAULT_SORT_ORDER = "desc";
 
     public static Builder builder() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchResultParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchResultParameters.java
@@ -4,7 +4,7 @@ public record SearchResultParameters(int offset, int size, String orderBy, Strin
 
     public static final int DEFAULT_SIZE = 10;
     public static final int DEFAULT_OFFSET = 0;
-    public static final String DEFAULT_ORDER_BY_FIELD = "createdDate";
+    public static final String DEFAULT_ORDER_BY_FIELD = OrderByFields.CREATED_DATE.getValue();
     public static final String DEFAULT_SORT_ORDER = "desc";
 
     public static Builder builder() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchResultParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchResultParameters.java
@@ -1,9 +1,10 @@
 package no.sikt.nva.nvi.index.model.search;
 
-public record SearchResultParameters(int offset, int size) {
+public record SearchResultParameters(int offset, int size, String orderBy) {
 
     public static final int DEFAULT_SIZE = 10;
     public static final int DEFAULT_OFFSET = 0;
+    public static final String DEFAULT_ORDER_BY_FIELD = "createDate";
 
     public static Builder builder() {
         return new Builder();
@@ -13,6 +14,7 @@ public record SearchResultParameters(int offset, int size) {
 
         private int offset = DEFAULT_OFFSET;
         private int size = DEFAULT_SIZE;
+        private String orderBy = DEFAULT_ORDER_BY_FIELD;
 
         private Builder() {
         }
@@ -27,8 +29,13 @@ public record SearchResultParameters(int offset, int size) {
             return this;
         }
 
+        public Builder withOrderBy(String orderBy) {
+            this.orderBy = orderBy;
+            return this;
+        }
+
         public SearchResultParameters build() {
-            return new SearchResultParameters(offset, size);
+            return new SearchResultParameters(offset, size, orderBy);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchResultParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchResultParameters.java
@@ -1,10 +1,11 @@
 package no.sikt.nva.nvi.index.model.search;
 
-public record SearchResultParameters(int offset, int size, String orderBy) {
+public record SearchResultParameters(int offset, int size, String orderBy, String sortOrder) {
 
     public static final int DEFAULT_SIZE = 10;
     public static final int DEFAULT_OFFSET = 0;
     public static final String DEFAULT_ORDER_BY_FIELD = "createDate";
+    public static final String DEFAULT_SORT_ORDER = "desc";
 
     public static Builder builder() {
         return new Builder();
@@ -15,6 +16,7 @@ public record SearchResultParameters(int offset, int size, String orderBy) {
         private int offset = DEFAULT_OFFSET;
         private int size = DEFAULT_SIZE;
         private String orderBy = DEFAULT_ORDER_BY_FIELD;
+        private String sortOrder = DEFAULT_SORT_ORDER;
 
         private Builder() {
         }
@@ -34,8 +36,13 @@ public record SearchResultParameters(int offset, int size, String orderBy) {
             return this;
         }
 
+        public Builder withSortOrder(String sortOrder) {
+            this.sortOrder = sortOrder;
+            return this;
+        }
+
         public SearchResultParameters build() {
-            return new SearchResultParameters(offset, size, orderBy);
+            return new SearchResultParameters(offset, size, orderBy, sortOrder);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
@@ -8,6 +8,7 @@ import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_CATE
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_CONTRIBUTOR;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_EXCLUDE_SUB_UNITS;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_FILTER;
+import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_ORDER_BY;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_TITLE;
 import static nva.commons.apigateway.RestRequestHandler.COMMA;
@@ -67,6 +68,7 @@ public final class PaginatedResultConverter {
         putIfValueNotNull(queryParams, QUERY_PARAM_CONTRIBUTOR, parameters.contributor());
         putIfValueNotNull(queryParams, QUERY_PARAM_ASSIGNEE, parameters.assignee());
         putIfValueNotNull(queryParams, QUERY_AGGREGATION_TYPE, parameters.aggregationType());
+        putIfValueNotNull(queryParams, QUERY_PARAM_ORDER_BY, parameters.searchResultParameters().orderBy());
         return queryParams;
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
@@ -10,6 +10,7 @@ import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_EXCL
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_FILTER;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_ORDER_BY;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
+import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SORT_ORDER;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_TITLE;
 import static nva.commons.apigateway.RestRequestHandler.COMMA;
 import java.net.URI;
@@ -69,6 +70,7 @@ public final class PaginatedResultConverter {
         putIfValueNotNull(queryParams, QUERY_PARAM_ASSIGNEE, parameters.assignee());
         putIfValueNotNull(queryParams, QUERY_AGGREGATION_TYPE, parameters.aggregationType());
         putIfValueNotNull(queryParams, QUERY_PARAM_ORDER_BY, parameters.searchResultParameters().orderBy());
+        putIfValueNotNull(queryParams, QUERY_PARAM_SORT_ORDER, parameters.searchResultParameters().sortOrder());
         return queryParams;
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
@@ -47,6 +47,7 @@ public final class SearchConstants {
     public static final String GLOBAL_APPROVAL_STATUS = "globalApprovalStatus";
     public static final String POINTS = "points";
     public static final String INSTITUTION_POINTS = "institutionPoints";
+    public static final String CREATED_DATE = "createdDate";
 
     private SearchConstants() {
 
@@ -73,6 +74,7 @@ public final class SearchConstants {
 
     private static Map<String, Property> mappingProperties() {
         return Map.of(GLOBAL_APPROVAL_STATUS, keywordProperty(),
+                      CREATED_DATE, keywordProperty(),
                       JSON_PATH_CONTRIBUTORS, nestedProperty(contributorsProperties()),
                       APPROVALS, nestedProperty(approvalProperties())
         );

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -65,6 +65,7 @@ import no.sikt.nva.nvi.index.model.document.Organization;
 import no.sikt.nva.nvi.index.model.document.PublicationDate;
 import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
+import no.sikt.nva.nvi.index.model.search.OrderByFields;
 import no.sikt.nva.nvi.index.model.search.SearchAggregation;
 import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.unit.nva.auth.CachedJwtProvider;
@@ -175,7 +176,8 @@ public class OpenSearchClientTest {
         var searchParameters =
             defaultSearchParameters().withSearchResultParameters(SearchResultParameters.builder()
                                                                      .withSortOrder(sortOrder)
-                                                                     .withOrderBy("createdDate").build()).build();
+                                                                     .withOrderBy(OrderByFields.CREATED_DATE.getValue())
+                                                                     .build()).build();
         var searchResponse = openSearchClient.search(searchParameters);
         var hits = searchResponse.hits().hits();
         var expectedFirst = sortOrder.equals("asc") ? createdFirst.createdDate() : createdSecond.createdDate();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -179,6 +179,7 @@ public class OpenSearchClientTest {
         addDocumentsToIndex(createdFirst, createdSecond);
         var searchParameters =
             defaultSearchParameters().withSearchResultParameters(SearchResultParameters.builder()
+                                                                     .withSortOrder("desc")
                                                                      .withOrderBy("createdDate").build()).build();
         var searchResponse = openSearchClient.search(searchParameters);
         var hits = searchResponse.hits().hits();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/OpenSearchClientTest.java
@@ -153,10 +153,10 @@ public class OpenSearchClientTest {
 
     @Test
     void shouldReturnDocumentsFromIndexAccordingToGivenOffsetAndSize() throws IOException {
-        int totalNumberOfDocuments = 12;
+        int totalNumberOfDocuments = 4;
         IntStream.range(0, totalNumberOfDocuments).forEach(i -> addDocumentToIndex());
-        int offset = 10;
-        int size = 10;
+        int offset = 2;
+        int size = 2;
         var searchParameters =
             CandidateSearchParameters.builder()
                 .withUsername(USERNAME)
@@ -687,7 +687,8 @@ public class OpenSearchClientTest {
                    .withPublicationDetails(randomPublicationDetails())
                    .withApprovals(approvals)
                    .withNumberOfApprovals(approvals.size())
-                   .withPoints(randomBigDecimal());
+                   .withPoints(randomBigDecimal())
+                   .withCreatedDate(Instant.now());
     }
 
     private static NviCandidateIndexDocument singleNviCandidateIndexDocumentWithCustomer(URI customer,
@@ -701,6 +702,7 @@ public class OpenSearchClientTest {
                    .withApprovals(List.of(randomApprovalWithCustomerAndAssignee(customer, assignee)))
                    .withNumberOfApprovals(1)
                    .withPoints(randomBigDecimal())
+                   .withCreatedDate(Instant.now())
                    .withModifiedDate(Instant.now())
                    .build();
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -227,6 +227,18 @@ public class SearchNviCandidatesHandlerTest {
     }
 
     @Test
+    void shouldReturnPaginatedSearchResultWithSortOrderInIdIfGiven() throws IOException {
+        mockOpenSearchClient();
+        var sortOrderValue = "desc";
+        var request = createRequest(TOP_LEVEL_CRISTIN_ORG, Map.of("sortOrder", sortOrderValue));
+        handler.handleRequest(request, output, context);
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var paginatedSearchResult = response.getBodyObject(PaginatedSearchResult.class);
+        var actualId = paginatedSearchResult.getId().toString();
+        assertThat(actualId, containsString("sortOrder" + "=" + sortOrderValue));
+    }
+
+    @Test
     void shouldReturnPaginatedSearchResultWithFilterAggregations() throws IOException {
         var documents = generateNumberOfIndexDocuments(10);
         var aggregationName = randomString();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -3,6 +3,7 @@ package no.sikt.nva.nvi.index;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_AGGREGATION_TYPE;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_EXCLUDE_SUB_UNITS;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
+import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_SORT_ORDER;
 import static no.sikt.nva.nvi.index.model.SearchQueryParameters.QUERY_PARAM_TITLE;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.NVI_CANDIDATES_INDEX;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
@@ -43,6 +44,7 @@ import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.document.PublicationDate;
 import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
+import no.sikt.nva.nvi.index.model.search.OrderByFields;
 import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
 import no.unit.nva.commons.json.JsonUtils;
@@ -227,7 +229,7 @@ public class SearchNviCandidatesHandlerTest {
     @Test
     void shouldReturnPaginatedSearchResultWithOrderByInIdIfGiven() throws IOException {
         mockOpenSearchClient();
-        var orderByValue = "createdDate";
+        var orderByValue = OrderByFields.CREATED_DATE.getValue();
         var request = createRequest(TOP_LEVEL_CRISTIN_ORG, Map.of(QUERY_PARAM_ORDER_BY, orderByValue));
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
@@ -240,12 +242,12 @@ public class SearchNviCandidatesHandlerTest {
     void shouldReturnPaginatedSearchResultWithSortOrderInIdIfGiven() throws IOException {
         mockOpenSearchClient();
         var sortOrderValue = "desc";
-        var request = createRequest(TOP_LEVEL_CRISTIN_ORG, Map.of("sortOrder", sortOrderValue));
+        var request = createRequest(TOP_LEVEL_CRISTIN_ORG, Map.of(QUERY_PARAM_SORT_ORDER, sortOrderValue));
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
         var paginatedSearchResult = response.getBodyObject(PaginatedSearchResult.class);
         var actualId = paginatedSearchResult.getId().toString();
-        assertThat(actualId, containsString("sortOrder" + "=" + sortOrderValue));
+        assertThat(actualId, containsString(QUERY_PARAM_SORT_ORDER + "=" + sortOrderValue));
     }
 
     @Test

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -80,6 +80,7 @@ public class SearchNviCandidatesHandlerTest {
 
     public static final URI TOP_LEVEL_CRISTIN_ORG = URI.create(
         "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0");
+    public static final String QUERY_PARAM_ORDER_BY = "orderBy";
     private static final String QUERY_PARAM_AFFILIATIONS = "affiliations";
     private static final String QUERY_PARAM_FILTER = "filter";
     private static final String QUERY_PARAM_CATEGORY = "category";
@@ -211,6 +212,18 @@ public class SearchNviCandidatesHandlerTest {
         var paginatedSearchResult = response.getBodyObject(PaginatedSearchResult.class);
         var actualId = paginatedSearchResult.getId().toString();
         assertThat(actualId, containsString(QUERY_AGGREGATION_TYPE + "=" + aggregationType));
+    }
+
+    @Test
+    void shouldReturnPaginatedSearchResultWithOrderByInIdIfGiven() throws IOException {
+        mockOpenSearchClient();
+        var orderByValue = "createdDate";
+        var request = createRequest(TOP_LEVEL_CRISTIN_ORG, Map.of(QUERY_PARAM_ORDER_BY, orderByValue));
+        handler.handleRequest(request, output, context);
+        var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+        var paginatedSearchResult = response.getBodyObject(PaginatedSearchResult.class);
+        var actualId = paginatedSearchResult.getId().toString();
+        assertThat(actualId, containsString(QUERY_PARAM_ORDER_BY + "=" + orderByValue));
     }
 
     @Test

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/SearchNviCandidatesHandlerTest.java
@@ -113,6 +113,16 @@ public class SearchNviCandidatesHandlerTest {
     }
 
     @Test
+    void shouldReturnBadRequestIfOrderByIsInvalid() throws IOException {
+        mockOpenSearchClient();
+        var request = createRequest(TOP_LEVEL_CRISTIN_ORG, Map.of(QUERY_PARAM_ORDER_BY, "invalid"));
+        handler.handleRequest(request, output, context);
+        var response = GatewayResponse.fromOutputStream(output, Problem.class);
+        assertThat(response.getBodyObject(Problem.class).getStatus().getStatusCode(),
+                   is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
+    }
+
+    @Test
     void shouldReturnDocumentFromIndexWhenNoSearchIsSpecified() throws IOException {
         var expectedDocument = singleNviCandidateIndexDocument();
         when(openSearchClient.search(any())).thenReturn(createSearchResponse(expectedDocument));
@@ -498,6 +508,7 @@ public class SearchNviCandidatesHandlerTest {
         throws JsonProcessingException {
         return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
                    .withTopLevelCristinOrgId(topLevelCristinOrgId)
+                   .withAccessRights(topLevelCristinOrgId, AccessRight.MANAGE_NVI_CANDIDATES)
                    .withUserName(randomString())
                    .withQueryParameters(queryParams)
                    .build();


### PR DESCRIPTION
Add support for new, optional query params orderBy and sortOrder.

`orderBy`:

- Default value: createdDate
- Supported values: createdDate

`sortOrder`:
- Default value: desc 
- Supported values: desc, asc@

Handler returns 400 Bad Request if query param `orderBy` contains unsupported value