### PR TITLE
Np 47106 Search, Exclude disputes in status aggregations and filters

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -1,16 +1,12 @@
 package no.sikt.nva.nvi.index.query;
 
 import static java.util.Objects.isNull;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.*;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.PENDING;
-import static no.sikt.nva.nvi.index.utils.AggregationFunctions.fieldValueQuery;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.filterAggregation;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.joinWithDelimiter;
-import static no.sikt.nva.nvi.index.utils.AggregationFunctions.mustMatch;
-import static no.sikt.nva.nvi.index.utils.AggregationFunctions.mustNotMatch;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.nestedAggregation;
-import static no.sikt.nva.nvi.index.utils.AggregationFunctions.nestedQuery;
-import static no.sikt.nva.nvi.index.utils.AggregationFunctions.rangeFromQuery;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.sumAggregation;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.termsAggregation;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVALS;
@@ -100,7 +96,7 @@ public final class Aggregations {
     }
 
     public static Aggregation statusAggregation(String topLevelCristinOrg, ApprovalStatus status) {
-        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status)));
+        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status), isNotDisputeQuery()));
     }
 
     public static Aggregation completedAggregation(String topLevelCristinOrg) {
@@ -122,11 +118,16 @@ public final class Aggregations {
     }
 
     public static Aggregation collaborationAggregation(String topLevelCristinOrg, ApprovalStatus status) {
-        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status), multipleApprovalsQuery()));
+        return filterAggregation(
+            mustMatch(statusQuery(topLevelCristinOrg, status), multipleApprovalsQuery(), isNotDisputeQuery()));
     }
 
     public static Aggregation disputeAggregation(String topLevelCristinOrg) {
         return filterAggregation(mustMatch(globalStatusDisputeForInstitution(topLevelCristinOrg)));
+    }
+
+    private static Query isNotDisputeQuery() {
+        return mustNotMatch(DISPUTE, GLOBAL_APPROVAL_STATUS);
     }
 
     private static Aggregation filterStatusDisputeAggregation() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.nvi.index.query;
 
 import static java.util.Objects.isNull;
