### PR TITLE
Np 47031 Rest handlers, validate viewing scope

### DIFF
--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -45,6 +45,7 @@ import no.sikt.nva.nvi.index.model.document.PublicationDate;
 import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.search.OrderByFields;
+import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
 import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.commons.pagination.PaginatedSearchResult;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/ViewingScopeHandler.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/ViewingScopeHandler.java
@@ -1,0 +1,18 @@
+package no.sikt.nva.nvi.common;
+
+import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.model.Username;
+import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
+
+public interface ViewingScopeHandler {
+
+    default Candidate validateViewingScope(ViewingScopeValidator validator, Username username, Candidate candidate)
+        throws UnauthorizedException {
+        var organizations = candidate.getNviCreatorAffiliations();
+        if (!validator.userIsAllowedToAccessOneOf(username.value(), organizations)) {
+            throw new UnauthorizedException();
+        }
+        return candidate;
+    }
+}

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -329,6 +329,10 @@ public final class Candidate {
         return publicationDetails.publicationId();
     }
 
+    public List<URI> getNviCreatorAffiliations() {
+        return publicationDetails.getNviCreatorAffiliations();
+    }
+
     private static boolean isNotExistingCandidate(UpsertCandidateRequest request, CandidateRepository repository) {
         return !isExistingCandidate(request.publicationId(), repository);
     }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
