### PR TITLE
Np 47564 source exclude non nvi contributors

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -12,13 +12,14 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.time.Clock;
+import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
 import no.sikt.nva.nvi.common.model.UsernamePasswordWrapper;
-import no.sikt.nva.nvi.index.query.Aggregations;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
+import no.sikt.nva.nvi.index.query.Aggregations;
 import no.sikt.nva.nvi.index.utils.SearchConstants;
 import no.unit.nva.auth.CachedJwtProvider;
 import no.unit.nva.auth.CachedValueProvider;
@@ -40,6 +41,8 @@ import org.opensearch.client.opensearch.core.IndexRequest;
 import org.opensearch.client.opensearch.core.IndexResponse;
 import org.opensearch.client.opensearch.core.SearchRequest;
 import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.SourceConfig;
+import org.opensearch.client.opensearch.core.search.SourceFilter;
 import org.opensearch.client.opensearch.indices.CreateIndexRequest;
 import org.opensearch.client.opensearch.indices.DeleteIndexRequest;
 import org.opensearch.client.opensearch.indices.GetIndexRequest;
@@ -190,6 +193,16 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
         return builder -> builder.field(resultParameters.orderBy()).order(getSortOrder(resultParameters.sortOrder()));
     }
 
+    private static SourceConfig getSourceConfig(CandidateSearchParameters parameters) {
+        var filterBuilderFunction = getBuilderObjectBuilderFunction(parameters.excludeFields());
+        return SourceConfig.of(sourceConfigBuilder -> sourceConfigBuilder.filter(filterBuilderFunction));
+    }
+
+    private static Function<SourceFilter.Builder, ObjectBuilder<SourceFilter>> getBuilderObjectBuilderFunction(
+        List<String> excludeFields) {
+        return filterBuilder -> filterBuilder.excludes(excludeFields);
+    }
+
     private static SortOrder getSortOrder(String sortOrder) {
         return SortOrder.Asc.jsonValue().equalsIgnoreCase(sortOrder) ? SortOrder.Asc : SortOrder.Desc;
     }
@@ -207,6 +220,7 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
         var query = SearchConstants.constructQuery(parameters);
         var resultParameters = parameters.searchResultParameters();
         var sortOptions = getSortOptions(parameters);
+        var sourceConfig = getSourceConfig(parameters);
         return new SearchRequest.Builder()
                    .index(NVI_CANDIDATES_INDEX)
                    .query(query)
@@ -216,6 +230,7 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
                                                                    parameters.topLevelOrgUriAsString()))
                    .from(resultParameters.offset())
                    .size(resultParameters.size())
+                   .source(sourceConfig)
                    .build();
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -194,11 +194,11 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
     }
 
     private static SourceConfig getSourceConfig(CandidateSearchParameters parameters) {
-        var filterBuilderFunction = getBuilderObjectBuilderFunction(parameters.excludeFields());
+        var filterBuilderFunction = getFilterBuilderFunction(parameters.excludeFields());
         return SourceConfig.of(sourceConfigBuilder -> sourceConfigBuilder.filter(filterBuilderFunction));
     }
 
