### PR TITLE
Np 47379 Fix: handle multiple channel types in evaluation

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/PointService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/PointService.java
@@ -14,6 +14,7 @@ import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_PUBLISHER;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ROLE_TYPE;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_SERIES;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_SERIES_SCIENTIFIC_VALUE;
+import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_TYPE;
 import static no.sikt.nva.nvi.common.utils.JsonUtils.extractJsonNodeTextValue;
 import static no.sikt.nva.nvi.common.utils.JsonUtils.streamNode;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
@@ -37,6 +38,8 @@ public final class PointService {
 
     private static final String COUNTRY_CODE_NORWAY = "NO";
     private static final String ROLE_CREATOR = "Creator";
+    private static final String TYPE = "type";
+    private static final String TYPE_SERIES = "Series";
     private final OrganizationRetriever organizationRetriever;
 
     public PointService(OrganizationRetriever organizationRetriever) {
@@ -158,16 +161,16 @@ public final class PointService {
     @Deprecated
     private static void massiveHackToFixObjectsWithMultipleTypes(JsonNode jsonNode) {
         var series = jsonNode.at(JSON_PTR_SERIES);
-        if (!series.isMissingNode() && series.at("/type").isArray()) {
+        if (!series.isMissingNode() && series.at(JSON_PTR_TYPE).isArray()) {
             var seriesObject = (ObjectNode) series;
-            seriesObject.remove("type");
-            seriesObject.put("type", "Series");
+            seriesObject.remove(TYPE);
+            seriesObject.put(TYPE, TYPE_SERIES);
         }
         var chapterSeries = jsonNode.at(JSON_PTR_CHAPTER_SERIES);
-        if (!chapterSeries.isMissingNode() && chapterSeries.at("/type").isArray()) {
+        if (!chapterSeries.isMissingNode() && chapterSeries.at(JSON_PTR_TYPE).isArray()) {
             var chapterSeriesObject = (ObjectNode) chapterSeries;
-            chapterSeriesObject.remove("type");
-            chapterSeriesObject.put("type", "Series");
+            chapterSeriesObject.remove(TYPE);
+            chapterSeriesObject.put(TYPE, TYPE_SERIES);
         }
     }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -452,6 +452,24 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
     }
 
     @Test
+    @Deprecated
+    void shouldHandleSeriesWithMultipleTypes() throws IOException {
+        mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
+        var path = "evaluator/candidate_academicMonograph_series_multiple_types.json";
+        var content = IoUtils.inputStreamFromResources(path);
+        var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
+        var event = createEvent(new PersistedResourceMessage(fileUri));
+        handler.handleRequest(event, context);
+        var messageBody = getMessageBody();
+        var expectedPoints = BigDecimal.valueOf(5).setScale(SCALE, ROUNDING_MODE);
+        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_MONOGRAPH.getValue(),
+                                                                   expectedPoints,
+                                                                   fileUri, SERIES,
+                                                                   BigDecimal.valueOf(5), expectedPoints);
+        assertEquals(expectedEvaluatedMessage, messageBody);
+    }
+
+    @Test
     void shouldCreateDlqWhenUnableToConnectToResources() {
 
     }

--- a/event-handlers/src/test/resources/evaluator/candidate_academicMonograph_series_multiple_types.json
+++ b/event-handlers/src/test/resources/evaluator/candidate_academicMonograph_series_multiple_types.json
@@ -1,0 +1,266 @@
+{
+  "body": {
+    "type": "Publication",
+    "publicationContextUris": [
+      "https://api.dev.nva.aws.unit.no/publication-channels/d1a0860e-f246-4c8a-a725-98e6bb4fc022",
+      "https://api.dev.nva.aws.unit.no/publication-channels/d96f1b8c-a0f0-450d-ac18-5d11a2ea1f1b"
+    ],
+    "@context": {
+      "@vocab": "https://nva.sikt.no/ontology/publication#",
+      "hasPart": "https://bibsysdev.github.io/src/organization-ontology.ttl#hasPart",
+      "xsd": "http://www.w3.org/2001/XMLSchema#",
+      "DIRHEALTH": "https://nva.sikt.no/ontology/approvals-body#DIRHEALTH",
+      "NMA": "https://nva.sikt.no/ontology/approvals-body#NMA",
+      "NARA": "https://nva.sikt.no/ontology/approvals-body#NARA",
+      "REK": "https://nva.sikt.no/ontology/approvals-body#REK",
+      "ShortFilm": "https://nva.sikt.no/ontology/publication#ShortFilm",
+      "SerialFilmProduction": "https://nva.sikt.no/ontology/publication#SerialFilmProduction",
+      "Film": "https://nva.sikt.no/ontology/publication#Film",
+      "InteractiveFilm": "https://nva.sikt.no/ontology/publication#InteractiveFilm",
+      "AugmentedVirtualRealityFilm": "https://nva.sikt.no/ontology/publication#AugmentedVirtualRealityFilm",
+      "approvedBy": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/approvals-body#"
+        },
+        "@type": "@vocab"
+      },
+      "activeFrom": {
+        "@type": "xsd:dateTime"
+      },
+      "activeTo": {
+        "@type": "xsd:dateTime"
+      },
+      "additionalIdentifiers": {
+        "@container": "@set",
+        "@id": "additionalIdentifier"
+      },
+      "affiliations": {
+        "@container": "@set",
+        "@id": "affiliation"
+      },
+      "alternativeTitles": {
+        "@container": "@language",
+        "@id": "alternativeTitle"
+      },
+      "approvals": {
+        "@container": "@set",
+        "@id": "approval"
+      },
+      "approvalStatus": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "architectureOutput": {
+        "@container": "@set",
+        "@id": "architectureOutput"
+      },
+      "associatedArtifacts": {
+        "@container": "@set",
+        "@id": "associatedArtifact"
+      },
+      "compliesWith": {
+        "@container": "@set",
+        "@id": "compliesWith"
+      },
+      "concertProgramme": {
+        "@container": "@set",
+        "@id": "concertProgramme"
+      },
+      "contributors": {
+        "@container": "@set",
+        "@id": "contributor"
+      },
+      "createdDate": {
+        "@type": "xsd:dateTime"
+      },
+      "doi": {
+        "@type": "@id"
+      },
+      "embargoDate": {
+        "@type": "xsd:dateTime"
+      },
+      "from": {
+        "@type": "xsd:dateTime"
+      },
+      "fundings": {
+        "@container": "@set",
+        "@id": "funding"
+      },
+      "handle": {
+        "@type": "@id"
+      },
+      "id": "@id",
+      "indexedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "isbnList": {
+        "@container": "@set",
+        "@id": "isbn"
+      },
+      "labels": {
+        "@container": "@language",
+        "@id": "label"
+      },
+      "language": {
+        "@type": "@id"
+      },
+      "link": {
+        "@type": "@id"
+      },
+      "manifestations": {
+        "@container": "@set",
+        "@id": "manifestation"
+      },
+      "metadataSource": {
+        "@type": "@id"
+      },
+      "modifiedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "musicalWorks": {
+        "@container": "@set",
+        "@id": "musicalWork"
+      },
+      "nameType": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "outputs": {
+        "@container": "@set",
+        "@id": "output"
+      },
+      "ownerAffiliation": {
+        "@type": "@id"
+      },
+      "projects": {
+        "@container": "@set",
+        "@id": "project"
+      },
+      "publishedDate": {
+        "@type": "xsd:dateTime"
+      },
+      "referencedBy": {
+        "@container": "@set",
+        "@id": "referencedBy"
+      },
+      "related": {
+        "@container": "@set",
+        "@id": "related"
+      },
+      "status": {
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        },
+        "@type": "@vocab"
+      },
+      "subjects": {
+        "@container": "@set",
+        "@id": "subject",
+        "@type": "@id"
+      },
+      "tags": {
+        "@container": "@set",
+        "@id": "tag"
+      },
+      "to": {
+        "@type": "xsd:dateTime"
+      },
+      "trackList": {
+        "@container": "@set",
+        "@id": "trackList"
+      },
+      "type": "@type",
+      "venues": {
+        "@container": "@set",
+        "@id": "venue"
+      },
+      "nviType": {
+        "@type": "@vocab",
+        "@context": {
+          "@vocab": "https://nva.sikt.no/ontology/publication#"
+        }
+      },
+      "NviCandidate": "https://nva.sikt.no/ontology/publication#NviCandidate",
+      "NonNviCandidate": "https://nva.sikt.no/ontology/publication#NonNviCandidate",
+      "publicationContextUris": {
+        "@container": "@set"
+      }
+    },
+    "id": "https://api.dev.nva.aws.unit.no/publication/01888b283f29-cae193c7-80fa-4f92-a164-c73b02c19f2d",
+    "entityDescription": {
+      "type": "EntityDescription",
+      "alternativeAbstracts": {},
+      "contributors": [
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://www.example.org/9e3de71b-0ecb-4464-b9f1-2f92b974839c",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "type": "Identity",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/123456",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "RoleOther"
+          }
+        },
+        {
+          "type": "Contributor",
+          "affiliations": [
+            {
+              "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.64.20.0",
+              "type": "Organization"
+            }
+          ],
+          "identity": {
+            "id": "https://api.dev.nva.aws.unit.no/cristin/person/997998",
+            "type": "Identity",
+            "verificationStatus": "Verified"
+          },
+          "role": {
+            "type": "Creator"
+          }
+        }
+      ],
+      "publicationDate": {
+        "type": "PublicationDate",
+        "year": "2023"
+      },
+      "reference": {
+        "type": "Reference",
+        "publicationContext": {
+          "type": "Book",
+          "publisher": {
+            "id": "https://api.dev.nva.aws.unit.no/publication-channels/d1a0860e-f246-4c8a-a725-98e6bb4fc022",
+            "type": "Publisher",
+            "scientificValue": "LevelOne"
+          },
+          "series": {
+            "id": "https://api.dev.nva.aws.unit.no/publication-channels/series/490845/2023",
+            "type": [
+              "Series",
+              "Journal"
+            ],
+            "scientificValue": "LevelOne"
+          }
+        },
+        "publicationInstance": {
+          "type": "AcademicMonograph"
+        }
+      }
+    },
+    "status": "PUBLISHED"
+  },
+  "consumptionAttributes": {
+    "index": "resources",
+    "documentIdentifier": "0188bee5a7f1-17acf7d5-5658-4a5a-89b2-b2ea73032661"
+  }
+}


### PR DESCRIPTION
Jira issue: 
`EvaluateNVICandidateHandler` is expecting `publicationContext` `type` as String. In some cases, where there is a mismatch between NVA and Kanalregisteret on the channel type, publicationContext is array (See example).

```
{
  "id": "https://api.dev.nva.aws.unit.no/publication-channels-v2/series/123/2024",
  "type": [
    "Series",
    "Journal"
  ],
  "identifier": "C8CCD71B-FD8B-47B4-B72A-905F6219D7D5",
  "name": "Some name",
  "scientificValue": "LevelOne",
  "year": "2024"
}
```

Long term fix: NVA and Kanalregisteret should agree on the type of the channel
Fix short term: Revert this removal: https://github.com/BIBSYSDEV/nva-nvi/pull/277