### PR TITLE
Np 47490 Index document: Add page information

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Pages.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Pages.java
@@ -11,8 +11,7 @@ public record Pages(String begin,
     public static final class Builder {
         private String begin;
         private String end;
-
-        private String total;
+        private String numberOfPages;
 
         private Builder() {
         }
@@ -27,13 +26,13 @@ public record Pages(String begin,
             return this;
         }
 
-        public Builder withTotal(String total) {
-            this.total = total;
+        public Builder withNumberOfPages(String numberOfPages) {
+            this.numberOfPages = numberOfPages;
             return this;
         }
 
         public Pages build() {
-            return new Pages(begin, end, total);
+            return new Pages(begin, end, numberOfPages);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Pages.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/Pages.java
@@ -1,0 +1,39 @@
+package no.sikt.nva.nvi.index.model.document;
+
+public record Pages(String begin,
+                    String end,
+                    String total) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String begin;
+        private String end;
+
+        private String total;
+
+        private Builder() {
+        }
+
+        public Builder withBegin(String begin) {
+            this.begin = begin;
+            return this;
+        }
+
+        public Builder withEnd(String end) {
+            this.end = end;
+            return this;
+        }
+
+        public Builder withTotal(String total) {
+            this.total = total;
+            return this;
+        }
+
+        public Pages build() {
+            return new Pages(begin, end, total);
+        }
+    }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -2,18 +2,18 @@ package no.sikt.nva.nvi.index.model.document;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
-public record PublicationDetails(@JsonProperty("id") String id,
-                                 @JsonProperty("type") String type,
-                                 @JsonProperty("title") String title,
-                                 @JsonProperty("publicationDate") PublicationDate publicationDate,
-                                 @JsonProperty("contributors") List<ContributorType> contributors,
-                                 @JsonProperty("publicationChannel") PublicationChannel publicationChannel) {
+public record PublicationDetails(String id,
+                                 String type,
+                                 String title,
+                                 PublicationDate publicationDate,
+                                 List<ContributorType> contributors,
+                                 PublicationChannel publicationChannel,
+                                 Pages pages) {
 
     public static Builder builder() {
         return new Builder();
@@ -35,6 +35,7 @@ public record PublicationDetails(@JsonProperty("id") String id,
         private PublicationDate publicationDate;
         private List<ContributorType> contributors;
         private PublicationChannel publicationChannel;
+        private Pages pages;
 
         private Builder() {
         }
@@ -69,8 +70,13 @@ public record PublicationDetails(@JsonProperty("id") String id,
             return this;
         }
 
+        public Builder withPages(Pages pages) {
+            this.pages = pages;
+            return this;
+        }
+
         public PublicationDetails build() {
-            return new PublicationDetails(id, type, title, publicationDate, contributors, publicationChannel);
+            return new PublicationDetails(id, type, title, publicationDate, contributors, publicationChannel, pages);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -3,6 +3,7 @@ package no.sikt.nva.nvi.index.utils;
 import static java.util.Objects.isNull;
 import static no.sikt.nva.nvi.common.utils.GraphUtils.PART_OF_PROPERTY;
 import static no.sikt.nva.nvi.common.utils.GraphUtils.createModel;
+import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PRT_PAGES_END;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_AFFILIATIONS;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CONTRIBUTOR;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_DAY;
@@ -15,6 +16,8 @@ import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_MAIN_TITLE;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_MONTH;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_NAME;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ORCID;
+import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_PAGES_BEGIN;
+import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_PAGES_NUMBER;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_PUBLICATION_DATE;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_PUBLISHER_NAME;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ROLE_TYPE;
@@ -73,10 +76,6 @@ public final class NviCandidateIndexDocumentGenerator {
     private static final TypeReference<Map<String, String>> TYPE_REF =
         new TypeReference<>() {
         };
-    private static final String JSON_PTR_PAGES_BEGIN = "/entityDescription/reference/publicationInstance/pages/begin";
-    private static final String JSON_PRT_PAGES_END = "/entityDescription/reference/publicationInstance/pages/end";
-    private static final String JSON_PTR_PAGES_NUMBER = "/entityDescription/reference/publicationInstance"
-                                                        + "/pages/pages";
     private final OrganizationRetriever organizationRetriever;
     private final JsonNode expandedResource;
     private final Candidate candidate;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -9,6 +9,7 @@ import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PAR
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SORT_ORDER;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_TITLE;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.randomPages;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.randomPublicationChannel;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
@@ -468,7 +469,7 @@ public class SearchNviCandidatesHandlerTest {
     private static PublicationDetails randomPublicationDetails() {
         return new PublicationDetails(randomString(), randomString(), randomString(),
                                       PublicationDate.builder().withYear(randomString()).build(), List.of(),
-                                      randomPublicationChannel());
+                                      randomPublicationChannel(), randomPages());
     }
 
     private static InputStream createRequest(URI topLevelCristinOrgId, Map<String, String> queryParams, String userName)

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -15,6 +15,7 @@ import static no.sikt.nva.nvi.index.query.SearchAggregation.PENDING_COLLABORATIO
 import static no.sikt.nva.nvi.index.query.SearchAggregation.REJECTED_AGG;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.REJECTED_COLLABORATION_AGG;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.TOTAL_COUNT_AGGREGATION_AGG;
+import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.randomPages;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.randomPublicationChannel;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
@@ -713,7 +714,7 @@ public class OpenSearchClientTest {
         return new PublicationDetails(randomString(), randomString(), title,
                                       publicationDate,
                                       List.of(contributorBuilder.build()),
-                                      randomPublicationChannel());
+                                      randomPublicationChannel(), randomPages());
     }
 
     private static Approval randomApprovalWithCustomerAndAssignee(URI affiliation, String assignee) {
@@ -752,7 +753,7 @@ public class OpenSearchClientTest {
     private static PublicationDetails randomPublicationDetails() {
         return new PublicationDetails(randomString(), randomString(), randomString(),
                                       PublicationDate.builder().withYear(YEAR).build(),
-                                      List.of(), randomPublicationChannel());
+                                      List.of(), randomPublicationChannel(), randomPages());
     }
 
     private static void addDocumentsToIndex(NviCandidateIndexDocument... documents) throws InterruptedException {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
@@ -26,6 +26,9 @@ public final class JsonPointers {
         + "/scientificValue";
     public static final String JSON_PTR_CHAPTER_SERIES =
         "/entityDescription/reference/publicationContext/entityDescription/reference/publicationContext/series";
+    public static final String JSON_PTR_PAGES_BEGIN = "/entityDescription/reference/publicationInstance/pages/begin";
+    public static final String JSON_PRT_PAGES_END = "/entityDescription/reference/publicationInstance/pages/end";
+    public static final String JSON_PTR_PAGES_NUMBER = "/entityDescription/reference/publicationInstance/pages/pages";
     public static final String JSON_PTR_YEAR = "/year";
     public static final String JSON_PTR_MONTH = "/month";
     public static final String JSON_PTR_DAY = "/day";

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
@@ -19,6 +19,12 @@ public final class JsonUtils {
                    .orElse(null);
     }
 
+    public static Optional<String> extractOptJsonNodeTextValue(JsonNode node, String jsonPointer) {
+        return Optional.ofNullable(node.at(jsonPointer))
+                   .filter(JsonUtils::isNotMissingNode)
+                   .map(JsonNode::textValue);
+    }
+
     public static Stream<JsonNode> streamNode(JsonNode node) {
         return StreamSupport.stream(node.spliterator(), false);
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.common.utils;
 
+import static no.sikt.nva.nvi.common.utils.JsonUtils.extractOptJsonNodeTextValue;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -20,6 +21,14 @@ class JsonUtilsTest {
         var fieldValue = randomString();
         var randomJsonNode = objectMapper.createObjectNode().put(fieldName, fieldValue);
         assertThat(JsonUtils.extractJsonNodeTextValue(randomJsonNode, "/" + fieldName), is(equalTo(fieldValue)));
+    }
+
+    @Test
+    void shouldExtractOptionalJsonNodeTextValueIfPresent() {
+        var fieldName = "fieldName";
+        var fieldValue = randomString();
+        var randomJsonNode = objectMapper.createObjectNode().put(fieldName, fieldValue);
+        assertThat(extractOptJsonNodeTextValue(randomJsonNode, "/" + fieldName).get(), is(equalTo(fieldValue)));
     }
 
     @Test

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
@@ -48,8 +48,7 @@ public final class ExpandedResourceGenerator {
 
         var reference = objectMapper.createObjectNode();
 
-        var publicationInstance = objectMapper.createObjectNode();
-        publicationInstance.put("type", candidate.getPublicationDetails().type());
+        var publicationInstance = createAndPopulatePublicationInstance(candidate);
         reference.set("publicationInstance", publicationInstance);
 
         var publicationContext = createAndPopulatePublicationContext(candidate);
@@ -103,6 +102,25 @@ public final class ExpandedResourceGenerator {
     public static String extractType(JsonNode expandedResource) {
         return JsonUtils.extractJsonNodeTextValue(expandedResource,
                                                   "/entityDescription/reference/publicationInstance/type");
+    }
+
+    private static ObjectNode createAndPopulatePublicationInstance(Candidate candidate) {
+        var publicationInstance = objectMapper.createObjectNode();
+        publicationInstance.put("type", candidate.getPublicationDetails().type());
+        switch (candidate.getPublicationDetails().type()) {
+            case "AcademicArticle", "AcademicLiteratureReview", "AcademicChapter" -> {
+                var pages = objectMapper.createObjectNode();
+                pages.put("begin", "pageBegin");
+                pages.put("end", "pageEnd");
+                publicationInstance.set("pages", pages);
+            }
+            case "AcademicMonograph" -> {
+                var pages = objectMapper.createObjectNode();
+                pages.put("pages", "numberOfPages");
+                publicationInstance.set("pages", pages);
+            }
+        }
+        return publicationInstance;
     }
 
     private static ObjectNode createAndPopulatePublicationContext(Candidate candidate) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -43,6 +43,7 @@ import no.sikt.nva.nvi.index.model.document.NviContributor;
 import no.sikt.nva.nvi.index.model.document.NviOrganization;
 import no.sikt.nva.nvi.index.model.document.Organization;
 import no.sikt.nva.nvi.index.model.document.OrganizationType;
+import no.sikt.nva.nvi.index.model.document.Pages;
 import no.sikt.nva.nvi.index.model.document.PublicationChannel;
 import no.sikt.nva.nvi.index.model.document.PublicationChannel.ScientificValue;
 import no.sikt.nva.nvi.index.model.document.PublicationDate;
@@ -87,6 +88,16 @@ public final class IndexDocumentTestUtils {
                    .withContributors(
                        mapToContributors(ExpandedResourceGenerator.extractContributors(expandedResource), candidate))
                    .withPublicationChannel(getPublicationChannel(candidate, expandedResource))
+                   .withPages(getPages(expandedResource))
+                   .build();
+    }
+
+    private static Pages getPages(JsonNode expandedResource) {
+        var pagesNode = expandedResource.at("/entityDescription/reference/publicationInstance/pages");
+        return Pages.builder()
+                   .withBegin(extractJsonNodeTextValue(pagesNode, "/begin"))
+                   .withEnd(extractJsonNodeTextValue(pagesNode, "/end"))
+                   .withTotal(extractJsonNodeTextValue(pagesNode, "/pages"))
                    .build();
     }
 
@@ -120,6 +131,14 @@ public final class IndexDocumentTestUtils {
                    .withId(randomUri())
                    .withType(randomString())
                    .withScientificValue(randomElement(ScientificValue.values()))
+                   .build();
+    }
+
+    public static Pages randomPages() {
+        return Pages.builder()
+                   .withBegin(randomString())
+                   .withEnd(randomString())
+                   .withTotal(randomString())
                    .build();
     }
 

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -97,7 +97,7 @@ public final class IndexDocumentTestUtils {
         return Pages.builder()
                    .withBegin(extractJsonNodeTextValue(pagesNode, "/begin"))
                    .withEnd(extractJsonNodeTextValue(pagesNode, "/end"))
-                   .withTotal(extractJsonNodeTextValue(pagesNode, "/pages"))
+                   .withNumberOfPages(extractJsonNodeTextValue(pagesNode, "/pages"))
                    .build();
     }
 
@@ -138,7 +138,7 @@ public final class IndexDocumentTestUtils {
         return Pages.builder()
                    .withBegin(randomString())
                    .withEnd(randomString())
-                   .withTotal(randomString())
+                   .withNumberOfPages(randomString())
                    .build();
     }
 


### PR DESCRIPTION
Jira task: NP-47490 Expand index document with page information

Extracting optional fields `begin`, `end` and `pages` from `publicationInstance` in expanded resource

Test that verifies this is `IndexDocumentHandlerTest.shouldBuildIndexDocumentAndPersistInS3WhenReceivingSqsEvent()` with `expectedIndexDocument` containing publication page info from test data setup (`expandedResource`)