### PR TITLE
Np 47488 IndexDocument: add publication channel id, type and scientificValue

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
@@ -19,7 +19,6 @@ import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.PUBLICA
 import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.PUBLICATION_TITLE;
 import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.PUBLISHED_YEAR;
 import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.REPORTING_YEAR;
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -38,12 +37,10 @@ import no.sikt.nva.nvi.index.model.report.InstitutionReportHeader;
 import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import no.unit.nva.commons.json.JsonSerializable;
-import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
 public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                                         URI id,
@@ -74,8 +71,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
 
     public static NviCandidateIndexDocument from(JsonNode expandedResource, Candidate candidate,
                                                  UriRetriever uriRetriever) {
-        var documentGenerator = new NviCandidateIndexDocumentGenerator(uriRetriever);
-        return documentGenerator.generateDocument(expandedResource, candidate);
+        return new NviCandidateIndexDocumentGenerator(uriRetriever, expandedResource, candidate).generateDocument();
     }
 
     public static Builder builder() {
@@ -88,12 +84,6 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                    .filter(approval -> approval.institutionId().equals(institutionId))
                    .findAny()
                    .orElseThrow();
-    }
-
-    @Override
-    @JacocoGenerated
-    public String toString() {
-        return toJsonString();
     }
 
     @JsonIgnore

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
@@ -38,6 +38,7 @@ import no.sikt.nva.nvi.index.model.report.InstitutionReportHeader;
 import no.sikt.nva.nvi.index.utils.NviCandidateIndexDocumentGenerator;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import no.unit.nva.commons.json.JsonSerializable;
+import nva.commons.core.JacocoGenerated;
 import nva.commons.core.paths.UriWrapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,6 +88,12 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
                    .filter(approval -> approval.institutionId().equals(institutionId))
                    .findAny()
                    .orElseThrow();
