### PR TITLE
Np 46965 Fix: Nvi institution report aggregations missing affiliations to top level org

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviContributor.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviContributor.java
@@ -25,6 +25,7 @@ public record NviContributor(@JsonProperty("id") String id,
         var organizationsPartOfTopLevelOrg = new ArrayList<URI>();
         organizationsPartOfTopLevelOrg.addAll(getOrganizationsAboveAffiliationInOrgHierarchy(topLevelOrg));
         organizationsPartOfTopLevelOrg.addAll(getAffiliationsIdsPartOf(topLevelOrg));
+        organizationsPartOfTopLevelOrg.add(topLevelOrg);
         return organizationsPartOfTopLevelOrg.stream().toList();
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviOrganization.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviOrganization.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.index.model.document;
 
+import static java.util.Objects.isNull;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -17,6 +18,11 @@ public record NviOrganization(@JsonProperty("id") URI id,
 
     public static Builder builder() {
         return new Builder();
+    }
+
+    @Override
+    public List<URI> partOf() {
+        return isNull(partOf) ? List.of() : partOf;
     }
 
     public static final class Builder {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -138,8 +138,12 @@ public final class NviCandidateIndexDocumentGenerator {
                                           .flatMap(contributor -> contributor.getOrganizationsPartOf(
                                               approval.getInstitutionId()).stream())
                                           .collect(Collectors.toCollection(HashSet::new));
-        affiliatedOrganizations.add(approval.getInstitutionId());
+        addTopLevelAffiliations(affiliatedOrganizations, approval.getInstitutionId());
         return affiliatedOrganizations;
+    }
+
+    private static void addTopLevelAffiliations(HashSet<URI> affiliatedOrganizations, URI institutionId) {
+        affiliatedOrganizations.add(institutionId);
     }
 
     private PublicationDetails expandPublicationDetails(JsonNode expandedResource, List<ContributorType> contributors) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -131,11 +132,14 @@ public final class NviCandidateIndexDocumentGenerator {
 
     private static Set<URI> extractInvolvedOrganizations(Approval approval,
                                                          List<ContributorType> expandedContributors) {
-        return expandedContributors.stream()
-                   .filter(NviContributor.class::isInstance)
-                   .map(NviContributor.class::cast)
-                   .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
-                   .collect(Collectors.toSet());
+        var affiliatedOrganizations = expandedContributors.stream()
+                                          .filter(NviContributor.class::isInstance)
+                                          .map(NviContributor.class::cast)
+                                          .flatMap(contributor -> contributor.getOrganizationsPartOf(
+                                              approval.getInstitutionId()).stream())
+                                          .collect(Collectors.toCollection(HashSet::new));
+        affiliatedOrganizations.add(approval.getInstitutionId());
+        return affiliatedOrganizations;
     }
 
     private PublicationDetails expandPublicationDetails(JsonNode expandedResource, List<ContributorType> contributors) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -25,7 +25,6 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -132,18 +131,11 @@ public final class NviCandidateIndexDocumentGenerator {
 
     private static Set<URI> extractInvolvedOrganizations(Approval approval,
                                                          List<ContributorType> expandedContributors) {
-        var affiliatedOrganizations = expandedContributors.stream()
-                                          .filter(NviContributor.class::isInstance)
-                                          .map(NviContributor.class::cast)
-                                          .flatMap(contributor -> contributor.getOrganizationsPartOf(
-                                              approval.getInstitutionId()).stream())
-                                          .collect(Collectors.toCollection(HashSet::new));
-        addTopLevelAffiliations(affiliatedOrganizations, approval.getInstitutionId());
-        return affiliatedOrganizations;
-    }
-
-    private static void addTopLevelAffiliations(HashSet<URI> affiliatedOrganizations, URI institutionId) {
-        affiliatedOrganizations.add(institutionId);
+        return expandedContributors.stream()
+                   .filter(NviContributor.class::isInstance)
+                   .map(NviContributor.class::cast)
+                   .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
+                   .collect(Collectors.toSet());
     }
 
     private PublicationDetails expandPublicationDetails(JsonNode expandedResource, List<ContributorType> contributors) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -8,6 +8,7 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractAffiliations
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -205,6 +206,7 @@ public final class IndexDocumentTestUtils {
     private static NviOrganization generateTopLevelNviOrg(URI id) {
         return NviOrganization.builder()
                    .withId(id)
+                   .withPartOf(Collections.emptyList())
                    .build();
     }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -9,7 +9,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.net.URI;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -92,14 +91,11 @@ public final class IndexDocumentTestUtils {
 
     private static Set<URI> extractInvolvedOrganizations(Approval approval,
                                                          List<ContributorType> expandedContributors) {
-        var affiliatedOrganizations = expandedContributors.stream()
-                                          .filter(NviContributor.class::isInstance)
-                                          .map(NviContributor.class::cast)
-                                          .flatMap(contributor -> contributor.getOrganizationsPartOf(
-                                              approval.getInstitutionId()).stream())
-                                          .collect(Collectors.toCollection(HashSet::new));
-        affiliatedOrganizations.add(approval.getInstitutionId());
-        return affiliatedOrganizations;
+        return expandedContributors.stream()
+                   .filter(NviContributor.class::isInstance)
+                   .map(NviContributor.class::cast)
+                   .flatMap(contributor -> contributor.getOrganizationsPartOf(approval.getInstitutionId()).stream())
+                   .collect(Collectors.toSet());
     }
 
     private static ApprovalStatus getApprovalStatus(Approval approval) {


### PR DESCRIPTION
Jira task: NP-46965 _Nvi institution report aggregations missing affiliations to top level org_
Aggragations for institution status is made for all orgs in Index document -> approvals.involvedOrganizations.
Bug: approvals.involvedOrganizations was missing top level orgs when nvi creator was affiliated directly to top level org.

Changes:
- Add top level org affiliations in `involvedOrganizations`
