### PR TITLE
Np 47460 fix collaboration aggregations

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -9,7 +9,7 @@ import static no.sikt.nva.nvi.index.utils.AggregationFunctions.nestedAggregation
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.sumAggregation;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.termsAggregation;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.assignmentsQuery;
-import static no.sikt.nva.nvi.index.utils.QueryFunctions.containsPendingStatusQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.containsNonFinalizedStatusQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.fieldValueQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.isNotDisputeQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.multipleApprovalsQuery;
@@ -97,7 +97,7 @@ public final class Aggregations {
     }
 
     public static Aggregation finalizedCollaborationAggregation(String topLevelCristinOrg, ApprovalStatus status) {
-        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status), containsPendingStatusQuery(),
+        return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status), containsNonFinalizedStatusQuery(),
                                            multipleApprovalsQuery()));
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -7,7 +7,7 @@ import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.PENDING;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.REJECTED;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.assignmentsQuery;
-import static no.sikt.nva.nvi.index.utils.QueryFunctions.containsPendingStatusQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.containsNonFinalizedStatusQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.disputeQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.fieldValueQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.matchAtLeastOne;
@@ -151,13 +151,13 @@ public class CandidateQuery {
             case APPROVED_AGG -> mustMatch(statusQuery(topLevelCristinOrg, APPROVED));
 
             case APPROVED_COLLABORATION_AGG -> mustMatch(statusQuery(topLevelCristinOrg, APPROVED),
-                                                         containsPendingStatusQuery(),
+                                                         containsNonFinalizedStatusQuery(),
                                                          multipleApprovalsQuery());
 
             case REJECTED_AGG -> mustMatch(statusQuery(topLevelCristinOrg, REJECTED));
 
             case REJECTED_COLLABORATION_AGG -> mustMatch(statusQuery(topLevelCristinOrg, REJECTED),
-                                                         containsPendingStatusQuery(),
+                                                         containsNonFinalizedStatusQuery(),
                                                          multipleApprovalsQuery());
 
             case DISPUTED_AGG -> mustMatch(disputeQuery(), institutionQuery(topLevelCristinOrg));

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.index.utils;
 
 import static java.util.Objects.nonNull;
+import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.PENDING;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVALS;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVAL_STATUS;
@@ -95,8 +96,8 @@ public final class QueryFunctions {
                    .build()._toQuery();
     }
 
-    public static Query containsPendingStatusQuery() {
-        return nestedQuery(APPROVALS, fieldValueQuery(jsonPathOf(APPROVALS, APPROVAL_STATUS), PENDING.getValue()));
+    public static Query containsNonFinalizedStatusQuery() {
+        return matchAtLeastOne(containsStatusPendingQuery(), containsStatusNewQuery());
     }
 
     public static Query statusQuery(String customer, ApprovalStatus status) {
@@ -122,6 +123,14 @@ public final class QueryFunctions {
         return nestedQuery(APPROVALS,
                            fieldValueQuery(jsonPathOf(APPROVALS, INSTITUTION_ID), customer),
                            fieldValueQuery(jsonPathOf(APPROVALS, ASSIGNEE), username));
+    }
+
+    private static Query containsStatusPendingQuery() {
+        return nestedQuery(APPROVALS, fieldValueQuery(jsonPathOf(APPROVALS, APPROVAL_STATUS), PENDING.getValue()));
+    }
+
+    private static Query containsStatusNewQuery() {
+        return nestedQuery(APPROVALS, fieldValueQuery(jsonPathOf(APPROVALS, APPROVAL_STATUS), NEW.getValue()));
     }
 
     private static Query matchAllQuery() {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -233,9 +233,11 @@ public class OpenSearchClientTest {
                             documentFromString("document_pending.json"),
                             documentFromString("document_pending_collaboration.json"),
                             documentFromString("document_approved.json"),
-                            documentFromString("document_approved_collaboration.json"),
+                            documentFromString("document_approved_collaboration_pending.json"),
+                            documentFromString("document_approved_collaboration_new.json"),
                             documentFromString("document_rejected.json"),
-                            documentFromString("document_rejected_collaboration.json"),
+                            documentFromString("document_rejected_collaboration_pending.json"),
+                            documentFromString("document_rejected_collaboration_new.json"),
                             documentFromString("document_organization_aggregation_dispute.json"));
 
         var searchParameters = defaultSearchParameters().build();
@@ -337,9 +339,11 @@ public class OpenSearchClientTest {
                             documentFromString("document_pending.json"),
                             documentFromString("document_pending_collaboration.json"),
                             documentFromString("document_approved.json"),
-                            documentFromString("document_approved_collaboration.json"),
+                            documentFromString("document_approved_collaboration_pending.json"),
+                            documentFromString("document_approved_collaboration_new.json"),
                             documentFromString("document_rejected.json"),
-                            documentFromString("document_rejected_collaboration.json"),
+                            documentFromString("document_rejected_collaboration_pending.json"),
+                            documentFromString("document_rejected_collaboration_new.json"),
                             documentFromString("document_organization_aggregation_dispute.json"));
 
         var searchParameters =
@@ -488,9 +492,11 @@ public class OpenSearchClientTest {
                             documentFromString("document_pending.json"),
                             documentFromString("document_pending_collaboration.json"),
                             documentFromString("document_approved.json"),
-                            documentFromString("document_approved_collaboration.json"),
+                            documentFromString("document_approved_collaboration_pending.json"),
+                            documentFromString("document_approved_collaboration_new.json"),
                             documentFromString("document_rejected.json"),
-                            documentFromString("document_rejected_collaboration.json"),
+                            documentFromString("document_rejected_collaboration_pending.json"),
+                            documentFromString("document_rejected_collaboration_new.json"),
                             documentFromString("document_organization_aggregation_dispute.json"));
 
         var searchParameters =
@@ -796,10 +802,10 @@ public class OpenSearchClientTest {
         map.put(NEW_COLLABORATION_AGG.getAggregationName(), 1);
         map.put(PENDING_AGG.getAggregationName(), 2);
         map.put(PENDING_COLLABORATION_AGG.getAggregationName(), 1);
-        map.put(APPROVED_AGG.getAggregationName(), 2);
-        map.put(APPROVED_COLLABORATION_AGG.getAggregationName(), 1);
-        map.put(REJECTED_AGG.getAggregationName(), 2);
-        map.put(REJECTED_COLLABORATION_AGG.getAggregationName(), 1);
+        map.put(APPROVED_AGG.getAggregationName(), 3);
+        map.put(APPROVED_COLLABORATION_AGG.getAggregationName(), 2);
+        map.put(REJECTED_AGG.getAggregationName(), 3);
+        map.put(REJECTED_COLLABORATION_AGG.getAggregationName(), 2);
         map.put(DISPUTED_AGG.getAggregationName(), 1);
         map.put(ASSIGNMENTS_AGG.getAggregationName(), 5);
         map.put(COMPLETED_AGGREGATION_AGG.getAggregationName(), 5);
@@ -813,10 +819,10 @@ public class OpenSearchClientTest {
         map.put(QueryFilterType.NEW_COLLABORATION_AGG.getFilter(), 1);
         map.put(QueryFilterType.PENDING_AGG.getFilter(), 2);
         map.put(QueryFilterType.PENDING_COLLABORATION_AGG.getFilter(), 1);
-        map.put(QueryFilterType.APPROVED_AGG.getFilter(), 2);
-        map.put(QueryFilterType.APPROVED_COLLABORATION_AGG.getFilter(), 1);
-        map.put(QueryFilterType.REJECTED_AGG.getFilter(), 2);
-        map.put(QueryFilterType.REJECTED_COLLABORATION_AGG.getFilter(), 1);
+        map.put(QueryFilterType.APPROVED_AGG.getFilter(), 3);
+        map.put(QueryFilterType.APPROVED_COLLABORATION_AGG.getFilter(), 2);
+        map.put(QueryFilterType.REJECTED_AGG.getFilter(), 3);
+        map.put(QueryFilterType.REJECTED_COLLABORATION_AGG.getFilter(), 2);
         map.put(QueryFilterType.ASSIGNMENTS_AGG.getFilter(), 5);
         map.put(QueryFilterType.DISPUTED_AGG.getFilter(), 1);
         return map.entrySet().stream();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -808,8 +808,8 @@ public class OpenSearchClientTest {
         map.put(REJECTED_COLLABORATION_AGG.getAggregationName(), 2);
         map.put(DISPUTED_AGG.getAggregationName(), 1);
         map.put(ASSIGNMENTS_AGG.getAggregationName(), 5);
-        map.put(COMPLETED_AGGREGATION_AGG.getAggregationName(), 5);
-        map.put(TOTAL_COUNT_AGGREGATION_AGG.getAggregationName(), 9);
+        map.put(COMPLETED_AGGREGATION_AGG.getAggregationName(), 7);
+        map.put(TOTAL_COUNT_AGGREGATION_AGG.getAggregationName(), 11);
         return map.entrySet().stream();
     }
 

--- a/index-handlers/src/test/resources/document_approved_collaboration_new.json
+++ b/index-handlers/src/test/resources/document_approved_collaboration_new.json
@@ -1,7 +1,7 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e8",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e51244",
   "numberOfApprovals": 2,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
@@ -28,22 +28,13 @@
   "approvals": [
     {
       "type": "Approval",
-      "assignee": "user1",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
-      "labels": {
-        "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",
-        "en": "Sikt - Norwegian Agency for Shared Services in Education and Research"
-      },
       "approvalStatus": "Approved"
     },
     {
       "type": "Approval",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/2333.0.0.0",
-      "labels": {
-        "nb": "NTNU",
-        "en": "NTNU"
-      },
-      "approvalStatus": "Pending"
+      "approvalStatus": "New"
     }
   ]
 }

--- a/index-handlers/src/test/resources/document_approved_collaboration_pending.json
+++ b/index-handlers/src/test/resources/document_approved_collaboration_pending.json
@@ -1,15 +1,14 @@
 {
   "@context": "https://bibsysdev.github.io/src/nvi-context.json",
   "type": "NviCandidate",
-  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e6",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e8",
   "numberOfApprovals": 2,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",
     "title": "Testing nvi flow 36",
     "publicationDate": {
-      "year": "2023",
-      "month": "1"
+      "year": "2023"
     },
     "contributors": [
       {
@@ -31,19 +30,11 @@
       "type": "Approval",
       "assignee": "user1",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
-      "labels": {
-        "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",
-        "en": "Sikt - Norwegian Agency for Shared Services in Education and Research"
-      },
-      "approvalStatus": "Rejected"
+      "approvalStatus": "Approved"
     },
     {
       "type": "Approval",
       "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/2333.0.0.0",
-      "labels": {
-        "nb": "NTNU",
-        "en": "NTNU"
-      },
       "approvalStatus": "Pending"
     }
   ]

--- a/index-handlers/src/test/resources/document_rejected_collaboration_new.json
+++ b/index-handlers/src/test/resources/document_rejected_collaboration_new.json
@@ -1,0 +1,41 @@
+{
+  "@context": "https://bibsysdev.github.io/src/nvi-context.json",
+  "type": "NviCandidate",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e12111",
+  "numberOfApprovals": 2,
+  "publicationDetails": {
+    "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
+    "type": "AcademicArticle",
+    "title": "Testing nvi flow 36",
+    "publicationDate": {
+      "year": "2023",
+      "month": "1"
+    },
+    "contributors": [
+      {
+        "type": "NviContributor",
+        "id": "https://api.dev.nva.aws.unit.no/cristin/person/1136323555",
+        "name": "Kir Truhacev",
+        "affiliations" : [ {
+          "type": "NviOrganization",
+          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
+          "identifier": "194.0.0.0",
+          "partOf": []
+        } ],
+        "role" : "Creator"
+      }
+    ]
+  },
+  "approvals": [
+    {
+      "type": "Approval",
+      "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+      "approvalStatus": "Rejected"
+    },
+    {
+      "type": "Approval",
+      "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/2333.0.0.0",
+      "approvalStatus": "New"
+    }
+  ]
+}

--- a/index-handlers/src/test/resources/document_rejected_collaboration_pending.json
+++ b/index-handlers/src/test/resources/document_rejected_collaboration_pending.json
@@ -1,0 +1,46 @@
+{
+  "@context": "https://bibsysdev.github.io/src/nvi-context.json",
+  "type": "NviCandidate",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e6",
+  "numberOfApprovals": 2,
+  "publicationDetails": {
+    "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
+    "type": "AcademicArticle",
+    "title": "Testing nvi flow 36",
+    "publicationDate": {
+      "year": "2023",
+      "month": "1"
+    },
+    "contributors": [
+      {
+        "type": "NviContributor",
+        "id": "https://api.dev.nva.aws.unit.no/cristin/person/1136323555",
+        "name": "Kir Truhacev",
+        "affiliations" : [ {
+          "type": "NviOrganization",
+          "id": "https://api.dev.nva.aws.unit.no/cristin/organization/194.0.0.0",
+          "identifier": "194.0.0.0",
+          "partOf": []
+        } ],
+        "role" : "Creator"
+      }
+    ]
+  },
+  "approvals": [
+    {
+      "type": "Approval",
+      "assignee": "user1",
+      "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+      "labels": {
+        "nb": "Sikt – Kunnskapssektorens tjenesteleverandør",
+        "en": "Sikt - Norwegian Agency for Shared Services in Education and Research"
+      },
+      "approvalStatus": "Rejected"
+    },
+    {
+      "type": "Approval",
+      "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/2333.0.0.0",
+      "approvalStatus": "Pending"
+    }
+  ]
+}


### PR DESCRIPTION
Jira task: NP-47460 Search aggregation "Venter på andre institusjoner" showing wrong number

Change:
- Update finalized collaboration* filters and aggregations -> Count candidates with approval status `New` as well

*`approvedCollaboration` and `rejectedCollaboration`: A candidate where requesting users top level org has approved/rejected (finalized) their `Approval`, but other institutions have not (still approval status `Pending` or `New`)