### PR TITLE
Np 47439 Institution report: Search for candidates with pagination

### DIFF
--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -63,4 +63,5 @@ test {
     environment("BACKEND_CLIENT_SECRET_NAME", "My secret name")
     environment("PERSISTED_INDEX_DOCUMENT_QUEUE_URL", "PersistedIndexDocumentQueue")
     environment("INDEX_DLQ", "IndexDlq")
+    environment("INSTITUTION_REPORT_SEARCH_PAGE_SIZE", "1")
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
@@ -11,6 +11,7 @@ import no.sikt.nva.nvi.index.aws.OpenSearchClient;
 import no.sikt.nva.nvi.index.aws.SearchClient;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.utils.InstitutionReportGenerator;
+import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -62,8 +63,9 @@ public class FetchInstitutionReportHandler extends ApiGatewayHandler<Void, Strin
         var institutionId = requestInfo.getTopLevelOrgCristinId().orElseThrow();
         logger.info("Generating report for institution {} for year {}", institutionId, year);
         var pageSize = parseInt(new Environment().readEnv(ENV_VAR_INSTITUTION_REPORT_SEARCH_PAGE_SIZE));
-        return new InstitutionReportGenerator(searchClient, pageSize, year, institutionId).generateReport()
-                   .toBase64EncodedString();
+        var report = new InstitutionReportGenerator(searchClient, pageSize, year, institutionId).generateReport();
+        logger.info("Report generated successfully. Returning report as base64 encoded string");
+        return report.toBase64EncodedString();
     }
 
     @Override

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
@@ -10,7 +10,6 @@ import no.sikt.nva.nvi.index.aws.OpenSearchClient;
 import no.sikt.nva.nvi.index.aws.SearchClient;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.utils.InstitutionReportGenerator;
-import no.sikt.nva.nvi.index.utils.TooManyHitsException;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -59,14 +58,8 @@ public class FetchInstitutionReportHandler extends ApiGatewayHandler<Void, Strin
         var year = requestInfo.getPathParameter(PATH_PARAMETER_YEAR);
         var institutionId = requestInfo.getTopLevelOrgCristinId().orElseThrow();
         logger.info("Generating report for institution {} for year {}", institutionId, year);
-        try {
-            return new InstitutionReportGenerator(searchClient, year, institutionId).generateReport()
-                       .toBase64EncodedString();
-        } catch (TooManyHitsException exception) {
-            logger.error("Failed to generate report for institution {} for year {}. Error: {}", institutionId, year,
-                         exception.getMessage());
-            throw exception;
-        }
+        return new InstitutionReportGenerator(searchClient, year, institutionId).generateReport()
+                   .toBase64EncodedString();
     }
 
     @Override

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
@@ -10,6 +10,7 @@ import no.sikt.nva.nvi.index.aws.OpenSearchClient;
 import no.sikt.nva.nvi.index.aws.SearchClient;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.utils.InstitutionReportGenerator;
+import no.sikt.nva.nvi.index.utils.TooManyHitsException;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -58,8 +59,14 @@ public class FetchInstitutionReportHandler extends ApiGatewayHandler<Void, Strin
         var year = requestInfo.getPathParameter(PATH_PARAMETER_YEAR);
         var institutionId = requestInfo.getTopLevelOrgCristinId().orElseThrow();
         logger.info("Generating report for institution {} for year {}", institutionId, year);
-        return new InstitutionReportGenerator(searchClient, year, institutionId).generateReport()
-                   .toBase64EncodedString();
+        try {
+            return new InstitutionReportGenerator(searchClient, year, institutionId).generateReport()
+                       .toBase64EncodedString();
+        } catch (TooManyHitsException exception) {
+            logger.error("Failed to generate report for institution {} for year {}. Error: {}", institutionId, year,
+                         exception.getMessage());
+            throw exception;
+        }
     }
 
     @Override

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.index.apigateway;
 
+import static java.lang.Integer.parseInt;
 import static nva.commons.core.attempt.Try.attempt;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.google.common.net.MediaType;
@@ -16,6 +17,7 @@ import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
+import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 
@@ -23,6 +25,7 @@ public class FetchInstitutionReportHandler extends ApiGatewayHandler<Void, Strin
 
     private static final Logger logger = org.slf4j.LoggerFactory.getLogger(FetchInstitutionReportHandler.class);
     private static final String PATH_PARAMETER_YEAR = "year";
