### PR TITLE
Np 47613 Fix: IndexDocumentHandler - filter non applicable candidates

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -24,8 +24,8 @@ import no.sikt.nva.nvi.common.queue.QueueClient;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.index.aws.S3StorageWriter;
 import no.sikt.nva.nvi.index.model.PersistedIndexDocumentMessage;
-import no.sikt.nva.nvi.index.model.document.IndexDocumentWithConsumptionAttributes;
 import no.sikt.nva.nvi.index.model.PersistedResource;
+import no.sikt.nva.nvi.index.model.document.IndexDocumentWithConsumptionAttributes;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
@@ -179,7 +179,7 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
     private IndexDocumentWithConsumptionAttributes generateIndexDocumentWithConsumptionAttributes(
         DynamodbStreamRecord record) {
         var candidate = fetchCandidate(record);
-        return generateIndexDocumentWithConsumptionAttributes(candidate);
+        return candidate.isApplicable() ? generateIndexDocumentWithConsumptionAttributes(candidate) : null;
     }
 
     private IndexDocumentWithConsumptionAttributes generateIndexDocumentWithConsumptionAttributes(

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -30,7 +30,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -80,6 +80,7 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 import software.amazon.awssdk.services.sqs.model.SqsException;
 
 public class IndexDocumentHandlerTest extends LocalDynamoTest {
@@ -286,7 +287,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         var event = createEvent(nonApplicableCandidate.getIdentifier());
         mockUriRetrieverOrgResponse(nonApplicableCandidate);
         handler.handleRequest(event, CONTEXT);
-        assertNull(s3Writer.getFile(createPath(nonApplicableCandidate)));
+        assertThrows(NoSuchKeyException.class, () -> s3Writer.getFile(createPath(nonApplicableCandidate)));
     }
 
     @Test


### PR DESCRIPTION
Race condition between two event flows:
1. When an _**approval is removed**_ from an applicable candidate -> We want to generate an index document with updated approvals
2. When an applicable candidate becomes not applicable and all _**approvals are removed**_ -> We want to remove the candidate from the index

![Screenshot 2024-09-18 at 08 58 57](https://github.com/user-attachments/assets/75aaa912-b051-4209-a379-f4560223e9dc)

Fix: In `IndexDocumentHandler` - filter non applicable candidates. This will prevent non-applicable candidates in index when approvals are removed (triggering case 1)