### PR TITLE
Np 47613 InstitutionReportGenerator: Should not fail on appproval not found

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
@@ -94,7 +94,7 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
         return approvals.stream()
                    .filter(approval -> approval.institutionId().equals(institutionId))
                    .findAny()
-                   .orElseThrow();
+                   .orElse(null);
     }
 
     public BigDecimal getPointsForContributorAffiliation(URI topLevelCristinOrg,

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.index.model.document;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.sikt.nva.nvi.common.utils.ExceptionUtils.getStackTrace;
 import static no.sikt.nva.nvi.index.model.report.InstitutionReportHeader.CONTRIBUTOR_FIRST_NAME;
@@ -118,6 +119,11 @@ public record NviCandidateIndexDocument(@JsonProperty(CONTEXT) URI context,
     }
 
     public List<Map<InstitutionReportHeader, String>> toReportRowsForInstitution(URI topLevelOrganization) {
+        if (isNull(getApprovalForInstitution(topLevelOrganization))) {
+            logger.warn("No approval found for institution: {}. Cannot convert candidate with id {} to report rows",
+                        topLevelOrganization, identifier);
+            return List.of();
+        }
         return getNviContributors().stream()
                    .flatMap(
                        nviContributor -> generateRowsForContributorAffiliations(nviContributor, topLevelOrganization))

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -57,6 +57,7 @@ import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.index.aws.S3StorageWriter;
 import no.sikt.nva.nvi.index.model.PersistedIndexDocumentMessage;
+import no.sikt.nva.nvi.index.model.document.Approval;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.document.ConsumptionAttributes;
 import no.sikt.nva.nvi.index.model.document.IndexDocumentWithConsumptionAttributes;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -98,7 +98,6 @@ import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
 import nva.commons.logutils.LogUtils;
 import org.hamcrest.Matchers;
-import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -334,7 +333,6 @@ public class FetchInstitutionReportHandlerTest {
         assertThat(response.getHeaders().get(CONTENT_TYPE), is(OOXML_SHEET.toString()));
     }
 
-    @NotNull
     private static List<NviCandidateIndexDocument> mockCandidateWithoutApprovals(URI topLevelCristinOrg)
         throws IOException {
         var indexDocumentMissingApprovals = indexDocumentMissingApprovals(CURRENT_YEAR, topLevelCristinOrg);

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -160,6 +160,12 @@ public final class IndexDocumentTestUtils {
 
     public static NviCandidateIndexDocument indexDocumentMissingCreatorAffiliationPoints(int year, URI institutionId) {
         var publicationDetails = publicationDetailsWithNviContributorsAffiliatedWith(institutionId).build();
+        var approvalsWithoutCreatorAffiliationPoints = createApprovals(institutionId, Collections.emptyList());
+        return getBuilder(year, approvalsWithoutCreatorAffiliationPoints, publicationDetails).build();
+    }
+
+    public static NviCandidateIndexDocument indexDocumentMissingApprovals(int year, URI institutionId) {
+        var publicationDetails = publicationDetailsWithNviContributorsAffiliatedWith(institutionId).build();
         var noApprovals = new ArrayList<no.sikt.nva.nvi.index.model.document.Approval>();
         return getBuilder(year, noApprovals, publicationDetails).build();
     }


### PR DESCRIPTION
Bug: `InstitutionReportGenerator` was failing when trying to generate report rows for non-applicable candidate without approvals.
In general: candidates that become non-applicable are removed from the search index, so this error should not occur. But if it does - `InstitutionReportGenerator` should handle this.

Change: If approval for institution not found for a candidate (index document), log waring and skip generation of report rows 