-import static no.sikt.nva.nvi.index.utils.QueryFunctions.*;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.PENDING;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.filterAggregation;
@@ -9,14 +8,21 @@ import static no.sikt.nva.nvi.index.utils.AggregationFunctions.joinWithDelimiter
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.nestedAggregation;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.sumAggregation;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.termsAggregation;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.assignmentsQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.containsPendingStatusQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.fieldValueQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.isNotDisputeQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.multipleApprovalsQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.mustMatch;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.mustNotMatch;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.nestedQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.statusQuery;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVALS;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVAL_STATUS;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.ASSIGNEE;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.GLOBAL_APPROVAL_STATUS;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.INSTITUTION_ID;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.INSTITUTION_POINTS;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.INVOLVED_ORGS;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.NUMBER_OF_APPROVALS;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.POINTS;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,12 +35,10 @@ public final class Aggregations {
 
     public static final String APPROVAL_STATUS_PATH = joinWithDelimiter(APPROVALS, APPROVAL_STATUS);
     public static final String INSTITUTION_ID_PATH = joinWithDelimiter(APPROVALS, INSTITUTION_ID);
-    public static final String ASSIGNEE_PATH = joinWithDelimiter(APPROVALS, ASSIGNEE);
     public static final String DISPUTE_AGGREGATION = "dispute";
     public static final String POINTS_AGGREGATION = "points";
     public static final String DISPUTE = "Dispute";
     public static final String APPROVAL_ORGANIZATIONS_AGGREGATION = "organizations";
-    private static final int MULTIPLE = 2;
     private static final String ALL_AGGREGATIONS = "all";
     private static final String STATUS_AGGREGATION = "status";
 
@@ -46,27 +50,6 @@ public final class Aggregations {
         return aggregationTypeIsNotSpecified(aggregationType)
                    ? generateAllAggregationTypes(username, topLevelCristinOrg)
                    : generateSingleAggregation(aggregationType, username, topLevelCristinOrg);
-    }
-
-    public static Query containsPendingStatusQuery() {
-        final var queries = statusQuery(PENDING);
-        final var query = mustMatch(queries);
-        return nestedQuery(APPROVALS, query);
-    }
-
-    public static Query multipleApprovalsQuery() {
-        return mustMatch(rangeFromQuery(NUMBER_OF_APPROVALS, MULTIPLE));
-    }
-
-    public static Query statusQuery(String topLevelCristinOrg, ApprovalStatus status) {
-        final var query = mustMatch(statusForInstitution(topLevelCristinOrg, status));
-        return nestedQuery(APPROVALS, query);
-    }
-
-    public static Query assignmentsQuery(String username, String topLevelCristinOrg) {
-        final var query = mustMatch(assigneeForInstitution(topLevelCristinOrg, username));
-        return nestedQuery(APPROVALS, query
-        );
     }
 
     public static Aggregation organizationApprovalStatusAggregations(String topLevelCristinOrg) {
@@ -96,7 +79,8 @@ public final class Aggregations {
     }
 
     public static Aggregation statusAggregation(String topLevelCristinOrg, ApprovalStatus status) {
-        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status), isNotDisputeQuery()));
+        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status),
+                                           isNotDisputeQuery()));
     }
 
     public static Aggregation completedAggregation(String topLevelCristinOrg) {
@@ -126,36 +110,14 @@ public final class Aggregations {
         return filterAggregation(mustMatch(globalStatusDisputeForInstitution(topLevelCristinOrg)));
     }
 
-    private static Query isNotDisputeQuery() {
-        return mustNotMatch(DISPUTE, GLOBAL_APPROVAL_STATUS);
-    }
-
     private static Aggregation filterStatusDisputeAggregation() {
         return filterAggregation(mustMatch(fieldValueQuery(joinWithDelimiter(APPROVALS,
                                                                              GLOBAL_APPROVAL_STATUS),
                                                            DISPUTE)));
     }
 
-    private static Query statusQuery(ApprovalStatus approvalStatus) {
-        return fieldValueQuery(APPROVAL_STATUS_PATH, approvalStatus.getValue());
-    }
-
     private static Query approvalInstitutionIdQuery(String topLevelCristinOrg) {
         return fieldValueQuery(INSTITUTION_ID_PATH, topLevelCristinOrg);
-    }
-
-    private static Query[] assigneeForInstitution(String institutionId, String username) {
-        return new Query[]{
-            approvalInstitutionIdQuery(institutionId),
-            fieldValueQuery(ASSIGNEE_PATH, username)
-        };
-    }
-
-    private static Query[] statusForInstitution(String institutionId, ApprovalStatus status) {
-        return new Query[]{
-            approvalInstitutionIdQuery(institutionId),
-            statusQuery(status)
-        };
     }
 
     private static Query[] globalStatusDisputeForInstitution(String institutionId) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFunctions.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/AggregationFunctions.java
@@ -1,56 +1,17 @@
 package no.sikt.nva.nvi.index.utils;
 
-import static java.util.Objects.nonNull;
-import java.util.Arrays;
 import java.util.Map;
-import org.opensearch.client.json.JsonData;
-import org.opensearch.client.opensearch._types.FieldValue;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 import org.opensearch.client.opensearch._types.aggregations.NestedAggregation;
 import org.opensearch.client.opensearch._types.aggregations.SumAggregation;
 import org.opensearch.client.opensearch._types.aggregations.TermsAggregation;
-import org.opensearch.client.opensearch._types.query_dsl.BoolQuery.Builder;
-import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
-import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
-import org.opensearch.client.opensearch._types.query_dsl.NestedQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
-import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
-import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
 
 public final class AggregationFunctions {
 
     private static final CharSequence DELIMITER = ".";
 
     private AggregationFunctions() {
-    }
-
-    public static Query nestedQuery(String path, Query query) {
-        return new NestedQuery.Builder()
-                   .path(path)
-                   .query(query)
-                   .build()._toQuery();
-    }
-
-    public static Query mustMatch(Query... queries) {
-        return new Query.Builder()
-                   .bool(new Builder().must(Arrays.stream(queries).toList()).build())
-                   .build();
-    }
-
-    public static Query fieldValueQuery(String field, String value) {
-        return nonNull(value) ? new TermQuery.Builder()
-                                    .field(field)
-                                    .value(getFieldValue(value))
-                                    .build()._toQuery()
-                   : matchAllQuery();
-    }
-
-    public static Query rangeFromQuery(String field, int greaterThanOrEqualTo) {
-        return new RangeQuery.Builder().field(field).gte(JsonData.of(greaterThanOrEqualTo)).build()._toQuery();
-    }
-
-    public static String joinWithDelimiter(String... args) {
-        return String.join(DELIMITER, args);
     }
 
     public static Aggregation filterAggregation(Query filterQuery) {
@@ -72,16 +33,8 @@ public final class AggregationFunctions {
                    .build();
     }
 
-    public static Query mustNotMatch(String value, String field) {
-        return new Builder()
-                   .mustNot(matchQuery(value, field))
-                   .build()._toQuery();
-    }
-
-    public static Query matchQuery(String value, String field) {
-        return new MatchQuery.Builder().field(field)
-                   .query(getFieldValue(value))
-                   .build()._toQuery();
+    public static String joinWithDelimiter(String... args) {
+        return String.join(DELIMITER, args);
     }
 
     public static NestedAggregation nestedAggregation(String... paths) {
@@ -92,13 +45,5 @@ public final class AggregationFunctions {
 
     public static Aggregation sumAggregation(String... paths) {
         return new SumAggregation.Builder().field(joinWithDelimiter(paths)).build()._toAggregation();
-    }
-
-    private static Query matchAllQuery() {
-        return new MatchAllQuery.Builder().build()._toQuery();
-    }
-
-    private static FieldValue getFieldValue(String value) {
-        return new FieldValue.Builder().stringValue(value).build();
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
@@ -1,0 +1,93 @@
+package no.sikt.nva.nvi.index.utils;
+
+import static java.util.Objects.nonNull;
+import java.util.Arrays;
+import java.util.List;
+import org.opensearch.client.json.JsonData;
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery.Builder;
+import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
+import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
+import org.opensearch.client.opensearch._types.query_dsl.NestedQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
+import org.opensearch.client.opensearch._types.query_dsl.TermsQueryField;
+
+public final class QueryFunctions {
+
+    private QueryFunctions() {
+    }
+
+    public static Query nestedQuery(String path, Query query) {
+        return new NestedQuery.Builder()
+                   .path(path)
+                   .query(query)
+                   .build()._toQuery();
+    }
+
+    public static Query nestedQuery(String path, Query... queries) {
+        return new NestedQuery.Builder()
+                   .path(path)
+                   .query(mustMatch(queries))
+                   .build()._toQuery();
+    }
+
+    public static Query fieldValueQuery(String field, String value) {
+        return nonNull(value) ? new TermQuery.Builder()
+                                    .field(field)
+                                    .value(getFieldValue(value))
+                                    .build()._toQuery()
+                   : matchAllQuery();
+    }
+
+    public static Query termsQuery(List<String> values, String field) {
+        var termsFields = values.stream().map(FieldValue::of).toList();
+        return new TermsQuery.Builder()
+                   .field(field)
+                   .terms(new TermsQueryField.Builder().value(termsFields).build())
+                   .build()._toQuery();
+    }
+
+    public static Query rangeFromQuery(String field, int greaterThanOrEqualTo) {
+        return new RangeQuery.Builder().field(field).gte(JsonData.of(greaterThanOrEqualTo)).build()._toQuery();
+    }
+
+    public static Query mustNotMatch(String value, String field) {
+        return mustNotMatch(matchQuery(value, field));
+    }
+
+    public static Query mustNotMatch(Query query) {
+        return new Builder()
+                   .mustNot(query)
+                   .build()._toQuery();
+    }
+
+    public static Query matchAtLeastOne(Query... queries) {
+        return new Query.Builder()
+                   .bool(new BoolQuery.Builder().should(Arrays.stream(queries).toList()).build())
+                   .build();
+    }
+
+    public static Query mustMatch(Query... queries) {
+        return new Query.Builder()
+                   .bool(new Builder().must(Arrays.stream(queries).toList()).build())
+                   .build();
+    }
+
+    public static Query matchQuery(String value, String field) {
+        return new MatchQuery.Builder().field(field)
+                   .query(getFieldValue(value))
+                   .build()._toQuery();
+    }
+
+    private static Query matchAllQuery() {
+        return new MatchAllQuery.Builder().build()._toQuery();
+    }
+
+    private static FieldValue getFieldValue(String value) {
+        return new FieldValue.Builder().stringValue(value).build();
+    }
+}

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -765,7 +765,7 @@ public class OpenSearchClientTest {
         map.put(PENDING_COLLABORATION_AGG.getAggregationName(), 1);
         map.put(APPROVED_AGG.getAggregationName(), 2);
         map.put(APPROVED_COLLABORATION_AGG.getAggregationName(), 1);
-        map.put(REJECTED_AGG.getAggregationName(), 3);
+        map.put(REJECTED_AGG.getAggregationName(), 2);
         map.put(REJECTED_COLLABORATION_AGG.getAggregationName(), 1);
         map.put(DISPUTED_AGG.getAggregationName(), 1);
         map.put(ASSIGNMENTS_AGG.getAggregationName(), 5);
@@ -782,7 +782,7 @@ public class OpenSearchClientTest {
         map.put(QueryFilterType.PENDING_COLLABORATION_AGG.getFilter(), 1);
         map.put(QueryFilterType.APPROVED_AGG.getFilter(), 2);
         map.put(QueryFilterType.APPROVED_COLLABORATION_AGG.getFilter(), 1);
-        map.put(QueryFilterType.REJECTED_AGG.getFilter(), 3);
+        map.put(QueryFilterType.REJECTED_AGG.getFilter(), 2);
         map.put(QueryFilterType.REJECTED_COLLABORATION_AGG.getFilter(), 1);
         map.put(QueryFilterType.ASSIGNMENTS_AGG.getFilter(), 5);
         map.put(QueryFilterType.DISPUTED_AGG.getFilter(), 1);


### PR DESCRIPTION
Jira task: NP-47106 Når der er en uenighet (minst ein har avvist og minst ein har godkjent) så er det ein Tvist og dermed ikkje lenger Godkjent/Avvist.

Exclude nvi candidates with global status dispute from all status aggregations and filters
Also: Noticed a lot of duplicate methods in `AggregationFunctions` and `CandidateQuery`, so moved these to a new class, `QueryFunctions`

Ignoring one codacy issue: _Linguistics Antipattern - The method 'isNotDisputeQuery' indicates linguistically it returns a boolean, but it returns 'Query'_