@@ -15,6 +15,13 @@ public record PublicationDetails(URI publicationId,
                                  URI publicationChannelId,
                                  String level) {
 
+    public List<URI> getNviCreatorAffiliations() {
+        return creators.stream()
+                   .map(Creator::affiliations)
+                   .flatMap(List::stream)
+                   .toList();
+    }
+
     public record PublicationDate(String year, String month, String day) {
 
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -540,6 +540,18 @@ class CandidateTest extends LocalDynamoTest {
         assertThat(id, is(not(nullValue())));
     }
 
+    @Test
+    void shouldReturnCreatorAffiliations() {
+        var creator1affiliation = randomUri();
+        var creator2affiliation = randomUri();
+        var creator1 = DbCreator.builder().creatorId(randomUri()).affiliations(List.of(creator1affiliation)).build();
+        var creator2 = DbCreator.builder().creatorId(randomUri()).affiliations(List.of(creator2affiliation)).build();
+        var dao = candidateRepository.create(randomCandidate().copy().creators(List.of(creator1, creator2)).build(),
+                                             List.of(randomApproval()));
+        var candidate = Candidate.fetch(dao::identifier, candidateRepository, periodRepository);
+        assertEquals(List.of(creator1affiliation, creator2affiliation), candidate.getNviCreatorAffiliations());
+    }
+
     private static InstitutionPoints createInstitutionPoints(URI institutionId, BigDecimal institutionPoints,
                                                              URI creatorId) {
         return new InstitutionPoints(institutionId, institutionPoints,

--- a/nvi-rest/build.gradle
+++ b/nvi-rest/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     implementation libs.nva.commons.apigateway
     implementation libs.nva.commons.core
     implementation libs.nva.json
+    implementation libs.nva.commons.clients
     implementation libs.jackson.databind
     implementation libs.nva.commons.auth
     implementation libs.jackson.databind

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/ViewingScopeHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/ViewingScopeHandler.java
@@ -1,11 +1,22 @@
 package no.sikt.nva.nvi.rest;
 
+import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.Username;
 import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
+import no.sikt.nva.nvi.common.validator.ViewingScopeValidatorImpl;
+import no.unit.nva.auth.uriretriever.UriRetriever;
+import no.unit.nva.clients.IdentityServiceClient;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
+import nva.commons.core.JacocoGenerated;
 
 public interface ViewingScopeHandler {
+
+    @JacocoGenerated
+    static ViewingScopeValidatorImpl defaultViewingScopeValidator() {
+        return new ViewingScopeValidatorImpl(IdentityServiceClient.prepare(),
+                                             new OrganizationRetriever(new UriRetriever()));
+    }
 
     default Candidate validateViewingScope(ViewingScopeValidator validator, Username username, Candidate candidate)
         throws UnauthorizedException {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/ViewingScopeHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/ViewingScopeHandler.java
@@ -1,4 +1,4 @@
-package no.sikt.nva.nvi.common;
+package no.sikt.nva.nvi.rest;
 
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.Username;

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
@@ -1,10 +1,13 @@
 package no.sikt.nva.nvi.rest.create;
 
 import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.utils.RequestUtil.hasAccessRight;
 import static no.sikt.nva.nvi.rest.fetch.FetchNviCandidateHandler.CANDIDATE_IDENTIFIER;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -22,6 +25,7 @@ import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
+import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.JacocoGenerated;
 
 public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, CandidateDto> {
@@ -48,7 +52,8 @@ public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, Candida
     @Override
     protected void validateRequest(NviNoteRequest input, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
-        RequestUtil.hasAccessRight(requestInfo, AccessRight.MANAGE_NVI_CANDIDATES);
+        validateViewingScope(requestInfo);
+        hasAccessRight(requestInfo, AccessRight.MANAGE_NVI_CANDIDATES);
         validate(input);
     }
 
@@ -73,6 +78,19 @@ public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, Candida
 
     private static ViewingScopeValidatorImpl defaultViewingScopeValidator() {
         return null;
+    }
+
+    private void validateViewingScope(RequestInfo requestInfo) throws UnauthorizedException {
+        var candidateIdentifier = UUID.fromString(requestInfo.getPathParameter(CANDIDATE_IDENTIFIER));
+        var organizations = Candidate.fetch(() -> candidateIdentifier, candidateRepository, periodRepository)
+                                .getNviCreatorAffiliations();
+        if (isNotAllowedToAccessOneOfOrganizations(requestInfo.getUserName(), organizations)) {
+            throw new UnauthorizedException();
+        }
+    }
+
+    private boolean isNotAllowedToAccessOneOfOrganizations(String userName, List<URI> organizations) {
+        return !viewingScopeValidator.userIsAllowedToAccessOneOf(userName, organizations);
     }
 
     private Candidate checkIfApplicable(Candidate candidate) {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
@@ -10,6 +10,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.exceptions.NotApplicableException;
@@ -20,6 +21,8 @@ import no.sikt.nva.nvi.common.utils.ExceptionMapper;
 import no.sikt.nva.nvi.common.utils.RequestUtil;
 import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
 import no.sikt.nva.nvi.common.validator.ViewingScopeValidatorImpl;
+import no.unit.nva.auth.uriretriever.UriRetriever;
+import no.unit.nva.clients.IdentityServiceClient;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -76,8 +79,10 @@ public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, Candida
         return HttpURLConnection.HTTP_OK;
     }
 
+    @JacocoGenerated
     private static ViewingScopeValidatorImpl defaultViewingScopeValidator() {
-        return null;
+        return new ViewingScopeValidatorImpl(IdentityServiceClient.prepare(),
+                                             new OrganizationRetriever(new UriRetriever()));
     }
 
     private void validateViewingScope(RequestInfo requestInfo) throws UnauthorizedException {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
@@ -15,6 +15,8 @@ import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.utils.ExceptionMapper;
 import no.sikt.nva.nvi.common.utils.RequestUtil;
+import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
+import no.sikt.nva.nvi.common.validator.ViewingScopeValidatorImpl;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -27,16 +29,20 @@ public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, Candida
     public static final String INVALID_REQUEST_ERROR = "Request body must contain text field.";
     private final CandidateRepository candidateRepository;
     private final PeriodRepository periodRepository;
+    private final ViewingScopeValidator viewingScopeValidator;
 
     @JacocoGenerated
     public CreateNoteHandler() {
-        this(new CandidateRepository(defaultDynamoClient()), new PeriodRepository(defaultDynamoClient()));
+        this(new CandidateRepository(defaultDynamoClient()), new PeriodRepository(defaultDynamoClient()),
+             defaultViewingScopeValidator());
     }
 
-    public CreateNoteHandler(CandidateRepository candidateRepository, PeriodRepository periodRepository) {
+    public CreateNoteHandler(CandidateRepository candidateRepository, PeriodRepository periodRepository,
+                             ViewingScopeValidator viewingScopeValidator) {
         super(NviNoteRequest.class);
         this.candidateRepository = candidateRepository;
         this.periodRepository = periodRepository;
+        this.viewingScopeValidator = viewingScopeValidator;
     }
 
     @Override
@@ -63,6 +69,10 @@ public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, Candida
     @Override
     protected Integer getSuccessStatusCode(NviNoteRequest input, CandidateDto output) {
         return HttpURLConnection.HTTP_OK;
+    }
+
+    private static ViewingScopeValidatorImpl defaultViewingScopeValidator() {
+        return null;
     }
 
     private Candidate checkIfApplicable(Candidate candidate) {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
@@ -8,7 +8,7 @@ import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
 import java.util.Objects;
 import java.util.UUID;
-import no.sikt.nva.nvi.common.ViewingScopeHandler;
+import no.sikt.nva.nvi.rest.ViewingScopeHandler;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/CreateNoteHandler.java
@@ -8,8 +8,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
 import java.util.Objects;
 import java.util.UUID;
-import no.sikt.nva.nvi.rest.ViewingScopeHandler;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.exceptions.NotApplicableException;
@@ -19,9 +17,7 @@ import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.utils.ExceptionMapper;
 import no.sikt.nva.nvi.common.utils.RequestUtil;
 import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
-import no.sikt.nva.nvi.common.validator.ViewingScopeValidatorImpl;
-import no.unit.nva.auth.uriretriever.UriRetriever;
-import no.unit.nva.clients.IdentityServiceClient;
+import no.sikt.nva.nvi.rest.ViewingScopeHandler;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -39,7 +35,7 @@ public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, Candida
     @JacocoGenerated
     public CreateNoteHandler() {
         this(new CandidateRepository(defaultDynamoClient()), new PeriodRepository(defaultDynamoClient()),
-             defaultViewingScopeValidator());
+             ViewingScopeHandler.defaultViewingScopeValidator());
     }
 
     public CreateNoteHandler(CandidateRepository candidateRepository, PeriodRepository periodRepository,
@@ -75,12 +71,6 @@ public class CreateNoteHandler extends ApiGatewayHandler<NviNoteRequest, Candida
     @Override
     protected Integer getSuccessStatusCode(NviNoteRequest input, CandidateDto output) {
         return HttpURLConnection.HTTP_OK;
-    }
-
-    @JacocoGenerated
-    private static ViewingScopeValidatorImpl defaultViewingScopeValidator() {
-        return new ViewingScopeValidatorImpl(IdentityServiceClient.prepare(),
-                                             new OrganizationRetriever(new UriRetriever()));
     }
 
     private Candidate checkIfApplicable(Candidate candidate) {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/NviNoteRequest.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/create/NviNoteRequest.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.rest.create;
 
-public record NviNoteRequest(String text) {
+import no.unit.nva.commons.json.JsonSerializable;
+
+public record NviNoteRequest(String text) implements JsonSerializable {
 
 }

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandler.java
@@ -5,8 +5,6 @@ import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.UUID;
-import no.sikt.nva.nvi.rest.ViewingScopeHandler;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
@@ -15,9 +13,7 @@ import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.utils.ExceptionMapper;
 import no.sikt.nva.nvi.common.utils.RequestUtil;
 import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
-import no.sikt.nva.nvi.common.validator.ViewingScopeValidatorImpl;
-import no.unit.nva.auth.uriretriever.UriRetriever;
-import no.unit.nva.clients.IdentityServiceClient;
+import no.sikt.nva.nvi.rest.ViewingScopeHandler;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -35,7 +31,7 @@ public class FetchNviCandidateHandler extends ApiGatewayHandler<Void, CandidateD
     @JacocoGenerated
     public FetchNviCandidateHandler() {
         this(new CandidateRepository(defaultDynamoClient()), new PeriodRepository(defaultDynamoClient()),
-             defaultViewingScopeValidator());
+             ViewingScopeHandler.defaultViewingScopeValidator());
     }
 
     public FetchNviCandidateHandler(CandidateRepository candidateRepository, PeriodRepository periodRepository,
@@ -81,12 +77,6 @@ public class FetchNviCandidateHandler extends ApiGatewayHandler<Void, CandidateD
 
     private static boolean isNviCurator(RequestInfo requestInfo) {
         return requestInfo.userIsAuthorized(AccessRight.MANAGE_NVI_CANDIDATES);
-    }
-
-    @JacocoGenerated
-    private static ViewingScopeValidatorImpl defaultViewingScopeValidator() {
-        return new ViewingScopeValidatorImpl(IdentityServiceClient.prepare(),
-                                             new OrganizationRetriever(new UriRetriever()));
     }
 
     private Candidate checkIfApplicable(Candidate candidate) {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandler.java
@@ -4,14 +4,18 @@ import static java.net.HttpURLConnection.HTTP_OK;
 import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
-import java.net.URI;
 import java.util.UUID;
+import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.exception.CandidateNotFoundException;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.utils.ExceptionMapper;
+import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
+import no.sikt.nva.nvi.common.validator.ViewingScopeValidatorImpl;
+import no.unit.nva.auth.uriretriever.UriRetriever;
+import no.unit.nva.clients.IdentityServiceClient;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -24,16 +28,20 @@ public class FetchNviCandidateHandler extends ApiGatewayHandler<Void, CandidateD
     public static final String CANDIDATE_IDENTIFIER = "candidateIdentifier";
     private final CandidateRepository candidateRepository;
     private final PeriodRepository periodRepository;
+    private final ViewingScopeValidator viewingScopeValidator;
 
     @JacocoGenerated
     public FetchNviCandidateHandler() {
-        this(new CandidateRepository(defaultDynamoClient()), new PeriodRepository(defaultDynamoClient()));
+        this(new CandidateRepository(defaultDynamoClient()), new PeriodRepository(defaultDynamoClient()),
+             defaultViewingScopeValidator());
     }
 
-    public FetchNviCandidateHandler(CandidateRepository candidateRepository, PeriodRepository periodRepository) {
+    public FetchNviCandidateHandler(CandidateRepository candidateRepository, PeriodRepository periodRepository,
+                                    ViewingScopeValidator viewingScopeValidator) {
         super(Void.class);
         this.candidateRepository = candidateRepository;
         this.periodRepository = periodRepository;
+        this.viewingScopeValidator = viewingScopeValidator;
     }
 
     @Override
@@ -44,11 +52,10 @@ public class FetchNviCandidateHandler extends ApiGatewayHandler<Void, CandidateD
     @Override
     protected CandidateDto processInput(Void input, RequestInfo requestInfo, Context context)
         throws ApiGatewayException {
-        var topLevelCristinOrg = requestInfo.getTopLevelOrgCristinId().orElseThrow();
         return attempt(() -> requestInfo.getPathParameter(CANDIDATE_IDENTIFIER)).map(UUID::fromString)
                    .map(identifier -> Candidate.fetch(() -> identifier, candidateRepository, periodRepository))
                    .map(this::checkIfApplicable)
-                   .map(candidate -> validateTopLevelOrg(candidate, topLevelCristinOrg))
+                   .map(candidate -> validateViewingScope(candidate, requestInfo))
                    .map(Candidate::toDto)
                    .orElseThrow(ExceptionMapper::map);
     }
@@ -73,16 +80,21 @@ public class FetchNviCandidateHandler extends ApiGatewayHandler<Void, CandidateD
         return requestInfo.userIsAuthorized(AccessRight.MANAGE_NVI_CANDIDATES);
     }
 
-    private static Candidate validateTopLevelOrg(Candidate candidate, URI topLevelOrgCristinId)
-        throws UnauthorizedException {
-        if (doesNotContainApprovalForInstitution(candidate, topLevelOrgCristinId)) {
+    @JacocoGenerated
+    private static ViewingScopeValidatorImpl defaultViewingScopeValidator() {
+        return new ViewingScopeValidatorImpl(IdentityServiceClient.prepare(),
+                                             new OrganizationRetriever(new UriRetriever()));
+    }
+
+    private Candidate validateViewingScope(Candidate candidate, RequestInfo requestInfo) throws UnauthorizedException {
+        if (isNotAllowedToAccessOneOfOrganizations(requestInfo.getUserName(), candidate)) {
             throw new UnauthorizedException();
         }
         return candidate;
     }
 
-    private static boolean doesNotContainApprovalForInstitution(Candidate candidate, URI topLevelOrgCristinId) {
-        return candidate.getApprovals().keySet().stream().noneMatch(uri -> uri.equals(topLevelOrgCristinId));
+    private boolean isNotAllowedToAccessOneOfOrganizations(String userName, Candidate candidate) {
+        return !viewingScopeValidator.userIsAllowedToAccessOneOf(userName, candidate.getNviCreatorAffiliations());
     }
 
     private Candidate checkIfApplicable(Candidate candidate) {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandler.java
@@ -5,7 +5,7 @@ import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.util.UUID;
-import no.sikt.nva.nvi.common.ViewingScopeHandler;
+import no.sikt.nva.nvi.rest.ViewingScopeHandler;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandler.java
@@ -5,7 +5,7 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
 import java.util.UUID;
-import no.sikt.nva.nvi.common.ViewingScopeHandler;
+import no.sikt.nva.nvi.rest.ViewingScopeHandler;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.DynamoRepository;

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandler.java
@@ -5,8 +5,6 @@ import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
 import java.util.UUID;
-import no.sikt.nva.nvi.rest.ViewingScopeHandler;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.DynamoRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
@@ -16,9 +14,7 @@ import no.sikt.nva.nvi.common.service.requests.DeleteNoteRequest;
 import no.sikt.nva.nvi.common.utils.ExceptionMapper;
 import no.sikt.nva.nvi.common.utils.RequestUtil;
 import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
-import no.sikt.nva.nvi.common.validator.ViewingScopeValidatorImpl;
-import no.unit.nva.auth.uriretriever.UriRetriever;
-import no.unit.nva.clients.IdentityServiceClient;
+import no.sikt.nva.nvi.rest.ViewingScopeHandler;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -35,7 +31,8 @@ public class RemoveNoteHandler extends ApiGatewayHandler<Void, CandidateDto> imp
     @JacocoGenerated
     public RemoveNoteHandler() {
         this(new CandidateRepository(DynamoRepository.defaultDynamoClient()),
-             new PeriodRepository(DynamoRepository.defaultDynamoClient()), defaultViewingScopeValidator());
+             new PeriodRepository(DynamoRepository.defaultDynamoClient()),
+             ViewingScopeHandler.defaultViewingScopeValidator());
     }
 
     public RemoveNoteHandler(CandidateRepository candidateRepository, PeriodRepository periodRepository,
@@ -67,11 +64,5 @@ public class RemoveNoteHandler extends ApiGatewayHandler<Void, CandidateDto> imp
     @Override
     protected Integer getSuccessStatusCode(Void input, CandidateDto output) {
         return HttpURLConnection.HTTP_OK;
-    }
-
-    @JacocoGenerated
-    private static ViewingScopeValidatorImpl defaultViewingScopeValidator() {
-        return new ViewingScopeValidatorImpl(IdentityServiceClient.prepare(),
-                                             new OrganizationRetriever(new UriRetriever()));
     }
 }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -64,9 +64,7 @@ public class CreateNoteHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnUnauthorizedWhenMissingAccessRights() throws IOException {
-        var candidate = Candidate.upsert(createUpsertCandidateRequest(randomUri()), candidateRepository,
-                                         periodRepository).orElseThrow();
-        handler.handleRequest(requestWithoutAccessRights(candidate.getIdentifier(), randomNote()), output, context);
+        handler.handleRequest(requestWithoutAccessRights(UUID.randomUUID(), randomNote()), output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -86,11 +84,9 @@ public class CreateNoteHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnBadRequestIfCreateNoteRequestIsInvalid() throws IOException {
-        var candidate = Candidate.upsert(createUpsertCandidateRequest(randomUri()), candidateRepository,
-                                         periodRepository).orElseThrow();
         var invalidRequestBody = JsonUtils.dtoObjectMapper.writeValueAsString(
             Map.of("someInvalidInputField", randomString()));
-        var request = createRequest(candidate.getIdentifier(), invalidRequestBody, randomString());
+        var request = createRequest(UUID.randomUUID(), invalidRequestBody, randomString());
 
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -72,9 +72,11 @@ public class CreateNoteHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnUnauthorizedWhenCandidateIsNotInUsersViewingScope() throws IOException {
+        var candidate = Candidate.upsert(createUpsertCandidateRequest(randomUri()), candidateRepository,
+                                         periodRepository).orElseThrow();
+        var request = createRequest(candidate.getIdentifier(), new NviNoteRequest("The note"), randomString());
         viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(false);
         handler = new CreateNoteHandler(candidateRepository, periodRepository, viewingScopeValidatorReturningFalse);
-        var request = createRequest(UUID.randomUUID(), randomString(), randomString());
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
         assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -128,7 +130,7 @@ public class CreateNoteHandlerTest extends LocalDynamoTest {
         var nonCandidate = Candidate.updateNonCandidate(
             createUpsertNonCandidateRequest(candidateBO.getPublicationId()),
             candidateRepository).orElseThrow();
-        var request = createRequest(nonCandidate.getIdentifier(), randomNote(), randomString());
+        var request = createRequest(nonCandidate.getIdentifier(), randomNote().toJsonString(), randomString());
         handler.handleRequest(request, output, context);
         var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/FakeViewingScopeValidator.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/FakeViewingScopeValidator.java
@@ -1,4 +1,4 @@
-package no.sikt.nva.nvi.index.apigateway;
+package no.sikt.nva.nvi.test;
 
 import java.net.URI;
 import java.util.List;


### PR DESCRIPTION
Jira task: NP-47031 Ensure curator only see NVI candidates for their viewingScope.
Validate viewing scope in following handlers:
- `FetchNviCandidateHandler`
- `CreateNoteHandler`
- `RemoveNoteHandler`
- `UpsertAssigneeHandler`
- `UpdateNviCandidateStatusHandler`