### PR TITLE
Index document, fetch labels from Cristin if extracting labels from index document fails

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -154,10 +154,10 @@ public final class NviCandidateIndexDocumentGenerator {
                    .filter(organization -> isOrgWithInstitutionId(organization, approval.getInstitutionId()))
                    .findFirst()
                    .map(org -> org.at(JSON_PTR_LABELS))
-                   .flatMap(NviCandidateIndexDocumentGenerator::getStringStringMap);
+                   .flatMap(NviCandidateIndexDocumentGenerator::readAsStringMap);
     }
 
-    private static Optional<Map<String, String>> getStringStringMap(JsonNode node) {
+    private static Optional<Map<String, String>> readAsStringMap(JsonNode node) {
         return attempt(() -> dtoObjectMapper.readValue(node.toString(), TYPE_REF)).toOptional();
     }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
@@ -34,6 +34,8 @@ public final class JsonPointers {
     public static final String JSON_PTR_NAME = "/name";
     public static final String JSON_PTR_ORCID = "/orcid";
     public static final String JSON_PTR_BODY = "/body";
+    public static final String JSON_PTR_TOP_LEVEL_ORGANIZATIONS = "/topLevelOrganizations";
+    public static final String JSON_PTR_LABELS = "/labels";
 
     private JsonPointers() {
     }


### PR DESCRIPTION
Root cause fix: https://github.com/BIBSYSDEV/nva-publication-api/pull/1753

But to make NVI indexing more robust, fetch labels from Cristin if extracting labels from index document fails