### PR TITLE
Np 46988 QueuePersistedResourcesHandler, filter out tickets and other types

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandler.java
@@ -17,9 +17,9 @@ import org.slf4j.LoggerFactory;
 
 public class QueuePersistedResourceHandler extends DestinationsEventBridgeEventHandler<EventReference, Void> {
 
-    public static final String PERSISTED_RESOURCES_PUBLICATION_FOLDER = "resources";
     private static final Logger LOGGER = LoggerFactory.getLogger(QueuePersistedResourceHandler.class);
     private static final String QUEUE_PERSISTED_RESOURCE_QUEUE_URL = "PERSISTED_RESOURCE_QUEUE_URL";
+    private static final String PERSISTED_RESOURCES_PUBLICATION_FOLDER = "resources";
     private static final String ERROR_MSG = "Invalid EventReference, missing uri: %s";
     private final QueueClient queueClient;
     private final String queueUrl;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.events;
 
 import static no.sikt.nva.nvi.events.evaluator.TestUtils.createS3Event;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
-import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +17,8 @@ import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class QueuePersistedResourceHandlerTest {
 
@@ -43,10 +44,12 @@ public class QueuePersistedResourceHandlerTest {
         assertThat(appender.getMessages(), containsString("Invalid EventReference, missing uri"));
     }
 
-    @Test
-    void shouldNotQueueResourcesThatAreNotPublications() throws IOException {
-        var invalidEvent = createS3Event(URI.create("s3://persisted-resources-884807050265/tickets/123.gz"));
-        handler.handleRequest(invalidEvent, output, context);
+    @ParameterizedTest
+    @ValueSource(strings = {"s3://persisted-resources-884807050265/tickets/123.gz",
+        "https://example.com/someOtherThing/123"})
+    void shouldNotQueueResourcesThatAreNotPublications(String uri) throws IOException {
+        var ticketEvent = createS3Event(URI.create(uri));
+        handler.handleRequest(ticketEvent, output, context);
         var sentMessages = sqsClient.getSentMessages();
         assertEquals(0, sentMessages.size());
     }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
@@ -11,8 +11,9 @@ import static org.mockito.Mockito.mock;
 import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import no.sikt.nva.nvi.test.FakeSqsClient;
+import java.net.URI;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
+import no.sikt.nva.nvi.test.FakeSqsClient;
 import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -43,8 +44,16 @@ public class QueuePersistedResourceHandlerTest {
     }
 
     @Test
+    void shouldNotQueueResourcesThatAreNotPublications() throws IOException {
+        var invalidEvent = createS3Event(URI.create("s3://persisted-resources-884807050265/tickets/123.gz"));
+        handler.handleRequest(invalidEvent, output, context);
+        var sentMessages = sqsClient.getSentMessages();
+        assertEquals(0, sentMessages.size());
+    }
+
+    @Test
     void shouldQueuePersistedResourceToEvaluatePublicationQueueWhenValidEventReferenceReceived() throws IOException {
-        var fileUri = randomUri();
+        var fileUri = URI.create("s3://persisted-resources-884807050265/resources/123.gz");
         var event = createS3Event(fileUri);
         handler.handleRequest(event, output, context);
         var sentMessages = sqsClient.getSentMessages();


### PR DESCRIPTION
Noticed that `EvaluateNviCandidateHandler` was failing in cases where it was trying to evaluate if tickets where nvi candidates

Issue: Today, `QueuePersistedResourcesHandler` queues all resources published on topic `PublicationService.ExpandedEntry.Persisted` for evaluation, including tickets
Fix: Only queue publications