### PR TITLE
Np 47456 SearchNviCandidatesHandler, use viewingScope as default for search parameter affiliations

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandler.java
@@ -109,7 +109,13 @@ public class SearchNviCandidatesHandler
 
     private List<String> getQueryParamAffiliationsOrViewingScope(RequestInfo requestInfo)
         throws UnauthorizedException {
-        return extractQueryParamAffiliations(requestInfo).orElse(getAffiliationsFromViewingScope(requestInfo));
+        return extractQueryParamAffiliations(requestInfo).orElse(getDefaultAffiliations(requestInfo));
+    }
+
+    private List<String> getDefaultAffiliations(RequestInfo requestInfo) throws UnauthorizedException {
+        return userIsNviAdmin(requestInfo)
+                   ? List.of()
+                   : getAffiliationsFromViewingScope(requestInfo);
     }
 
     private List<String> getAffiliationsFromViewingScope(RequestInfo requestInfo) throws UnauthorizedException {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -52,12 +52,12 @@ public record CandidateSearchParameters(String searchTerm,
         return new Builder();
     }
 
-    public static CandidateSearchParameters fromRequestInfo(RequestInfo requestInfo)
+    public static CandidateSearchParameters fromRequestInfo(RequestInfo requestInfo, List<String> affiliationIdentifiers)
         throws UnauthorizedException, BadRequestException {
         var aggregationType = extractQueryParamAggregationType(requestInfo);
         return CandidateSearchParameters.builder()
                    .withSearchTerm(extractQueryParamSearchTermOrDefault(requestInfo))
-                   .withAffiliations(extractQueryParamAffiliations(requestInfo))
+                   .withAffiliations(affiliationIdentifiers)
                    .withExcludeSubUnits(extractQueryParamExcludeSubUnitsOrDefault(requestInfo))
                    .withFilter(extractQueryParamFilterOrDefault(requestInfo))
                    .withUsername(requestInfo.getUserName())
@@ -112,20 +112,6 @@ public record CandidateSearchParameters(String searchTerm,
         return requestInfo.getQueryParameterOpt(QUERY_OFFSET_PARAM)
                    .map(Integer::parseInt)
                    .orElse(DEFAULT_OFFSET_SIZE);
-    }
-
-    private static List<String> extractQueryParamAffiliations(RequestInfo requestInfo) {
-        return requestInfo.getQueryParameterOpt(QUERY_PARAM_AFFILIATIONS)
-                   .map(CandidateSearchParameters::splitStringToIdentifiers)
-                   .orElse(requestInfo.getTopLevelOrgCristinId()
-                               .map(UriWrapper::fromUri)
-                               .map(UriWrapper::getLastPathElement)
-                               .map(List::of)
-                               .orElse(List.of()));
-    }
-
-    private static List<String> splitStringToIdentifiers(String identifierListAsString) {
-        return Arrays.stream(identifierListAsString.split(COMMA)).collect(Collectors.toList());
     }
 
     private static boolean extractQueryParamExcludeSubUnitsOrDefault(RequestInfo requestInfo) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -313,16 +313,16 @@ public class SearchNviCandidatesHandlerTest {
     }
 
     @Test
-    void shouldReturnResultsWithUserTopLevelOrgAsDefaultAffiliationIfNotSet() throws IOException {
-        var searchedAffiliations = List.of(randomSiktSubUnit(), randomSiktSubUnit());
+    void shouldReturnResultsWithUsersViewingScopeAsDefaultAffiliationIfNotSet() throws IOException {
+        var usersViewingScope = List.of(randomSiktSubUnit(), randomSiktSubUnit());
 
         var matcher =
             new CandidateSearchParamsAffiliationMatcher(CandidateSearchParameters.builder()
-                                                            .withAffiliations(searchedAffiliations).build());
+                                                            .withAffiliations(usersViewingScope).build());
         when(openSearchClient.search(argThat(matcher)))
             .thenReturn(createSearchResponse(singleNviCandidateIndexDocument()));
 
-        var request = requestWithInstitutionsAndTopLevelCristinOrgId(searchedAffiliations, TOP_LEVEL_CRISTIN_ORG);
+        var request = createRequest(TOP_LEVEL_CRISTIN_ORG, Map.of());
         handler.handleRequest(request, output, context);
 
         var response = GatewayResponse.fromOutputStream(output, Problem.class);


### PR DESCRIPTION
Users are experiencing Unauthorized-errors if they have a sub unit viewing scope and query parameter `affiliations` is not set when searching for nvi candidates.

Change:
- Before, search parameter affiliations was set to users top level org if query parameter `affiliations` was not provided
- Now, search parameter affiliations is set to users `viewingScope.includedUnits` if query parameter `affiliations` is not provided
- Unless you have access right `NVI_ADMIN`, then search parameter affiliations is an empty list:)