+    }
+
+    @Override
+    @JacocoGenerated
+    public String toString() {
+        return toJsonString();
     }
 
     @JsonIgnore

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationChannel.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationChannel.java
@@ -1,0 +1,71 @@
+package no.sikt.nva.nvi.index.model.document;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.net.URI;
+import java.util.Arrays;
+
+@JsonSerialize
+public record PublicationChannel(@JsonProperty("id") URI id,
+                                 @JsonProperty("type") String type,
+                                 @JsonProperty("scientificValue") ScientificValue scientificValue) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public enum ScientificValue {
+        LEVEL_ONE("LevelOne"),
+        LEVEL_TWO("LevelTwo");
+        @JsonValue
+        private final String value;
+
+        ScientificValue(String value) {
+            this.value = value;
+        }
+
+        public static ScientificValue parse(String value) {
+            return switch (value) {
+                case "LevelOne" -> LEVEL_ONE;
+                case "LevelTwo" -> LEVEL_TWO;
+                default -> throw new IllegalArgumentException("Unknown value. Expected one of: " + Arrays.toString(
+                    values()));
+            };
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public static final class Builder {
+
+        private URI id;
+        private String type;
+
+        private ScientificValue scientificValue;
+
+        private Builder() {
+        }
+
+        public Builder withId(URI id) {
+            this.id = id;
+            return this;
+        }
+
+        public Builder withType(String type) {
+            this.type = type;
+            return this;
+        }
+
+        public Builder withScientificValue(ScientificValue scientificValue) {
+            this.scientificValue = scientificValue;
+            return this;
+        }
+
+        public PublicationChannel build() {
+            return new PublicationChannel(id, type, scientificValue);
+        }
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationChannel.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationChannel.java
@@ -1,15 +1,14 @@
 package no.sikt.nva.nvi.index.model.document;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URI;
 import java.util.Arrays;
 
 @JsonSerialize
-public record PublicationChannel(@JsonProperty("id") URI id,
-                                 @JsonProperty("type") String type,
-                                 @JsonProperty("scientificValue") ScientificValue scientificValue) {
+public record PublicationChannel(URI id,
+                                 String type,
+                                 ScientificValue scientificValue) {
 
     public static Builder builder() {
         return new Builder();

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationChannel.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationChannel.java
@@ -26,16 +26,19 @@ public record PublicationChannel(@JsonProperty("id") URI id,
         }
 
         public static ScientificValue parse(String value) {
-            return switch (value) {
-                case "LevelOne" -> LEVEL_ONE;
-                case "LevelTwo" -> LEVEL_TWO;
-                default -> throw new IllegalArgumentException("Unknown value. Expected one of: " + Arrays.toString(
-                    values()));
-            };
+            return Arrays.stream(ScientificValue.values())
+                       .filter(type -> type.getValue().equalsIgnoreCase(value))
+                       .findFirst()
+                       .orElseThrow(ScientificValue::getIllegalArgumentException);
         }
 
         public String getValue() {
             return value;
+        }
+
+        private static IllegalArgumentException getIllegalArgumentException() {
+            return new IllegalArgumentException(String.format("Unknown value. Valid values are: %s",
+                                                              Arrays.toString(ScientificValue.values())));
         }
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -12,7 +12,8 @@ public record PublicationDetails(@JsonProperty("id") String id,
                                  @JsonProperty("type") String type,
                                  @JsonProperty("title") String title,
                                  @JsonProperty("publicationDate") PublicationDate publicationDate,
-                                 @JsonProperty("contributors") List<ContributorType> contributors) {
+                                 @JsonProperty("contributors") List<ContributorType> contributors,
+                                 @JsonProperty("publicationChannel") PublicationChannel publicationChannel) {
 
     public static Builder builder() {
         return new Builder();
@@ -33,6 +34,7 @@ public record PublicationDetails(@JsonProperty("id") String id,
         private String title;
         private PublicationDate publicationDate;
         private List<ContributorType> contributors;
+        private PublicationChannel publicationChannel;
 
         private Builder() {
         }
@@ -62,8 +64,13 @@ public record PublicationDetails(@JsonProperty("id") String id,
             return this;
         }
 
+        public Builder withPublicationChannel(PublicationChannel publicationChannel) {
+            this.publicationChannel = publicationChannel;
+            return this;
+        }
+
         public PublicationDetails build() {
-            return new PublicationDetails(id, type, title, publicationDate, contributors);
+            return new PublicationDetails(id, type, title, publicationDate, contributors, publicationChannel);
         }
     }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -9,6 +9,7 @@ import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PAR
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SORT_ORDER;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_TITLE;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.randomPublicationChannel;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
@@ -466,7 +467,8 @@ public class SearchNviCandidatesHandlerTest {
 
     private static PublicationDetails randomPublicationDetails() {
         return new PublicationDetails(randomString(), randomString(), randomString(),
-                                      PublicationDate.builder().withYear(randomString()).build(), List.of());
+                                      PublicationDate.builder().withYear(randomString()).build(), List.of(),
+                                      randomPublicationChannel());
     }
 
     private static InputStream createRequest(URI topLevelCristinOrgId, Map<String, String> queryParams, String userName)

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -15,6 +15,7 @@ import static no.sikt.nva.nvi.index.query.SearchAggregation.PENDING_COLLABORATIO
 import static no.sikt.nva.nvi.index.query.SearchAggregation.REJECTED_AGG;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.REJECTED_COLLABORATION_AGG;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.TOTAL_COUNT_AGGREGATION_AGG;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.randomPublicationChannel;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
@@ -67,6 +68,7 @@ import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.search.OrderByFields;
 import no.sikt.nva.nvi.index.query.SearchAggregation;
 import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
+import no.sikt.nva.nvi.test.IndexDocumentTestUtils;
 import no.unit.nva.auth.CachedJwtProvider;
 import no.unit.nva.auth.CognitoAuthenticator;
 import nva.commons.core.ioutils.IoUtils;
@@ -710,7 +712,8 @@ public class OpenSearchClientTest {
         }
         return new PublicationDetails(randomString(), randomString(), title,
                                       publicationDate,
-                                      List.of(contributorBuilder.build()));
+                                      List.of(contributorBuilder.build()),
+                                      randomPublicationChannel());
     }
 
     private static Approval randomApprovalWithCustomerAndAssignee(URI affiliation, String assignee) {
@@ -749,7 +752,7 @@ public class OpenSearchClientTest {
     private static PublicationDetails randomPublicationDetails() {
         return new PublicationDetails(randomString(), randomString(), randomString(),
                                       PublicationDate.builder().withYear(YEAR).build(),
-                                      List.of());
+                                      List.of(), randomPublicationChannel());
     }
 
     private static void addDocumentsToIndex(NviCandidateIndexDocument... documents) throws InterruptedException {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/model/document/PublicationChannelTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/model/document/PublicationChannelTest.java
@@ -1,0 +1,14 @@
+package no.sikt.nva.nvi.index.model.document;
+
+import static org.junit.Assert.assertThrows;
+import no.sikt.nva.nvi.index.model.document.PublicationChannel.ScientificValue;
+import org.junit.jupiter.api.Test;
+
+class PublicationChannelTest {
+
+    @Test
+    void shouldThrowIllegalArgumentExceptionWhenParsingUnknownValue() {
+        var unknownValue = "UnknownValue";
+        assertThrows(IllegalArgumentException.class, () -> ScientificValue.parse(unknownValue));
+    }
+}

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -41,6 +41,8 @@ import no.sikt.nva.nvi.index.model.document.NviContributor;
 import no.sikt.nva.nvi.index.model.document.NviOrganization;
 import no.sikt.nva.nvi.index.model.document.Organization;
 import no.sikt.nva.nvi.index.model.document.OrganizationType;
+import no.sikt.nva.nvi.index.model.document.PublicationChannel;
+import no.sikt.nva.nvi.index.model.document.PublicationChannel.ScientificValue;
 import no.sikt.nva.nvi.index.model.document.PublicationDate;
 import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import no.sikt.nva.nvi.index.model.document.ReportingPeriod;
@@ -82,6 +84,7 @@ public final class IndexDocumentTestUtils {
                    .withPublicationDate(mapToPublicationDate(candidate.getPublicationDetails().publicationDate()))
                    .withContributors(
                        mapToContributors(ExpandedResourceGenerator.extractContributors(expandedResource), candidate))
+                   .withPublicationChannel(getPublicationChannel(candidate))
                    .build();
     }
 
@@ -108,6 +111,22 @@ public final class IndexDocumentTestUtils {
         var publicationDetails = publicationDetailsWithNviContributorsAffiliatedWith(institutionId);
         var noApprovals = new ArrayList<no.sikt.nva.nvi.index.model.document.Approval>();
         return getBuilder(year, noApprovals, publicationDetails).build();
+    }
+
+    public static PublicationChannel randomPublicationChannel() {
+        return PublicationChannel.builder()
+                   .withId(randomUri())
+                   .withType(randomString())
+                   .withScientificValue(randomElement(ScientificValue.values()))
+                   .build();
+    }
+
+    private static PublicationChannel getPublicationChannel(Candidate candidate) {
+        return PublicationChannel.builder()
+                   .withId(candidate.getPublicationDetails().publicationChannelId())
+                   .withType(candidate.getPublicationDetails().channelType().getValue())
+                   .withScientificValue(ScientificValue.parse(candidate.getPublicationDetails().level()))
+                   .build();
     }
 
     private static Builder getBuilder(int year, List<no.sikt.nva.nvi.index.model.document.Approval> approvals,

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -97,7 +97,7 @@ public final class TestUtils {
                    .points(List.of(new DbInstitutionPoints(institutionId, institutionPoints,
                                                            List.of(new DbCreatorAffiliationPoints(
                                                                creatorId, institutionId, institutionPoints)))))
-                   .level(randomElement(DbLevel.values()))
+                   .level(DbLevel.LEVEL_ONE)
                    .channelType(randomElement(ChannelType.values()))
                    .publicationDate(new DbPublicationDate(randomString(), randomString(), randomString()))
                    .internationalCollaboration(randomBoolean())

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -98,6 +98,7 @@ public final class TestUtils {
                                                            List.of(new DbCreatorAffiliationPoints(
                                                                creatorId, institutionId, institutionPoints)))))
                    .level(randomElement(DbLevel.values()))
+                   .channelType(randomElement(ChannelType.values()))
                    .publicationDate(new DbPublicationDate(randomString(), randomString(), randomString()))
                    .internationalCollaboration(randomBoolean())
                    .creatorCount(randomInteger())


### PR DESCRIPTION
Change in index document model: add `document.publicationDetails.publicationChannel` with `id`, `type` and `scientificValue`

Also did some refactoring in `NviIndexDocumentGenerator`: instead of getting `JsonNode expandedResource` and `Candidate candidate` as input parameters in method `generateDocument()`, added these as class variables.