### PR TITLE
not creating approval for institution missing identifier

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
@@ -121,7 +121,9 @@ public final class CristinMapper {
     }
 
     public List<DbApprovalStatus> toApprovals(CristinNviReport cristinNviReport) {
-        return cristinNviReport.cristinLocales().stream().map(CristinMapper::toApproval).toList();
+        return cristinNviReport.cristinLocales().stream()
+                   .filter(cristinLocale -> nonNull(cristinLocale.getInstitutionIdentifier()))
+                   .map(CristinMapper::toApproval).toList();
     }
 
     private static BigDecimal sumPoints(List<DbInstitutionPoints> points) {
@@ -307,7 +309,11 @@ public final class CristinMapper {
     }
 
     private static boolean hasSameInstitutionIdentifier(ScientificPerson scientificPerson, CristinLocale cristinLocale) {
-        return cristinLocale.getInstitutionIdentifier().equals(scientificPerson.getInstitutionIdentifier());
+        if (nonNull(cristinLocale.getInstitutionIdentifier())) {
+            return cristinLocale.getInstitutionIdentifier().equals(scientificPerson.getInstitutionIdentifier());
+        } else {
+            return false;
+        }
     }
 
     private URI extractInstitutionIdentifierForTransferredInstitution(ScientificPerson scientificPerson,

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinMapperTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinMapperTest.java
@@ -459,6 +459,17 @@ class CristinMapperTest {
         assertThat(dbCandidate.points(), is(emptyIterable()));
     }
 
+    @Test
+    void shouldNotCreateApprovalWhenApprovalIsMissingInstitutionIdentifier() {
+        var creator = scientificPersonAtInstitutionWithPoints(INSTITUTION_IDENTIFIER, POINTS_PER_CONTRIBUTOR);
+        var scientificResource = scientificResourceWithCreators(List.of(creator));
+        var cristinLocale = cristinLocaleWithInstitutionIdentifier(null);
+        var report = cristinReportFromCristinLocalesAndScientificResource(cristinLocale, scientificResource);
+        var approvals = cristinMapper.toApprovals(report.build());
+
+        assertThat(approvals, is(emptyIterable()));
+    }
+
     private static CristinNviReport nviReportWithInstanceTypeAndReference(String instanceType, String reference) {
         var institutionIdentifier = randomString();
         var creators = List.of(scientificPersonAtInstitutionWithPoints(institutionIdentifier, POINTS_PER_CONTRIBUTOR),


### PR DESCRIPTION
Some approvals for nvi candidates are missing institution identifier, ignoring these approvals when creating candidate:

```
{
  "eierkode": "KREFTREG",
  "brukernavn_kontrollert": "sos",
  "dato_kontrollert": "2015-10-05",
  "status_kontrollert": "J"
}
```