### PR TITLE
Bump nva commons to 1.40.11

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 junit = { strictly = '5.10.2' }
-nva = { strictly = '1.40.8' }
+nva = { strictly = '1.40.11' }
 jackson = { strictly = '2.16.1' }
 mockito = { strictly = '5.10.0' }
 hamcrest = { strictly = '2.2' }


### PR DESCRIPTION
To get latest changes in [AuthorizedBackendClient](https://github.com/BIBSYSDEV/nva-commons/commit/8c4f633617f163d04da5fb704835aaffd040d269)