+    private static final String ENV_VAR_INSTITUTION_REPORT_SEARCH_PAGE_SIZE = "INSTITUTION_REPORT_SEARCH_PAGE_SIZE";
     private final SearchClient<NviCandidateIndexDocument> searchClient;
 
     @JacocoGenerated
@@ -58,7 +61,8 @@ public class FetchInstitutionReportHandler extends ApiGatewayHandler<Void, Strin
         var year = requestInfo.getPathParameter(PATH_PARAMETER_YEAR);
         var institutionId = requestInfo.getTopLevelOrgCristinId().orElseThrow();
         logger.info("Generating report for institution {} for year {}", institutionId, year);
-        return new InstitutionReportGenerator(searchClient, year, institutionId).generateReport()
+        var pageSize = parseInt(new Environment().readEnv(ENV_VAR_INSTITUTION_REPORT_SEARCH_PAGE_SIZE));
+        return new InstitutionReportGenerator(searchClient, pageSize, year, institutionId).generateReport()
                    .toBase64EncodedString();
     }
 
@@ -68,6 +72,6 @@ public class FetchInstitutionReportHandler extends ApiGatewayHandler<Void, Strin
     }
 
     private static boolean isInvalidPathParameterYear(RequestInfo requestInfo) {
-        return attempt(() -> Year.of(Integer.parseInt(requestInfo.getPathParameter(PATH_PARAMETER_YEAR)))).isFailure();
+        return attempt(() -> Year.of(parseInt(requestInfo.getPathParameter(PATH_PARAMETER_YEAR)))).isFailure();
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandler.java
@@ -11,7 +11,6 @@ import no.sikt.nva.nvi.index.aws.OpenSearchClient;
 import no.sikt.nva.nvi.index.aws.SearchClient;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.utils.InstitutionReportGenerator;
-import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.index.utils;
 
 import static nva.commons.core.attempt.Try.attempt;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -11,22 +12,28 @@ import no.sikt.nva.nvi.index.aws.SearchClient;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.report.InstitutionReportHeader;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
+import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
 import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class InstitutionReportGenerator {
 
     private static final Logger logger = LoggerFactory.getLogger(InstitutionReportGenerator.class);
+    private static final int INITIAL_OFFSET = 0;
     private final SearchClient<NviCandidateIndexDocument> searchClient;
+    private final int searchPageSize;
     private final String year;
     private final URI topLevelOrganization;
 
     public InstitutionReportGenerator(SearchClient<NviCandidateIndexDocument> searchClient,
+                                      int searchPageSize,
                                       String year,
                                       URI topLevelOrganization) {
         this.searchClient = searchClient;
+        this.searchPageSize = searchPageSize;
         this.year = year;
         this.topLevelOrganization = topLevelOrganization;
     }
@@ -48,27 +55,54 @@ public class InstitutionReportGenerator {
                    .toList();
     }
 
+    private static void addHitsToListOfCandidates(HitsMetadata<NviCandidateIndexDocument> hits,
+                                                  ArrayList<NviCandidateIndexDocument> fetchedCandidates) {
+        hits.hits().stream().map(Hit::source).forEach(fetchedCandidates::add);
+    }
+
     private Stream<List<String>> orderByHeaderOrder(
         List<Map<InstitutionReportHeader, String>> reportRows) {
         return reportRows.stream().map(InstitutionReportGenerator::sortValuesByHeaderOrder);
     }
 
     private List<NviCandidateIndexDocument> fetchNviCandidates() {
-        var searchHits = attempt(() -> searchClient.search(buildSearchRequest())).orElseThrow()
-                               .hits()
-                               .hits()
-                               .stream()
-                               .map(Hit::source)
-                               .toList();
-        logger.info("Found {} candidates for institution {} for year {}", searchHits.size(), topLevelOrganization,
-                    year);
-        return searchHits;
+        var fetchedCandidates = new ArrayList<NviCandidateIndexDocument>();
+        var hits = search(INITIAL_OFFSET);
+        addHitsToListOfCandidates(hits, fetchedCandidates);
+        while (thereAreMoreHitsThanReturned(hits.total().value(), fetchedCandidates.size())) {
+            hits = search(searchPageSize);
+            addHitsToListOfCandidates(hits, fetchedCandidates);
+        }
+        logNumberOfCandidatesFound(fetchedCandidates);
+        return fetchedCandidates;
     }
 
-    private CandidateSearchParameters buildSearchRequest() {
+    private void logNumberOfCandidatesFound(ArrayList<NviCandidateIndexDocument> fetchedCandidates) {
+        logger.info("Found {} candidates for institution {} for year {}", fetchedCandidates.size(),
+                    topLevelOrganization,
+                    year);
+    }
+
+    private HitsMetadata<NviCandidateIndexDocument> search(int offset) {
+        return attempt(() -> searchClient.search(buildSearchRequest(offset))).orElseThrow().hits();
+    }
+
+    private boolean thereAreMoreHitsThanReturned(long total, int size) {
+        return total > size;
+    }
+
+    private CandidateSearchParameters buildSearchRequest(int offset) {
         return CandidateSearchParameters.builder()
                    .withYear(year)
                    .withTopLevelCristinOrg(topLevelOrganization)
+                   .withSearchResultParameters(getSearchRequestParameters(offset))
+                   .build();
+    }
+
+    private SearchResultParameters getSearchRequestParameters(int offset) {
+        return SearchResultParameters.builder()
+                   .withSize(searchPageSize)
+                   .withOffset(offset)
                    .build();
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 public class InstitutionReportGenerator {
 
     private static final Logger logger = LoggerFactory.getLogger(InstitutionReportGenerator.class);
-    private static final int MAX_HITS = 10_000;
+    private static final int MAX_HITS = 10000;
     private final SearchClient<NviCandidateIndexDocument> searchClient;
     private final String year;
     private final URI topLevelOrganization;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -11,6 +11,7 @@ import no.sikt.nva.nvi.index.aws.SearchClient;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.report.InstitutionReportHeader;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
+import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.slf4j.Logger;
@@ -19,6 +20,7 @@ import org.slf4j.LoggerFactory;
 public class InstitutionReportGenerator {
 
     private static final Logger logger = LoggerFactory.getLogger(InstitutionReportGenerator.class);
+    private static final int MAX_HITS = 10000;
     private final SearchClient<NviCandidateIndexDocument> searchClient;
     private final String year;
     private final URI topLevelOrganization;
@@ -54,21 +56,31 @@ public class InstitutionReportGenerator {
     }
 
     private List<NviCandidateIndexDocument> fetchNviCandidates() {
-        var searchHits = attempt(() -> searchClient.search(buildSearchRequest())).orElseThrow()
-                               .hits()
-                               .hits()
-                               .stream()
-                               .map(Hit::source)
-                               .toList();
+        var hits = attempt(() -> searchClient.search(buildSearchRequest())).orElseThrow().hits();
+        var searchHits = hits.hits()
+                             .stream()
+                             .map(Hit::source)
+                             .toList();
+        throwErrorIfTooManyHits(hits.total().value());
         logger.info("Found {} candidates for institution {} for year {}", searchHits.size(), topLevelOrganization,
                     year);
         return searchHits;
+    }
+
+    private void throwErrorIfTooManyHits(long totalHits) {
+        if (totalHits > MAX_HITS) {
+            var message = String.format(
+                "More than %s candidates found for institution %s for year %s. Number of hits: %s",
+                MAX_HITS, topLevelOrganization, year, totalHits);
+            throw new TooManyHitsException(message);
+        }
     }
 
     private CandidateSearchParameters buildSearchRequest() {
         return CandidateSearchParameters.builder()
                    .withYear(year)
                    .withTopLevelCristinOrg(topLevelOrganization)
+                   .withSearchResultParameters(SearchResultParameters.builder().withSize(MAX_HITS).build())
                    .build();
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -56,7 +56,7 @@ public class InstitutionReportGenerator {
     }
 
     private static void addHitsToListOfCandidates(HitsMetadata<NviCandidateIndexDocument> hits,
-                                                  ArrayList<NviCandidateIndexDocument> fetchedCandidates) {
+                                                  List<NviCandidateIndexDocument> fetchedCandidates) {
         hits.hits().stream().map(Hit::source).forEach(fetchedCandidates::add);
     }
 
@@ -79,9 +79,8 @@ public class InstitutionReportGenerator {
         return fetchedCandidates;
     }
 
-    private void logNumberOfCandidatesFound(ArrayList<NviCandidateIndexDocument> fetchedCandidates) {
-        logger.info("Found {} candidates for institution {} for year {}", fetchedCandidates.size(),
-                    topLevelOrganization,
+    private void logNumberOfCandidatesFound(List<NviCandidateIndexDocument> candidates) {
+        logger.info("Found {} candidates for institution {} for year {}", candidates.size(), topLevelOrganization,
                     year);
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -70,7 +70,7 @@ public class InstitutionReportGenerator {
         var offset = INITIAL_OFFSET;
         var hits = search(offset);
         addHitsToListOfCandidates(hits, fetchedCandidates);
-        while (thereAreMoreHitsThanReturned(hits, fetchedCandidates.size())) {
+        while (thereAreMoreHitsToFetch(hits, fetchedCandidates.size())) {
             offset += searchPageSize;
             hits = search(offset);
             addHitsToListOfCandidates(hits, fetchedCandidates);
@@ -89,7 +89,7 @@ public class InstitutionReportGenerator {
         return attempt(() -> searchClient.search(buildSearchRequest(offset))).orElseThrow().hits();
     }
 
-    private boolean thereAreMoreHitsThanReturned(HitsMetadata<NviCandidateIndexDocument> hitsMetadata, int size) {
+    private boolean thereAreMoreHitsToFetch(HitsMetadata<NviCandidateIndexDocument> hitsMetadata, int size) {
         return hitsMetadata.total().value() > size;
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 public class InstitutionReportGenerator {
 
     private static final Logger logger = LoggerFactory.getLogger(InstitutionReportGenerator.class);
-    private static final int MAX_HITS = 10000;
+    private static final int MAX_HITS = 10_000;
     private final SearchClient<NviCandidateIndexDocument> searchClient;
     private final String year;
     private final URI topLevelOrganization;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/TooManyHitsException.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/TooManyHitsException.java
@@ -1,8 +1,0 @@
-package no.sikt.nva.nvi.index.utils;
-
-public class TooManyHitsException extends RuntimeException {
-
-    public TooManyHitsException(String message) {
-        super(message);
-    }
-}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/TooManyHitsException.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/TooManyHitsException.java
@@ -1,0 +1,8 @@
+package no.sikt.nva.nvi.index.utils;
+
+public class TooManyHitsException extends RuntimeException {
+
+    public TooManyHitsException(String message) {
+        super(message);
+    }
+}

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -160,18 +160,6 @@ public class FetchInstitutionReportHandlerTest {
         assertEquals(expected, actual);
     }
 
-    @NotNull
-    private static List<NviCandidateIndexDocument> mockTwoCandidatesInIndex(URI topLevelCristinOrg)
-        throws IOException {
-        var firstDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
-        var secondDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
-        var candidatesInIndex = List.of(firstDocument, secondDocument);
-        when(openSearchClient.search(any()))
-            .thenReturn(createSearchResponseWithTotal(firstDocument, candidatesInIndex.size()))
-            .thenReturn(createSearchResponseWithTotal(secondDocument, candidatesInIndex.size()));
-        return candidatesInIndex;
-    }
-
     @Test
     void shouldPerformSearchForGivenInstitutionAndYear() throws IOException {
         var topLevelCristinOrg = randomCristinOrgUri();
@@ -183,6 +171,8 @@ public class FetchInstitutionReportHandlerTest {
         var expectedSearchParameters = CandidateSearchParameters.builder()
                                            .withYear(year)
                                            .withTopLevelCristinOrg(topLevelCristinOrg)
+                                           .withSearchResultParameters(
+                                               SearchResultParameters.builder().withSize(PAGE_SIZE).build())
                                            .build();
         verify(openSearchClient).search(eq(expectedSearchParameters));
     }
@@ -245,12 +235,24 @@ public class FetchInstitutionReportHandlerTest {
         assertThat(response.getHeaders().get(CONTENT_TYPE), is(OOXML_SHEET.toString()));
     }
 
+    @NotNull
+    private static List<NviCandidateIndexDocument> mockTwoCandidatesInIndex(URI topLevelCristinOrg)
+        throws IOException {
+        var firstDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
+        var secondDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
+        var candidatesInIndex = List.of(firstDocument, secondDocument);
+        when(openSearchClient.search(any()))
+            .thenReturn(createSearchResponseWithTotal(firstDocument, candidatesInIndex.size()))
+            .thenReturn(createSearchResponseWithTotal(secondDocument, candidatesInIndex.size()));
+        return candidatesInIndex;
+    }
+
     private static CandidateSearchParameters buildRequest(URI topLevelCristinOrg,
-                                                          SearchResultParameters firstExpectedResultParameters) {
+                                                          SearchResultParameters resultParameters) {
         return CandidateSearchParameters.builder()
                    .withYear(String.valueOf(CURRENT_YEAR))
                    .withTopLevelCristinOrg(topLevelCristinOrg)
-                   .withSearchResultParameters(firstExpectedResultParameters)
+                   .withSearchResultParameters(resultParameters)
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -76,6 +76,7 @@ import nva.commons.apigateway.GatewayResponse;
 import nva.commons.core.Environment;
 import nva.commons.logutils.LogUtils;
 import org.hamcrest.Matchers;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -141,12 +142,7 @@ public class FetchInstitutionReportHandlerTest {
     void shouldFetchCandidatesWithPagination()
         throws IOException {
         var topLevelCristinOrg = randomCristinOrgUri();
-        var firstDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
-        var secondDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
-        var candidatesInIndex = List.of(firstDocument, secondDocument);
-        when(openSearchClient.search(any()))
-            .thenReturn(createSearchResponseWithTotal(firstDocument, candidatesInIndex.size()))
-            .thenReturn(createSearchResponseWithTotal(secondDocument, candidatesInIndex.size()));
+        var candidatesInIndex = mockTwoCandidatesInIndex(topLevelCristinOrg);
 
         handler.handleRequest(requestWithMediaType(MICROSOFT_EXCEL.toString(), topLevelCristinOrg), output, CONTEXT);
 
@@ -162,6 +158,18 @@ public class FetchInstitutionReportHandlerTest {
         var actual = fromInputStream(new ByteArrayInputStream(decodedResponse));
         var expected = getExpectedReport(candidatesInIndex, topLevelCristinOrg);
         assertEquals(expected, actual);
+    }
+
+    @NotNull
+    private static List<NviCandidateIndexDocument> mockTwoCandidatesInIndex(URI topLevelCristinOrg)
+        throws IOException {
+        var firstDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
+        var secondDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
+        var candidatesInIndex = List.of(firstDocument, secondDocument);
+        when(openSearchClient.search(any()))
+            .thenReturn(createSearchResponseWithTotal(firstDocument, candidatesInIndex.size()))
+            .thenReturn(createSearchResponseWithTotal(secondDocument, candidatesInIndex.size()));
+        return candidatesInIndex;
     }
 
     @Test

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -65,7 +65,6 @@ import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.document.NviContributor;
 import no.sikt.nva.nvi.index.model.document.NviOrganization;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
-import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
 import no.sikt.nva.nvi.test.IndexDocumentTestUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
@@ -143,24 +142,6 @@ public class FetchInstitutionReportHandlerTest {
         var expectedSearchParameters = CandidateSearchParameters.builder()
                                            .withYear(year)
                                            .withTopLevelCristinOrg(topLevelCristinOrg)
-                                           .build();
-        verify(openSearchClient).search(eq(expectedSearchParameters));
-    }
-
-    @Test
-    void shouldPerformSearchWithPageSize10000() throws IOException {
-        var topLevelCristinOrg = randomCristinOrgUri();
-        var year = "2021";
-        var request = createRequest(topLevelCristinOrg, MANAGE_NVI_CANDIDATES, topLevelCristinOrg,
-                                    Map.of(YEAR, year)).build();
-        handler.handleRequest(request, output, CONTEXT);
-
-        var expectedPageSize = 10000;
-        var expectedSearchParameters = CandidateSearchParameters.builder()
-                                           .withYear(year)
-                                           .withTopLevelCristinOrg(topLevelCristinOrg)
-                                           .withSearchResultParameters(
-                                               SearchResultParameters.builder().withSize(expectedPageSize).build())
                                            .build();
         verify(openSearchClient).search(eq(expectedSearchParameters));
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -65,6 +65,7 @@ import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.document.NviContributor;
 import no.sikt.nva.nvi.index.model.document.NviOrganization;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
+import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
 import no.sikt.nva.nvi.test.IndexDocumentTestUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
@@ -142,6 +143,24 @@ public class FetchInstitutionReportHandlerTest {
         var expectedSearchParameters = CandidateSearchParameters.builder()
                                            .withYear(year)
                                            .withTopLevelCristinOrg(topLevelCristinOrg)
+                                           .build();
+        verify(openSearchClient).search(eq(expectedSearchParameters));
+    }
+
+    @Test
+    void shouldPerformSearchWithPageSize10000() throws IOException {
+        var topLevelCristinOrg = randomCristinOrgUri();
+        var year = "2021";
+        var request = createRequest(topLevelCristinOrg, MANAGE_NVI_CANDIDATES, topLevelCristinOrg,
+                                    Map.of(YEAR, year)).build();
+        handler.handleRequest(request, output, CONTEXT);
+
+        var expectedPageSize = 10000;
+        var expectedSearchParameters = CandidateSearchParameters.builder()
+                                           .withYear(year)
+                                           .withTopLevelCristinOrg(topLevelCristinOrg)
+                                           .withSearchResultParameters(
+                                               SearchResultParameters.builder().withSize(expectedPageSize).build())
                                            .build();
         verify(openSearchClient).search(eq(expectedSearchParameters));
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -69,7 +69,6 @@ import no.sikt.nva.nvi.index.model.document.NviOrganization;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
-import no.sikt.nva.nvi.test.IndexDocumentTestUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.GatewayResponse;
@@ -87,6 +86,9 @@ public class FetchInstitutionReportHandlerTest {
     private static final String YEAR = "year";
     private static final int CURRENT_YEAR = Year.now().getValue();
     private static final Context CONTEXT = mock(Context.class);
+    private static final SearchResultParameters EXPECTED_SEARCH_RESULT_PARAMETERS = SearchResultParameters.builder()
+                                                                                        .withSize(10000)
+                                                                                        .build();
     private static SearchClient<NviCandidateIndexDocument> openSearchClient;
     private ByteArrayOutputStream output;
     private FetchInstitutionReportHandler handler;
@@ -158,6 +160,7 @@ public class FetchInstitutionReportHandlerTest {
 
         var expectedSearchParameters = CandidateSearchParameters.builder()
                                            .withYear(year)
+                                           .withSearchResultParameters(EXPECTED_SEARCH_RESULT_PARAMETERS)
                                            .withTopLevelCristinOrg(topLevelCristinOrg)
                                            .build();
         verify(openSearchClient).search(eq(expectedSearchParameters));
@@ -171,12 +174,10 @@ public class FetchInstitutionReportHandlerTest {
                                     Map.of(YEAR, year)).build();
         handler.handleRequest(request, output, CONTEXT);
 
-        var expectedPageSize = 10000;
         var expectedSearchParameters = CandidateSearchParameters.builder()
                                            .withYear(year)
                                            .withTopLevelCristinOrg(topLevelCristinOrg)
-                                           .withSearchResultParameters(
-                                               SearchResultParameters.builder().withSize(expectedPageSize).build())
+                                           .withSearchResultParameters(EXPECTED_SEARCH_RESULT_PARAMETERS)
                                            .build();
         verify(openSearchClient).search(eq(expectedSearchParameters));
     }
@@ -373,6 +374,4 @@ public class FetchInstitutionReportHandlerTest {
         when(openSearchClient.search(any())).thenReturn(createSearchResponse(indexDocument));
         return List.of(indexDocument);
     }
-
-
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -8,7 +8,6 @@ import static com.google.common.net.MediaType.OOXML_SHEET;
 import static no.sikt.nva.nvi.index.apigateway.utils.ExcelWorkbookUtil.extractLinesInInstitutionIdentifierColumn;
 import static no.sikt.nva.nvi.index.apigateway.utils.ExcelWorkbookUtil.fromInputStream;
 import static no.sikt.nva.nvi.index.apigateway.utils.MockOpenSearchUtil.createSearchResponse;
-import static no.sikt.nva.nvi.index.apigateway.utils.MockOpenSearchUtil.searchResponseWithTotalHitsOver10000;
 import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.CONTRIBUTOR_FIRST_NAME;
 import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.CONTRIBUTOR_IDENTIFIER;
 import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.CONTRIBUTOR_LAST_NAME;
@@ -29,7 +28,6 @@ import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.PUBLISH
 import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.REPORTING_YEAR;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.indexDocumentMissingCreatorAffiliationPoints;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.randomCristinOrgUri;
-import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.randomIndexDocumentWith;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -132,20 +130,6 @@ public class FetchInstitutionReportHandlerTest {
         var decodedResponse = Base64.getDecoder().decode(fromOutputStream(output, String.class).getBody());
         var actual = fromInputStream(new ByteArrayInputStream(decodedResponse));
         assertEquals(expected, actual);
-    }
-
-    @Test
-    void shouldReturnInternalServerErrorAndLogErrorWhenMoreThan10000Hits() throws IOException {
-        var topLevelCristinOrg = randomCristinOrgUri();
-        var indexDocuments = List.of(randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg));
-        when(openSearchClient.search(any())).thenReturn(searchResponseWithTotalHitsOver10000(indexDocuments));
-
-        var appender = LogUtils.getTestingAppender(FetchInstitutionReportHandler.class);
-        handler.handleRequest(requestWithMediaType(MICROSOFT_EXCEL.toString(), topLevelCristinOrg), output, CONTEXT);
-
-        var response = GatewayResponse.fromOutputStream(output, Problem.class);
-        assertThat(response.getStatusCode(), is(Matchers.equalTo(HttpURLConnection.HTTP_INTERNAL_ERROR)));
-        assertTrue(appender.getMessages().contains("More than 10000 candidates found"));
     }
 
     @Test
@@ -369,10 +353,8 @@ public class FetchInstitutionReportHandlerTest {
     }
 
     private List<NviCandidateIndexDocument> mockCandidatesInOpenSearch(URI topLevelCristinOrg) throws IOException {
-        var indexDocument = randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
+        var indexDocument = IndexDocumentTestUtils.randomIndexDocumentWith(CURRENT_YEAR, topLevelCristinOrg);
         when(openSearchClient.search(any())).thenReturn(createSearchResponse(indexDocument));
         return List.of(indexDocument);
     }
-
-
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -87,7 +87,7 @@ public class FetchInstitutionReportHandlerTest {
     private static final int CURRENT_YEAR = Year.now().getValue();
     private static final Context CONTEXT = mock(Context.class);
     private static final SearchResultParameters EXPECTED_SEARCH_RESULT_PARAMETERS = SearchResultParameters.builder()
-                                                                                        .withSize(10_000)
+                                                                                        .withSize(10000)
                                                                                         .build();
     private static SearchClient<NviCandidateIndexDocument> openSearchClient;
     private ByteArrayOutputStream output;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -69,6 +69,7 @@ import no.sikt.nva.nvi.index.model.document.NviOrganization;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
+import no.sikt.nva.nvi.test.IndexDocumentTestUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.GatewayResponse;
@@ -86,9 +87,6 @@ public class FetchInstitutionReportHandlerTest {
     private static final String YEAR = "year";
     private static final int CURRENT_YEAR = Year.now().getValue();
     private static final Context CONTEXT = mock(Context.class);
-    private static final SearchResultParameters EXPECTED_SEARCH_RESULT_PARAMETERS = SearchResultParameters.builder()
-                                                                                        .withSize(10000)
-                                                                                        .build();
     private static SearchClient<NviCandidateIndexDocument> openSearchClient;
     private ByteArrayOutputStream output;
     private FetchInstitutionReportHandler handler;
@@ -160,7 +158,6 @@ public class FetchInstitutionReportHandlerTest {
 
         var expectedSearchParameters = CandidateSearchParameters.builder()
                                            .withYear(year)
-                                           .withSearchResultParameters(EXPECTED_SEARCH_RESULT_PARAMETERS)
                                            .withTopLevelCristinOrg(topLevelCristinOrg)
                                            .build();
         verify(openSearchClient).search(eq(expectedSearchParameters));
@@ -174,10 +171,12 @@ public class FetchInstitutionReportHandlerTest {
                                     Map.of(YEAR, year)).build();
         handler.handleRequest(request, output, CONTEXT);
 
+        var expectedPageSize = 10000;
         var expectedSearchParameters = CandidateSearchParameters.builder()
                                            .withYear(year)
                                            .withTopLevelCristinOrg(topLevelCristinOrg)
-                                           .withSearchResultParameters(EXPECTED_SEARCH_RESULT_PARAMETERS)
+                                           .withSearchResultParameters(
+                                               SearchResultParameters.builder().withSize(expectedPageSize).build())
                                            .build();
         verify(openSearchClient).search(eq(expectedSearchParameters));
     }
@@ -374,4 +373,6 @@ public class FetchInstitutionReportHandlerTest {
         when(openSearchClient.search(any())).thenReturn(createSearchResponse(indexDocument));
         return List.of(indexDocument);
     }
+
+
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -87,7 +87,7 @@ public class FetchInstitutionReportHandlerTest {
     private static final int CURRENT_YEAR = Year.now().getValue();
     private static final Context CONTEXT = mock(Context.class);
     private static final SearchResultParameters EXPECTED_SEARCH_RESULT_PARAMETERS = SearchResultParameters.builder()
-                                                                                        .withSize(10000)
+                                                                                        .withSize(10_000)
                                                                                         .build();
     private static SearchClient<NviCandidateIndexDocument> openSearchClient;
     private ByteArrayOutputStream output;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.index.apigateway.utils;
 
 import static no.sikt.nva.nvi.index.utils.SearchConstants.NVI_CANDIDATES_INDEX;
+import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,6 +20,17 @@ public class MockOpenSearchUtil {
     public static SearchResponse<NviCandidateIndexDocument> createSearchResponse(NviCandidateIndexDocument document) {
         return defaultBuilder()
                    .hits(constructHitsMetadata(List.of(document)))
+                   .build();
+    }
+
+    public static SearchResponse<NviCandidateIndexDocument> searchResponseWithTotalHitsOver10000(
+        List<NviCandidateIndexDocument> documents) {
+        var total = 10000 + randomInteger();
+        return defaultBuilder()
+                   .hits(new HitsMetadata.Builder<NviCandidateIndexDocument>()
+                             .hits(documents.stream().map(MockOpenSearchUtil::toHit).collect(Collectors.toList()))
+                             .total(new TotalHits.Builder().value(total).relation(TotalHitsRelation.Eq).build())
+                             .build())
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.nvi.index.apigateway.utils;
 
 import static no.sikt.nva.nvi.index.utils.SearchConstants.NVI_CANDIDATES_INDEX;
-import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -20,17 +19,6 @@ public class MockOpenSearchUtil {
     public static SearchResponse<NviCandidateIndexDocument> createSearchResponse(NviCandidateIndexDocument document) {
         return defaultBuilder()
                    .hits(constructHitsMetadata(List.of(document)))
-                   .build();
-    }
-
-    public static SearchResponse<NviCandidateIndexDocument> searchResponseWithTotalHitsOver10000(
-        List<NviCandidateIndexDocument> documents) {
-        var total = 10000 + randomInteger();
-        return defaultBuilder()
-                   .hits(new HitsMetadata.Builder<NviCandidateIndexDocument>()
-                             .hits(documents.stream().map(MockOpenSearchUtil::toHit).collect(Collectors.toList()))
-                             .total(new TotalHits.Builder().value(total).relation(TotalHitsRelation.Eq).build())
-                             .build())
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
@@ -21,6 +21,15 @@ public class MockOpenSearchUtil {
                    .hits(constructHitsMetadata(List.of(document)))
                    .build();
     }
+    public static SearchResponse<NviCandidateIndexDocument> createSearchResponseWithTotal(NviCandidateIndexDocument document, int total) {
+        List<NviCandidateIndexDocument> hits = List.of(document);
+        return defaultBuilder()
+                   .hits(new HitsMetadata.Builder<NviCandidateIndexDocument>()
+                             .hits(hits.stream().map(MockOpenSearchUtil::toHit).collect(Collectors.toList()))
+                             .total(new TotalHits.Builder().relation(TotalHitsRelation.Eq).value(total).build())
+                             .build())
+                   .build();
+    }
 
     public static SearchResponse<NviCandidateIndexDocument> createSearchResponse(
         List<NviCandidateIndexDocument> documents, String aggregateName, Aggregate aggregate) {

--- a/template.yaml
+++ b/template.yaml
@@ -1213,6 +1213,7 @@ Resources:
         Variables:
           ALLOWED_ORIGIN: !Ref AllowedOrigins
           COGNITO_HOST: !Ref CognitoAuthorizationUri
+          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 500
       Policies:
         - !GetAtt ReadSearchInfrastructureSecretsPolicy.PolicyArn
       Events:


### PR DESCRIPTION
Noticed only 10 candidates in report when testing `FetchInstitutionReportHandler`. 10 is the default search page size 😄 

Changes:
- Use page size (500, set in env var) and offset to fetch candidates for given year and top level organization