-    private static Function<SourceFilter.Builder, ObjectBuilder<SourceFilter>> getBuilderObjectBuilderFunction(
+    private static Function<SourceFilter.Builder, ObjectBuilder<SourceFilter>> getFilterBuilderFunction(
         List<String> excludeFields) {
         return filterBuilder -> filterBuilder.excludes(excludeFields);
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/aws/OpenSearchClient.java
@@ -193,7 +193,7 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
         return builder -> builder.field(resultParameters.orderBy()).order(getSortOrder(resultParameters.sortOrder()));
     }
 
-    private static SourceConfig getSourceConfig(CandidateSearchParameters parameters) {
+    private static SourceConfig getSourceConfigWithExcludedFields(CandidateSearchParameters parameters) {
         var filterBuilderFunction = getFilterBuilderFunction(parameters.excludeFields());
         return SourceConfig.of(sourceConfigBuilder -> sourceConfigBuilder.filter(filterBuilderFunction));
     }
@@ -220,7 +220,7 @@ public class OpenSearchClient implements SearchClient<NviCandidateIndexDocument>
         var query = SearchConstants.constructQuery(parameters);
         var resultParameters = parameters.searchResultParameters();
         var sortOptions = getSortOptions(parameters);
-        var sourceConfig = getSourceConfig(parameters);
+        var sourceConfig = getSourceConfigWithExcludedFields(parameters);
         return new SearchRequest.Builder()
                    .index(NVI_CANDIDATES_INDEX)
                    .query(query)

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -16,6 +16,7 @@ import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_SIZ
 import static no.sikt.nva.nvi.index.model.search.SearchResultParameters.DEFAULT_SORT_ORDER;
 import java.net.URI;
 import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import no.unit.nva.commons.json.JsonSerializable;
@@ -158,7 +159,7 @@ public record CandidateSearchParameters(String searchTerm,
         private String assignee;
         private URI topLevelCristinOrg;
         private String aggregationType;
-        private List<String> excludeFields;
+        private List<String> excludeFields = new ArrayList<>();
         private SearchResultParameters searchResultParameters = SearchResultParameters.builder().build();
 
         private Builder() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -36,7 +36,7 @@ public record CandidateSearchParameters(String searchTerm,
                                         String assignee,
                                         URI topLevelCristinOrg,
                                         String aggregationType,
-                                        String[] excludeFields,
+                                        List<String> excludeFields,
                                         SearchResultParameters searchResultParameters) implements JsonSerializable {
 
     public static final String DEFAULT_AGGREGATION_TYPE = "all";
@@ -158,7 +158,7 @@ public record CandidateSearchParameters(String searchTerm,
         private String assignee;
         private URI topLevelCristinOrg;
         private String aggregationType;
-        private String[] excludeFields;
+        private List<String> excludeFields;
         private SearchResultParameters searchResultParameters = SearchResultParameters.builder().build();
 
         private Builder() {
@@ -223,7 +223,7 @@ public record CandidateSearchParameters(String searchTerm,
             return this;
         }
 
-        public Builder withExcludeFields(String[] excludeFields) {
+        public Builder withExcludeFields(List<String> excludeFields) {
             this.excludeFields = excludeFields;
             return this;
         }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.index.model.search;
 
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_AGGREGATION_TYPE;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_OFFSET_PARAM;
-import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_AFFILIATIONS;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_ASSIGNEE;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_CATEGORY;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_CONTRIBUTOR;
@@ -15,19 +14,15 @@ import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PAR
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_YEAR;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_SIZE_PARAM;
 import static no.sikt.nva.nvi.index.model.search.SearchResultParameters.DEFAULT_SORT_ORDER;
-import static nva.commons.apigateway.RestRequestHandler.COMMA;
 import java.net.URI;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import no.unit.nva.commons.json.JsonSerializable;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.BadRequestException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.StringUtils;
-import nva.commons.core.paths.UriWrapper;
 
 public record CandidateSearchParameters(String searchTerm,
                                         List<String> affiliationIdentifiers,
@@ -41,6 +36,7 @@ public record CandidateSearchParameters(String searchTerm,
                                         String assignee,
                                         URI topLevelCristinOrg,
                                         String aggregationType,
+                                        String[] excludeFields,
                                         SearchResultParameters searchResultParameters) implements JsonSerializable {
 
     public static final String DEFAULT_AGGREGATION_TYPE = "all";
@@ -151,7 +147,7 @@ public record CandidateSearchParameters(String searchTerm,
     public static final class Builder {
 
         private String searchTerm;
-        private List<String> affiliations;
+        private List<String> affiliationIdentifiers;
         private boolean excludeSubUnits;
         private String filter;
         private String username;
@@ -162,18 +158,18 @@ public record CandidateSearchParameters(String searchTerm,
         private String assignee;
         private URI topLevelCristinOrg;
         private String aggregationType;
+        private String[] excludeFields;
         private SearchResultParameters searchResultParameters = SearchResultParameters.builder().build();
 
         private Builder() {
         }
-
         public Builder withSearchTerm(String searchTerm) {
             this.searchTerm = searchTerm;
             return this;
         }
 
-        public Builder withAffiliations(List<String> affiliations) {
-            this.affiliations = affiliations;
+        public Builder withAffiliations(List<String> affiliationIdentifiers) {
+            this.affiliationIdentifiers = affiliationIdentifiers;
             return this;
         }
 
@@ -227,15 +223,20 @@ public record CandidateSearchParameters(String searchTerm,
             return this;
         }
 
+        public Builder withExcludeFields(String[] excludeFields) {
+            this.excludeFields = excludeFields;
+            return this;
+        }
+
         public Builder withSearchResultParameters(SearchResultParameters searchResultParameters) {
             this.searchResultParameters = searchResultParameters;
             return this;
         }
 
         public CandidateSearchParameters build() {
-            return new CandidateSearchParameters(searchTerm, affiliations, excludeSubUnits, filter, username, year,
-                                                 category, title, contributor, assignee, topLevelCristinOrg,
-                                                 aggregationType, searchResultParameters);
+            return new CandidateSearchParameters(searchTerm, affiliationIdentifiers, excludeSubUnits, filter, username,
+                                                 year, category, title, contributor, assignee, topLevelCristinOrg,
+                                                 aggregationType, excludeFields, searchResultParameters);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -24,6 +24,7 @@ public class InstitutionReportGenerator {
 
     private static final Logger logger = LoggerFactory.getLogger(InstitutionReportGenerator.class);
     private static final int INITIAL_OFFSET = 0;
+    private static final String EXCLUDE_CONTRIBUTORS_FIELD = "publicationDetails.contributors";
     private final SearchClient<NviCandidateIndexDocument> searchClient;
     private final int searchPageSize;
     private final String year;
@@ -103,6 +104,7 @@ public class InstitutionReportGenerator {
                    .withTopLevelCristinOrg(topLevelOrganization)
                    .withAffiliations(List.of(topLevelOrganizationIdentifier))
                    .withSearchResultParameters(getSearchRequestParameters(offset))
+                   .withExcludeFields(List.of(EXCLUDE_CONTRIBUTORS_FIELD))
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -111,6 +111,7 @@ public class FetchInstitutionReportHandlerTest {
     private static final Context CONTEXT = mock(Context.class);
     private static final int PAGE_SIZE = Integer.parseInt(new Environment().readEnv(
         "INSTITUTION_REPORT_SEARCH_PAGE_SIZE"));
+    private static final String NESTED_FIELD_CONTRIBUTORS = "publicationDetails.contributors";
     private static SearchClient<NviCandidateIndexDocument> openSearchClient;
     private ByteArrayOutputStream output;
     private FetchInstitutionReportHandler handler;
@@ -235,6 +236,26 @@ public class FetchInstitutionReportHandlerTest {
                                            .withAffiliations(List.of(extractIdentifier(topLevelCristinOrg)))
                                            .withSearchResultParameters(
                                                SearchResultParameters.builder().withSize(PAGE_SIZE).build())
+                                           .withExcludeFields(List.of(NESTED_FIELD_CONTRIBUTORS))
+                                           .build();
+        verify(openSearchClient).search(eq(expectedSearchParameters));
+    }
+
+    @Test
+    void shouldExcludeNonNviContributorsFromSearch() throws IOException {
+        var topLevelCristinOrg = randomCristinOrgUri();
+        var year = "2021";
+        var request = createRequest(topLevelCristinOrg, MANAGE_NVI_CANDIDATES, topLevelCristinOrg,
+                                    Map.of(YEAR, year)).build();
+        handler.handleRequest(request, output, CONTEXT);
+
+        var expectedSearchParameters = CandidateSearchParameters.builder()
+                                           .withYear(year)
+                                           .withTopLevelCristinOrg(topLevelCristinOrg)
+                                           .withAffiliations(List.of(extractIdentifier(topLevelCristinOrg)))
+                                           .withSearchResultParameters(
+                                               SearchResultParameters.builder().withSize(PAGE_SIZE).build())
+                                           .withExcludeFields(List.of("publicationDetails.contributors"))
                                            .build();
         verify(openSearchClient).search(eq(expectedSearchParameters));
     }
@@ -338,6 +359,7 @@ public class FetchInstitutionReportHandlerTest {
                    .withTopLevelCristinOrg(topLevelCristinOrg)
                    .withAffiliations(List.of(extractIdentifier(topLevelCristinOrg)))
                    .withSearchResultParameters(resultParameters)
+                   .withExcludeFields(List.of(NESTED_FIELD_CONTRIBUTORS))
                    .build();
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.index.aws;
 
+import static java.util.Objects.requireNonNull;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.PENDING;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.REJECTED;
@@ -188,8 +189,8 @@ public class OpenSearchClientTest {
         var hits = searchResponse.hits().hits();
         var expectedFirst = sortOrder.equals("asc") ? createdFirst.createdDate() : createdSecond.createdDate();
         var expectedSecond = sortOrder.equals("asc") ? createdSecond.createdDate() : createdFirst.createdDate();
-        assertThat(hits.get(0).source().createdDate(), is(equalTo(expectedFirst)));
-        assertThat(hits.get(1).source().createdDate(), is(equalTo(expectedSecond)));
+        assertThat(requireNonNull(hits.get(0).source()).createdDate(), is(equalTo(expectedFirst)));
+        assertThat(requireNonNull(hits.get(1).source()).createdDate(), is(equalTo(expectedSecond)));
     }
 
     @Test
@@ -360,10 +361,10 @@ public class OpenSearchClientTest {
 
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
-        assertTrue(searchResponse.hits()
-                       .hits()
-                       .get(0)
-                       .source()
+        assertTrue(requireNonNull(searchResponse.hits()
+                                      .hits()
+                                      .get(0)
+                                      .source())
                        .approvals()
                        .stream()
                        .anyMatch(approval -> approval.institutionId().equals(searchParameters.topLevelCristinOrg())));
@@ -586,7 +587,7 @@ public class OpenSearchClientTest {
                                    .build();
         var searchResponse = openSearchClient.search(searchParameters);
         var firstHit = searchResponse.hits().hits().get(0).source();
-        assertNull(firstHit.publicationDetails().contributors());
+        assertNull(requireNonNull(firstHit).publicationDetails().contributors());
     }
 
     private static NviCandidateIndexDocument documentWithContributors() {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -28,6 +28,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNot.not;
+import static org.junit.Assert.assertNull;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,6 +44,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -575,7 +577,18 @@ public class OpenSearchClientTest {
         assertThat(orgIds, not(containsInAnyOrder(NTNU_INSTITUTION_ID.toString())));
     }
 
-    @NotNull
+    @Test
+    void shouldExcludeFields() throws IOException, InterruptedException {
+        var document = singleNviCandidateIndexDocument().build();
+        addDocumentsToIndex(document);
+        var searchParameters = defaultSearchParameters()
+                                   .withExcludeFields(new String[]{"points"})
+                                   .build();
+        var searchResponse = openSearchClient.search(searchParameters);
+        var hits = searchResponse.hits().hits();
+        assertNull(hits.get(0).source().points());
+    }
+
     private static String getLastPathElement(URI customer) {
         return UriWrapper.fromUri(customer).getLastPathElement();
     }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -127,7 +127,8 @@ public final class IndexDocumentTestUtils {
         return getBuilder(year, approvals, publicationDetails).build();
     }
 
-    public static NviCandidateIndexDocument indexDocumentWithLanguage(int currentYear, URI topLevelCristinOrg, String languageUri) {
+    public static NviCandidateIndexDocument indexDocumentWithLanguage(int currentYear, URI topLevelCristinOrg,
+                                                                      String languageUri) {
         var publicationDetails = publicationDetailsWithNviContributorsAffiliatedWith(topLevelCristinOrg)
                                      .withLanguage(languageUri)
                                      .build();
@@ -180,6 +181,20 @@ public final class IndexDocumentTestUtils {
                    .withBegin(randomString())
                    .withEnd(randomString())
                    .withNumberOfPages(randomString())
+                   .build();
+    }
+
+    public static NviContributor randomNviContributor(URI institutionId) {
+        return NviContributor.builder()
+                   .withId(randomUri().toString())
+                   .withName(randomString())
+                   .withOrcid(randomString())
+                   .withRole(randomString())
+                   .withAffiliations(List.of(
+                       randomSubUnitNviAffiliation(institutionId),
+                       nviOrganization(institutionId),
+                       nviOrganization(randomUri()),
+                       randomNonNviAffiliation()))
                    .build();
     }
 
@@ -421,23 +436,9 @@ public final class IndexDocumentTestUtils {
                    .withId(randomUri().toString())
                    .withTitle(randomString())
                    .withPublicationDate(randomPublicationDate())
-                   .withContributors(List.of(randomContributor(institutionId), randomContributor(institutionId)))
+                   .withContributors(List.of(randomNviContributor(institutionId), randomNviContributor(institutionId)))
                    .withPublicationChannel(randomPublicationChannel())
                    .withPages(randomPages());
-    }
-
-    private static NviContributor randomContributor(URI institutionId) {
-        return NviContributor.builder()
-                   .withId(randomUri().toString())
-                   .withName(randomString())
-                   .withOrcid(randomString())
-                   .withRole(randomString())
-                   .withAffiliations(List.of(
-                       randomSubUnitNviAffiliation(institutionId),
-                       nviOrganization(institutionId),
-                       nviOrganization(randomUri()),
-                       randomNonNviAffiliation()))
-                   .build();
     }
 
     private static NviOrganization nviOrganization(URI id) {


### PR DESCRIPTION
Jira task: Export to NVI-kontrolldata optimization: exclude non-nvi-contributors from search response

Change:
- Add list of excludeFields in search parameters, use this to set `SourceConfig` in search request
- In `InstitutionReportGenerator`: exclude `publicationDetails.contributors` in search request