### PR TITLE
Np 47563 Index document: Extract nvi contributors in separate field

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.nvi.index.model.document;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
 
@@ -11,6 +10,7 @@ public record PublicationDetails(String id,
                                  String type,
                                  String title,
                                  PublicationDate publicationDate,
+                                 List<NviContributor> nviContributors,
                                  List<ContributorType> contributors,
                                  PublicationChannel publicationChannel,
                                  Pages pages,
@@ -20,20 +20,13 @@ public record PublicationDetails(String id,
         return new Builder();
     }
 
-    @JsonIgnore
-    public List<NviContributor> nviContributors() {
-        return contributors.stream()
-                   .filter(NviContributor.class::isInstance)
-                   .map(NviContributor.class::cast)
-                   .toList();
-    }
-
     public static final class Builder {
 
         private String id;
         private String type;
         private String title;
         private PublicationDate publicationDate;
+        private List<NviContributor> nviContributors;
         private List<ContributorType> contributors;
         private PublicationChannel publicationChannel;
         private Pages pages;
@@ -64,6 +57,10 @@ public record PublicationDetails(String id,
 
         public Builder withContributors(List<ContributorType> contributors) {
             this.contributors = contributors;
+            this.nviContributors = contributors.stream()
+                                       .filter(NviContributor.class::isInstance)
+                                       .map(NviContributor.class::cast)
+                                       .toList();
             return this;
         }
 
@@ -83,8 +80,8 @@ public record PublicationDetails(String id,
         }
 
         public PublicationDetails build() {
-            return new PublicationDetails(id, type, title, publicationDate, contributors, publicationChannel, pages,
-                                          language);
+            return new PublicationDetails(id, type, title, publicationDate, nviContributors, contributors,
+                                          publicationChannel, pages, language);
         }
     }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -142,15 +144,15 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     void shouldExtractNviContributorsInSeparateList() {
         var candidate = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(candidate).indexDocument();
-        var event = createEvent(candidate.getIdentifier());
         mockUriRetrieverOrgResponse(candidate);
 
-        handler.handleRequest(event, CONTEXT);
+        handler.handleRequest(createEvent(candidate.getIdentifier()), CONTEXT);
 
-        var actualContributors =
+        var actualNviContributors =
             parseJson(s3Writer.getFile(createPath(candidate))).indexDocument().publicationDetails().nviContributors();
         var expectedNviContributors = expectedIndexDocument.getNviContributors();
-        assertEquals(expectedNviContributors, actualContributors);
+        assertEquals(expectedNviContributors, actualNviContributors);
+        assertNotEquals(expectedIndexDocument.publicationDetails().contributors(), actualNviContributors);
     }
 
     @Test

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -37,6 +37,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.time.Year;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -63,7 +64,6 @@ import nva.commons.apigateway.GatewayResponse;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
-import nva.commons.logutils.LogUtils;
 import org.hamcrest.Matchers;
 import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
@@ -467,9 +467,12 @@ public class SearchNviCandidatesHandlerTest {
     }
 
     private static PublicationDetails randomPublicationDetails() {
-        return new PublicationDetails(randomString(), randomString(), randomString(),
-                                      PublicationDate.builder().withYear(randomString()).build(), List.of(),
-                                      randomPublicationChannel(), randomPages(), randomString());
+        return PublicationDetails.builder()
+                   .withTitle(randomString())
+                   .withPublicationDate(PublicationDate.builder().withYear(Year.now().toString()).build())
+                   .withPublicationChannel(randomPublicationChannel())
+                   .withPages(randomPages())
+                   .build();
     }
 
     private static InputStream createRequest(URI topLevelCristinOrgId, Map<String, String> queryParams, String userName)

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -55,7 +55,6 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
-import no.sikt.nva.nvi.index.query.CandidateQuery.QueryFilterType;
 import no.sikt.nva.nvi.index.model.document.Approval;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.document.InstitutionPoints;
@@ -67,9 +66,9 @@ import no.sikt.nva.nvi.index.model.document.PublicationDate;
 import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.search.OrderByFields;
-import no.sikt.nva.nvi.index.query.SearchAggregation;
 import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
-import no.sikt.nva.nvi.test.IndexDocumentTestUtils;
+import no.sikt.nva.nvi.index.query.CandidateQuery.QueryFilterType;
+import no.sikt.nva.nvi.index.query.SearchAggregation;
 import no.unit.nva.auth.CachedJwtProvider;
 import no.unit.nva.auth.CognitoAuthenticator;
 import nva.commons.core.ioutils.IoUtils;
@@ -711,10 +710,13 @@ public class OpenSearchClientTest {
         if (contributor != null) {
             contributorBuilder.withName(contributor);
         }
-        return new PublicationDetails(randomString(), randomString(), title,
-                                      publicationDate,
-                                      List.of(contributorBuilder.build()),
-                                      randomPublicationChannel(), randomPages(), randomString());
+        return PublicationDetails.builder()
+                   .withTitle(title)
+                   .withPublicationDate(publicationDate)
+                   .withContributors(List.of(contributorBuilder.build()))
+                   .withPublicationChannel(randomPublicationChannel())
+                   .withPages(randomPages())
+                   .build();
     }
 
     private static Approval randomApprovalWithCustomerAndAssignee(URI affiliation, String assignee) {
@@ -751,9 +753,12 @@ public class OpenSearchClientTest {
     }
 
     private static PublicationDetails randomPublicationDetails() {
-        return new PublicationDetails(randomString(), randomString(), randomString(),
-                                      PublicationDate.builder().withYear(YEAR).build(),
-                                      List.of(), randomPublicationChannel(), randomPages(), randomString());
+        return PublicationDetails.builder()
+                   .withTitle(randomString())
+                   .withPublicationDate(PublicationDate.builder().withYear(YEAR).build())
+                   .withPublicationChannel(randomPublicationChannel())
+                   .withPages(randomPages())
+                   .build();
     }
 
     private static void addDocumentsToIndex(NviCandidateIndexDocument... documents) throws InterruptedException {


### PR DESCRIPTION
Jira task: NP-47560 Export to NVI-kontrolldata optimization: exclude non-nvi-contributors from search response

Part one:
- Index document: Extract nvi contributors (type NviContributor) in separate list