### PR TITLE
Np 47380 Fix: EvaluatorService, NumberFormatException

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -64,7 +64,7 @@ public class EvaluatorService {
         var publicationId = extractPublicationId(publication);
         var publicationDate = extractPublicationDate(publication);
         if (hasInvalidPublicationYear(publicationDate)) {
-            logger.info("Skipping evaluation due to invalid year format {}. Publication id {}",
+            logger.warn("Skipping evaluation due to invalid year format {}. Publication id {}",
                         publicationDate.year(), publicationId);
             return Optional.empty();
         }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -64,7 +64,7 @@ public class EvaluatorService {
         var publicationId = extractPublicationId(publication);
         var publicationDate = extractPublicationDate(publication);
         if (hasInvalidPublicationYear(publicationDate)) {
-            logger.info("Invalid year format. " + NON_NVI_CANDIDATE_MESSAGE, publicationId);
+            logger.info("Invalid year format. Evaluated publication with id {} as NonNviCandidate.", publicationId);
             return createNonNviMessage(publicationId);
         }
         if (isPublishedBeforeOrInLatestClosedPeriod(publicationDate)) {
@@ -151,6 +151,10 @@ public class EvaluatorService {
                    .orElse(new PublicationDate(null, null, year.textValue()));
     }
 
+    private static boolean isBeforeOrEqualTo(Year publishedYear, Year latestClosedPeriodYear) {
+        return publishedYear.isBefore(latestClosedPeriodYear) || publishedYear.equals(latestClosedPeriodYear);
+    }
+
     private boolean hasInvalidPublicationYear(PublicationDate publicationDate) {
         return attempt(() -> Year.parse(publicationDate.year())).isFailure();
     }
@@ -161,10 +165,6 @@ public class EvaluatorService {
                    .map(Year::of)
                    .map(latestClosedPeriodYear -> isBeforeOrEqualTo(publishedYear, latestClosedPeriodYear))
                    .orElse(false);
-    }
-
-    private static boolean isBeforeOrEqualTo(Year publishedYear, Year latestClosedPeriodYear) {
-        return publishedYear.isBefore(latestClosedPeriodYear) || publishedYear.equals(latestClosedPeriodYear);
     }
 
     private Optional<CandidateEvaluatedMessage> createNonNviMessage(URI publicationId) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -64,8 +64,9 @@ public class EvaluatorService {
         var publicationId = extractPublicationId(publication);
         var publicationDate = extractPublicationDate(publication);
         if (hasInvalidPublicationYear(publicationDate)) {
-            logger.info("Invalid year format. Evaluated publication with id {} as NonNviCandidate.", publicationId);
-            return createNonNviMessage(publicationId);
+            logger.info("Skipping evaluation due to invalid year format {}. Publication id {}",
+                        publicationDate.year(), publicationId);
+            return Optional.empty();
         }
         if (isPublishedBeforeOrInLatestClosedPeriod(publicationDate)) {
             logger.info("Skipping evaluation. Publication with id {} is published before or same as latest closed "

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -172,7 +172,6 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         var fileUri = setUpPublicationWithInvalidYear();
         var event = createEvent(new PersistedResourceMessage(fileUri));
         handler.handleRequest(event, context);
-        assertEquals(0, queueClient.getSentMessages().size());
         var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
         assertThat(nonCandidate.publicationId(), is(equalTo(HARDCODED_PUBLICATION_ID)));
     }


### PR DESCRIPTION
In `EvaluatorService.isPublishedBeforeOrInLatestClosedPeriod()`, a `NumberFormatException` is thrown if year is not a valid integer. Examlple: "1948-1997". 

Change:
- If `publicationDate.year` is invalid, skip evaluation and log invalid year and publication id. In this way, we can report which publications have an invalid year format and fix metadata for these if necessary