### PR TITLE
Bump nva commons to 1.40.12

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 junit = { strictly = '5.10.2' }
-nva = { strictly = '1.40.11' }
+nva = { strictly = '1.40.12' }
 jackson = { strictly = '2.16.1' }
 mockito = { strictly = '5.10.0' }
 hamcrest = { strictly = '2.2' }


### PR DESCRIPTION
To get latest changes in [AuthorizedBackendUriRetriever](https://github.com/BIBSYSDEV/nva-commons/commit/e637e5faea0ade289f32ea910dd3e8577997f1a0)