### PR TITLE
ReQueueDlqHandler: Handle channel type null

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -39,25 +39,26 @@ public record NviCandidate(URI publicationId,
 
     public static NviCandidate fromCandidate(Candidate candidate) {
         var details = candidate.getPublicationDetails();
-
-        return NviCandidate.builder()
-                   .withPublicationId(candidate.getPublicationId())
-                   .withPublicationBucketUri(details.publicationBucketUri())
-                   .withInstanceType(details.type())
-                   .withDate(toPublicationDate(details.publicationDate()))
-                   .withVerifiedCreators(details.creators().stream()
-                                             .map(NviCandidate::mapToNviCreator)
-                                             .toList())
-                   .withChannelType(nonNull(details.channelType()) ? details.channelType().getValue() : null)
-                   .withPublicationChannelId(details.publicationChannelId())
-                   .withLevel(details.level())
-                   .withBasePoints(candidate.getBasePoints())
-                   .withIsInternationalCollaboration(candidate.isInternationalCollaboration())
-                   .withCollaborationFactor(candidate.getCollaborationFactor())
-                   .withCreatorShareCount(candidate.getCreatorShareCount())
-                   .withInstitutionPoints(candidate.getInstitutionPoints())
-                   .withTotalPoints(candidate.getTotalPoints())
-                   .build();
+        var candidateBuilder = NviCandidate.builder()
+                                   .withPublicationId(candidate.getPublicationId())
+                                   .withPublicationBucketUri(details.publicationBucketUri())
+                                   .withInstanceType(details.type())
+                                   .withDate(toPublicationDate(details.publicationDate()))
+                                   .withVerifiedCreators(details.creators().stream()
+                                                             .map(NviCandidate::mapToNviCreator)
+                                                             .toList())
+                                   .withPublicationChannelId(details.publicationChannelId())
+                                   .withLevel(details.level())
+                                   .withBasePoints(candidate.getBasePoints())
+                                   .withIsInternationalCollaboration(candidate.isInternationalCollaboration())
+                                   .withCollaborationFactor(candidate.getCollaborationFactor())
+                                   .withCreatorShareCount(candidate.getCreatorShareCount())
+                                   .withInstitutionPoints(candidate.getInstitutionPoints())
+                                   .withTotalPoints(candidate.getTotalPoints());
+        if (nonNull(details.channelType())) {
+            candidateBuilder.withChannelType(details.channelType().getValue());
+        }
+        return candidateBuilder.build();
     }
 
     @Override

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.events.model;
 
-import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -9,10 +8,8 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.InstitutionPoints;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails;
-import no.sikt.nva.nvi.common.service.model.PublicationDetails.Creator;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
 
@@ -37,30 +34,6 @@ public record NviCandidate(URI publicationId,
         return new Builder();
     }
 
-    public static NviCandidate fromCandidate(Candidate candidate) {
-        var details = candidate.getPublicationDetails();
-        var candidateBuilder = NviCandidate.builder()
-                                   .withPublicationId(candidate.getPublicationId())
-                                   .withPublicationBucketUri(details.publicationBucketUri())
-                                   .withInstanceType(details.type())
-                                   .withDate(toPublicationDate(details.publicationDate()))
-                                   .withVerifiedCreators(details.creators().stream()
-                                                             .map(NviCandidate::mapToNviCreator)
-                                                             .toList())
-                                   .withPublicationChannelId(details.publicationChannelId())
-                                   .withLevel(details.level())
-                                   .withBasePoints(candidate.getBasePoints())
-                                   .withIsInternationalCollaboration(candidate.isInternationalCollaboration())
-                                   .withCollaborationFactor(candidate.getCollaborationFactor())
-                                   .withCreatorShareCount(candidate.getCreatorShareCount())
-                                   .withInstitutionPoints(candidate.getInstitutionPoints())
-                                   .withTotalPoints(candidate.getTotalPoints());
-        if (nonNull(details.channelType())) {
-            candidateBuilder.withChannelType(details.channelType().getValue());
-        }
-        return candidateBuilder.build();
-    }
-
     @Override
     public boolean isApplicable() {
         return true;
@@ -75,18 +48,6 @@ public record NviCandidate(URI publicationId,
     @Override
     public PublicationDetails.PublicationDate publicationDate() {
         return mapToPublicationDate(date);
-    }
-
-    private static NviCreator mapToNviCreator(Creator creator) {
-        return new NviCreator(creator.id(), creator.affiliations());
-    }
-
-    private static PublicationDate toPublicationDate(
-        no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate publicationDate) {
-        return new PublicationDate(
-            publicationDate.day(),
-            publicationDate.month(),
-            publicationDate.year());
     }
 
     private static PublicationDetails.PublicationDate mapToPublicationDate(

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.events.model;
 
+import static java.util.Objects.nonNull;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
@@ -47,7 +48,7 @@ public record NviCandidate(URI publicationId,
                    .withVerifiedCreators(details.creators().stream()
                                              .map(NviCandidate::mapToNviCreator)
                                              .toList())
-                   .withChannelType(details.channelType().getValue())
+                   .withChannelType(nonNull(details.channelType()) ? details.channelType().getValue() : null)
                    .withPublicationChannelId(details.publicationChannelId())
                    .withLevel(details.level())
                    .withBasePoints(candidate.getBasePoints())

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
@@ -166,7 +166,7 @@ public class RequeueDlqHandlerTest {
         assertEquals(1, getFailureCount(response));
 
         var error = response.messages().stream().filter(a -> !a.success()).findFirst().get().error().get();
-        assertTrue(error.contains("Exception"));
+        assertTrue(error.contains("Could not process message"));
     }
 
     @Test
@@ -201,14 +201,8 @@ public class RequeueDlqHandlerTest {
 
     @Test
     void shouldHandleFailureToWriteUpdatedCandidate() {
-        var candidate = createCandidateDao();
-
-        when(candidateRepository.findByPublicationId(any()))
-            .thenReturn(Optional.of(candidate))
-            .thenReturn(Optional.empty());
-
         when(candidateRepository.findCandidateById(any()))
-            .thenReturn(Optional.of(candidate));
+            .thenReturn(Optional.empty());
 
         when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
             .thenReturn(ReceiveMessageResponse.builder()

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerTest.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
+import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate.Builder;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints.DbCreatorAffiliationPoints;
@@ -47,6 +48,7 @@ public class RequeueDlqHandlerTest {
     private static final String DLQ_URL = "https://some-sqs-url";
     private RequeueDlqHandler handler;
     private SqsClient sqsClient;
+    private NviQueueClient client;
     private CandidateRepository candidateRepository;
     private PeriodRepository periodRepository;
 
@@ -54,7 +56,7 @@ public class RequeueDlqHandlerTest {
     void setUp() {
         sqsClient = setUpSqsClient();
 
-        var client = new NviQueueClient(sqsClient);
+        client = new NviQueueClient(sqsClient);
 
         candidateRepository = setupCandidateRepository();
 
@@ -223,6 +225,17 @@ public class RequeueDlqHandlerTest {
         assertEquals(10, input.count());
     }
 
+    @Test
+    void shouldHandleCandidateWithoutChannelType() {
+        // This is not a valid state for candidates created in nva-nvi, but it may occur for candidates imported via
+        // Cristin.
+        var handler = setupHandlerReceivingCandidateWithoutChannelType();
+
+        var response = handler.handleRequest(new RequeueDlqInput(1), CONTEXT);
+
+        assertEquals(0, response.failedBatchesCount());
+    }
+
     private static CandidateRepository setupCandidateRepository() {
         var repo = mock(CandidateRepository.class);
 
@@ -245,31 +258,41 @@ public class RequeueDlqHandlerTest {
         return response.messages().stream().filter(a -> !a.success()).count();
     }
 
-    private static CandidateDao createCandidateDao() {
-        var institutionId = randomUri();
-        var institutionPoints = BigDecimal.valueOf(1);
-        var creatorId = randomUri();
+    private static CandidateDao createCandidateDao(DbCandidate candidate) {
         return CandidateDao.builder()
                    .identifier(UUID.randomUUID())
-                   .candidate(DbCandidate.builder()
-                                  .publicationDate(
-                                      DbPublicationDate.builder()
-                                          .day("1")
-                                          .month("1")
-                                          .year("2000").build())
-                                  .points(
-                                      List.of(generateInstitutionPoints(institutionId, institutionPoints, creatorId)))
-                                  .instanceType(InstanceType.ACADEMIC_ARTICLE.getValue())
-                                  .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))))
-                                  .creators(List.of(new DbCreator(creatorId, List.of(institutionId))))
-                                  .level(DbLevel.LEVEL_ONE)
-                                  .channelType(ChannelType.JOURNAL)
-                                  .totalPoints(BigDecimal.valueOf(1))
-                                  .publicationId(randomUri())
-                                  .applicable(true)
-                                  .publicationBucketUri(randomUri())
-                                  .build())
+                   .candidate(candidate)
                    .build();
+    }
+
+    private static CandidateDao candidateMissingChannelType() {
+        var candidate = randomCandidateBuilder().channelType(null).build();
+        return createCandidateDao(candidate);
+    }
+
+    private static CandidateDao createCandidateDao() {
+        var candidate = randomCandidateBuilder().build();
+        return createCandidateDao(candidate);
+    }
+
+    private static Builder randomCandidateBuilder() {
+        return DbCandidate.builder()
+                   .publicationDate(
+                       DbPublicationDate.builder()
+                           .day("1")
+                           .month("1")
+                           .year("2000").build())
+                   .points(
+                       List.of(generateInstitutionPoints(randomUri(), BigDecimal.ONE, randomUri())))
+                   .instanceType(InstanceType.ACADEMIC_ARTICLE.getValue())
+                   .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))))
+                   .creators(List.of(new DbCreator(randomUri(), List.of(randomUri()))))
+                   .level(DbLevel.LEVEL_ONE)
+                   .channelType(ChannelType.JOURNAL)
+                   .totalPoints(BigDecimal.valueOf(1))
+                   .publicationId(randomUri())
+                   .applicable(true)
+                   .publicationBucketUri(randomUri());
     }
 
     private static DbInstitutionPoints generateInstitutionPoints(URI institutionId, BigDecimal institutionPoints,
@@ -288,5 +311,17 @@ public class RequeueDlqHandlerTest {
                                                                                BigDecimal institutionPoints,
                                                                                URI creatorId) {
         return new DbCreatorAffiliationPoints(creatorId, institutionId, institutionPoints);
+    }
+
+    private RequeueDlqHandler setupHandlerReceivingCandidateWithoutChannelType() {
+        var repo = mock(CandidateRepository.class);
+        var candidate = candidateMissingChannelType();
+        when(repo.findByPublicationId(any())).thenReturn(Optional.of(candidate));
+        when(repo.findCandidateById(any())).thenReturn(Optional.of(candidate));
+        when(sqsClient.receiveMessage(any(ReceiveMessageRequest.class)))
+            .thenReturn(ReceiveMessageResponse.builder().messages(generateMessages(1, "firstBatch")).build())
+            .thenReturn(ReceiveMessageResponse.builder().messages(List.of()).build());
+        var handler = new RequeueDlqHandler(client, DLQ_URL, repo, periodRepository);
+        return handler;
     }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerWithLocalDynamoTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerWithLocalDynamoTest.java
@@ -5,6 +5,7 @@ import static no.sikt.nva.nvi.events.batch.RequeueDlqTestUtils.setUpSqsClient;
 import static no.sikt.nva.nvi.test.TestUtils.createCandidateDao;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidateWithYear;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -53,6 +54,7 @@ public class RequeueDlqHandlerWithLocalDynamoTest extends LocalDynamoTest {
         handler = new RequeueDlqHandler(client, DLQ_URL, candidateRepository, periodRepository);
         handler.handleRequest(new RequeueDlqInput(1), CONTEXT);
         var actualCandidate = candidateRepository.findCandidateById(expectedCandidate.identifier()).orElseThrow();
-        assertEquals(expectedCandidate, actualCandidate);
+        assertEquals(expectedCandidate.identifier(), actualCandidate.identifier());
+        assertEquals(expectedCandidate.candidate(), actualCandidate.candidate());
     }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -197,7 +197,6 @@ public final class CandidateDao extends Dao {
     public boolean isNotReported() {
         return !isReported();
     }
-
     @Deprecated
     private String migratePeriodYear() {
         return isApplicableAndMissingPeriodYear() ? candidate.publicationDate().year() : periodYear;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -333,6 +333,18 @@ public final class Candidate {
         return publicationDetails.getNviCreatorAffiliations();
     }
 
+    public void updateVersion(CandidateRepository candidateRepository) {
+        candidateRepository.findCandidateById(identifier)
+            .map(candidateDao -> updateVersion(candidateRepository, candidateDao))
+            .orElseThrow(CandidateNotFoundException::new);
+    }
+
+    private static CandidateDao updateVersion(CandidateRepository candidateRepository, CandidateDao candidateDao) {
+        var candidateWithNewVersion = candidateDao.copy().version(randomUUID().toString()).build();
+        candidateRepository.updateCandidate(candidateWithNewVersion);
+        return candidateWithNewVersion;
+    }
+
     private static boolean isNotExistingCandidate(UpsertCandidateRequest request, CandidateRepository repository) {
         return !isExistingCandidate(request.publicationId(), repository);
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -116,11 +116,6 @@ class CandidateTest extends LocalDynamoTest {
                                                                                randomUri()))));
     }
 
-    @Deprecated
-    public static Stream<Arguments> levelValues() {
-        return Stream.of(Arguments.of(DbLevel.LEVEL_ONE, "LevelOne"), Arguments.of(DbLevel.LEVEL_TWO, "LevelTwo"));
-    }
-
     @BeforeEach
     void setup() {
         localDynamo = initializeTestDatabase();
@@ -216,6 +211,11 @@ class CandidateTest extends LocalDynamoTest {
                                            .orElseThrow()
                                            .candidate();
         assertEquals(expectedCreatedDate, actualPersistedCandidate.createdDate());
+    }
+
+    @Test
+    void shouldNotUpdateReportedCandidate() {
+        var request = getUpdateRequestForExistingCandidate();
     }
 
     @Test
@@ -550,6 +550,11 @@ class CandidateTest extends LocalDynamoTest {
                                              List.of(randomApproval()));
         var candidate = Candidate.fetch(dao::identifier, candidateRepository, periodRepository);
         assertEquals(List.of(creator1affiliation, creator2affiliation), candidate.getNviCreatorAffiliations());
+    }
+
+    @Deprecated
+    private static Stream<Arguments> levelValues() {
+        return Stream.of(Arguments.of(DbLevel.LEVEL_ONE, "LevelOne"), Arguments.of(DbLevel.LEVEL_TWO, "LevelTwo"));
     }
 
     private static InstitutionPoints createInstitutionPoints(URI institutionId, BigDecimal institutionPoints,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -552,6 +552,21 @@ class CandidateTest extends LocalDynamoTest {
         assertEquals(List.of(creator1affiliation, creator2affiliation), candidate.getNviCreatorAffiliations());
     }
 
+    @Test
+    void shouldUpdateVersion() {
+        var candidate = Candidate.upsert(createUpsertCandidateRequest(randomUri()), candidateRepository,
+                                         periodRepository).orElseThrow();
+        var dao = candidateRepository.findCandidateById(candidate.getIdentifier()).orElseThrow();
+
+        candidate.updateVersion(candidateRepository);
+
+        var updatedCandidate = Candidate.fetch(candidate::getIdentifier, candidateRepository, periodRepository);
+        var updatedDao = candidateRepository.findCandidateById(candidate.getIdentifier()).orElseThrow();
+
+        assertEquals(candidate, updatedCandidate);
+        assertNotEquals(dao.version(), updatedDao.version());
+    }
+
     @Deprecated
     private static Stream<Arguments> levelValues() {
         return Stream.of(Arguments.of(DbLevel.LEVEL_ONE, "LevelOne"), Arguments.of(DbLevel.LEVEL_TWO, "LevelTwo"));
@@ -642,6 +657,11 @@ class CandidateTest extends LocalDynamoTest {
                                             createPoints(creators),
                                             randomInteger(), false,
                                             TestUtils.randomBigDecimal(), null, randomBigDecimal());
+    }
+
+    private UpsertCandidateRequest getRandomUpsertCandidateRequest() {
+        return getUpsertCandidateRequest(randomUri(), randomUri(), randomString(),
+                                         randomLevelExcluding(DbLevel.NON_CANDIDATE));
     }
 
     private UpsertCandidateRequest getUpsertCandidateRequest(URI creatorId, URI institutionId,


### PR DESCRIPTION
`ReQueueDlqHandler` failing to requeue candidates imported from Cristin missing `channelType` (`NullpointerException`)