### PR TITLE
Np 47031 ViewingScopeValidator, userIsAllowedToAccessOneOf

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandler.java
@@ -134,7 +134,7 @@ public class SearchNviCandidatesHandler
 
     private boolean userIsNotAllowedToView(RequestInfo requestInfo, List<URI> requestedOrganizations)
         throws UnauthorizedException {
-        return !viewingScopeValidator.userIsAllowedToAccess(requestInfo.getUserName(), requestedOrganizations);
+        return !viewingScopeValidator.userIsAllowedToAccessAll(requestInfo.getUserName(), requestedOrganizations);
     }
 
     private List<URI> toOrganizationUris(List<String> affiliationIdentifiers) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FakeViewingScopeValidator.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FakeViewingScopeValidator.java
@@ -13,7 +13,12 @@ public class FakeViewingScopeValidator implements ViewingScopeValidator {
     }
 
     @Override
-    public boolean userIsAllowedToAccess(String userName, List<URI> requestedOrganizations) {
+    public boolean userIsAllowedToAccessAll(String userName, List<URI> organizations) {
+        return returnValue;
+    }
+
+    @Override
+    public boolean userIsAllowedToAccessOneOf(String userName, List<URI> organizations) {
         return returnValue;
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidator.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidator.java
@@ -5,5 +5,6 @@ import java.util.List;
 
 public interface ViewingScopeValidator {
 
-    boolean userIsAllowedToAccess(String userName, List<URI> requestedOrganizations);
+    boolean userIsAllowedToAccessAll(String userName, List<URI> organizations);
+    boolean userIsAllowedToAccessOneOf(String userName, List<URI> organizations);
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImpl.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImpl.java
@@ -38,7 +38,9 @@ public class ViewingScopeValidatorImpl implements ViewingScopeValidator {
 
     @Override
     public boolean userIsAllowedToAccessOneOf(String userName, List<URI> organizations) {
-        return false;
+        var viewingScope = fetchViewingScope(userName);
+        var allowed = getAllowedUnits(viewingScope);
+        return organizations.stream().anyMatch(allowed::contains);
     }
 
     private static Set<URI> difference(Set<URI> allowed, List<URI> requested) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImpl.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImpl.java
@@ -29,11 +29,16 @@ public class ViewingScopeValidatorImpl implements ViewingScopeValidator {
     }
 
     @Override
-    public boolean userIsAllowedToAccess(String userName, List<URI> requestedOrganizations) {
+    public boolean userIsAllowedToAccessAll(String userName, List<URI> organizations) {
         var viewingScope = fetchViewingScope(userName);
         var allowed = getAllowedUnits(viewingScope);
-        var illegal = difference(allowed, requestedOrganizations);
+        var illegal = difference(allowed, organizations);
         return illegal.isEmpty();
+    }
+
+    @Override
+    public boolean userIsAllowedToAccessOneOf(String userName, List<URI> organizations) {
+        return false;
     }
 
     private static Set<URI> difference(Set<URI> allowed, List<URI> requested) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImpl.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImpl.java
@@ -31,9 +31,7 @@ public class ViewingScopeValidatorImpl implements ViewingScopeValidator {
     @Override
     public boolean userIsAllowedToAccessAll(String userName, List<URI> organizations) {
         var viewingScope = fetchViewingScope(userName);
-        var allowed = getAllowedUnits(viewingScope);
-        var illegal = difference(allowed, organizations);
-        return illegal.isEmpty();
+        return getAllowedUnits(viewingScope).containsAll(organizations);
     }
 
     @Override
@@ -41,12 +39,6 @@ public class ViewingScopeValidatorImpl implements ViewingScopeValidator {
         var viewingScope = fetchViewingScope(userName);
         var allowed = getAllowedUnits(viewingScope);
         return organizations.stream().anyMatch(allowed::contains);
-    }
-
-    private static Set<URI> difference(Set<URI> allowed, List<URI> requested) {
-        var difference = new HashSet<>(requested);
-        difference.removeAll(allowed);
-        return difference;
     }
 
     private static Stream<String> concat(URI topLevelOrg, Stream<String> stringStream) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImplTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImplTest.java
@@ -76,7 +76,7 @@ class ViewingScopeValidatorImplTest {
         when(identityServiceClient.getUser(SOME_USERNAME)).thenReturn(userWithViewingScope(org));
         when(organizationRetriever.fetchOrganization(org)).thenReturn(createOrgWithSubOrg(org, subOrg));
         var someOtherOrg = randomUri();
-        assertTrue(viewingScopeValidator.userIsAllowedToAccessAll(SOME_USERNAME, List.of(subOrg, someOtherOrg)));
+        assertTrue(viewingScopeValidator.userIsAllowedToAccessOneOf(SOME_USERNAME, List.of(subOrg, someOtherOrg)));
     }
 
     private static Organization createOrg(URI orgId) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImplTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImplTest.java
@@ -70,8 +70,13 @@ class ViewingScopeValidatorImplTest {
     }
 
     @Test
-    void shouldReturnTrueWhenUserIsAllowedToAccessOneOfOrgsSubOrg() {
-
+    void shouldReturnTrueWhenUserIsAllowedToAccessOneOfOrgsSubOrg() throws NotFoundException {
+        var org = URI.create("https://www.example.com/org");
+        var subOrg = URI.create("https://www.example.com/subOrg");
+        when(identityServiceClient.getUser(SOME_USERNAME)).thenReturn(userWithViewingScope(org));
+        when(organizationRetriever.fetchOrganization(org)).thenReturn(createOrgWithSubOrg(org, subOrg));
+        var someOtherOrg = randomUri();
+        assertTrue(viewingScopeValidator.userIsAllowedToAccessAll(SOME_USERNAME, List.of(subOrg, someOtherOrg)));
     }
 
     private static Organization createOrg(URI orgId) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImplTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/validator/ViewingScopeValidatorImplTest.java
@@ -35,29 +35,43 @@ class ViewingScopeValidatorImplTest {
     }
 
     @Test
-    void shouldReturnFalseIfUserIsNotAllowedToAccessRequestedOrgs() throws NotFoundException {
+    void shouldReturnFalseWhenUserIsNotAllowedToAccessAllOrgs() throws NotFoundException {
         var allowedOrg = randomUri();
         when(identityServiceClient.getUser(SOME_USERNAME)).thenReturn(userWithViewingScope(allowedOrg));
         when(organizationRetriever.fetchOrganization(allowedOrg)).thenReturn(createOrg(allowedOrg));
         var someOtherOrg = randomUri();
-        assertFalse(viewingScopeValidator.userIsAllowedToAccess(SOME_USERNAME, List.of(someOtherOrg)));
+        assertFalse(viewingScopeValidator.userIsAllowedToAccessAll(SOME_USERNAME, List.of(allowedOrg, someOtherOrg)));
     }
 
     @Test
-    void shouldReturnTrueIfUserIsAllowedToAccessRequestedOrgs() throws NotFoundException {
+    void shouldReturnTrueWhenUserIsAllowedToAccessAllOrgs() throws NotFoundException {
         var allowedOrg = randomUri();
         when(identityServiceClient.getUser(SOME_USERNAME)).thenReturn(userWithViewingScope(allowedOrg));
         when(organizationRetriever.fetchOrganization(allowedOrg)).thenReturn(createOrg(allowedOrg));
-        assertTrue(viewingScopeValidator.userIsAllowedToAccess(SOME_USERNAME, List.of(allowedOrg)));
+        assertTrue(viewingScopeValidator.userIsAllowedToAccessAll(SOME_USERNAME, List.of(allowedOrg)));
     }
 
     @Test
-    void shouldReturnTrueIfUserIsAllowedToAccessRequestedOrgsSubOrg() throws NotFoundException {
+    void shouldReturnTrueWhenUserIsAllowedToAccessOrgsSubOrg() throws NotFoundException {
         var org = URI.create("https://www.example.com/org");
         var subOrg = URI.create("https://www.example.com/subOrg");
         when(identityServiceClient.getUser(SOME_USERNAME)).thenReturn(userWithViewingScope(org));
         when(organizationRetriever.fetchOrganization(org)).thenReturn(createOrgWithSubOrg(org, subOrg));
-        assertTrue(viewingScopeValidator.userIsAllowedToAccess(SOME_USERNAME, List.of(subOrg)));
+        assertTrue(viewingScopeValidator.userIsAllowedToAccessAll(SOME_USERNAME, List.of(subOrg)));
+    }
+
+    @Test
+    void shouldReturnTrueWhenUserIsAllowedToAccessOneOfOrgs() throws NotFoundException {
+        var allowedOrg = randomUri();
+        when(identityServiceClient.getUser(SOME_USERNAME)).thenReturn(userWithViewingScope(allowedOrg));
+        when(organizationRetriever.fetchOrganization(allowedOrg)).thenReturn(createOrg(allowedOrg));
+        var someOtherOrg = randomUri();
+        assertTrue(viewingScopeValidator.userIsAllowedToAccessOneOf(SOME_USERNAME, List.of(allowedOrg, someOtherOrg)));
+    }
+
+    @Test
+    void shouldReturnTrueWhenUserIsAllowedToAccessOneOfOrgsSubOrg() {
+
     }
 
     private static Organization createOrg(URI orgId) {


### PR DESCRIPTION
Add new method `userIsAllowedToAccessOneOf` in `ViewingScopeValidator`.
A curator is allowed to view a candidate where one of the contributors affiliations is within the curators viewing scope.

This will allow following change in next PR:
```
@Override
protected void validateRequest(Void unused, RequestInfo requestInfo, Context context) throws ApiGatewayException {
    var candidateIdentifier = UUID.fromString(requestInfo.getPathParameter(CANDIDATE_IDENTIFIER));
    var organizations = Candidate.fetch(() -> candidateIdentifier, candidateRepository, periodRepository)
                            .getNviCreatorAffiliations();
    if (!viewingscopeValidator.userIsAllowedToAccessOneOf(requestInfo.getUserName(), organizations)) {
        throw new UnauthorizedException();
    }
}
```