### PR TITLE
CristinMapper: shouldThrowIllegalArgumentExceptionWhenQualityCodeIsInvalid

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -227,10 +227,11 @@ public final class CandidateDao extends Dao {
         @JacocoGenerated//This is tested in CristinMapperTest
         //TODO: Remove after cristin migration
         public static DbLevel fromDeprecatedValue(String value) {
+            Objects.requireNonNull(value);
             return switch (value) {
                 case "1" -> LEVEL_ONE;
                 case "2" -> LEVEL_TWO;
-                default -> NON_CANDIDATE;
+                default -> throw new IllegalArgumentException("Invalid value. Valid values are 1 and 2");
             };
         }
 


### PR DESCRIPTION
Indexing failing for candidates imported via Cristin, some of these do not have level NON_CANDIDATE, which does not seem like a valid state?

Suggestion: throw IllegalArgumentException and fix this in the data source?