### PR TITLE
Np 47614 reduce pagesize on 413

### DIFF
--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -64,5 +64,5 @@ test {
     environment("BACKEND_CLIENT_SECRET_NAME", "My secret name")
     environment("PERSISTED_INDEX_DOCUMENT_QUEUE_URL", "PersistedIndexDocumentQueue")
     environment("INDEX_DLQ", "IndexDlq")
-    environment("INSTITUTION_REPORT_SEARCH_PAGE_SIZE", "1")
+    environment("INSTITUTION_REPORT_SEARCH_PAGE_SIZE", "4")
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.index.utils;
 
+import static java.util.Objects.nonNull;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -76,7 +77,7 @@ public class InstitutionReportGenerator {
 
     private static boolean thereAreMoreHitsToFetch(HitsMetadata<NviCandidateIndexDocument> hitsMetadata,
                                                    int numberOfFetchedCandidates) {
-        return hitsMetadata.total().value() > numberOfFetchedCandidates;
+        return nonNull(hitsMetadata) && hitsMetadata.total().value() > numberOfFetchedCandidates;
     }
 
     private Stream<List<String>> orderByHeaderOrder(

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.index.utils;
 
+import static java.util.Objects.nonNull;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -74,8 +75,8 @@ public class InstitutionReportGenerator {
         return currentPageSize > MIN_PAGE_SIZE;
     }
 
-    private static boolean thereAreMoreHitsToFetch(long totalHits, int numberOfFetchedCandidates) {
-        return totalHits > numberOfFetchedCandidates;
+    private static boolean thereAreMoreHitsToFetch(Long totalHits, int numberOfFetchedCandidates) {
+        return nonNull(totalHits) && totalHits > numberOfFetchedCandidates;
     }
 
     private Stream<List<String>> orderByHeaderOrder(
@@ -87,13 +88,13 @@ public class InstitutionReportGenerator {
         var fetchedCandidates = new ArrayList<NviCandidateIndexDocument>();
         var offset = INITIAL_OFFSET;
         var currentPageSize = searchPageSize;
-        var totalHits = -1;
+        Long totalHits = null;
 
         do {
             try {
                 var hits = search(offset, currentPageSize);
                 addHitsToListOfCandidates(hits, fetchedCandidates);
-                totalHits = (int) hits.total().value();
+                totalHits = hits.total().value();
                 offset += currentPageSize;
                 currentPageSize = searchPageSize;
             } catch (ResponseException responseException) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -1,6 +1,6 @@
 package no.sikt.nva.nvi.index.utils;
 
-import static nva.commons.core.attempt.Try.attempt;
+import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -15,6 +15,7 @@ import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
 import nva.commons.core.paths.UriWrapper;
+import org.opensearch.client.ResponseException;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.slf4j.Logger;
@@ -25,6 +26,9 @@ public class InstitutionReportGenerator {
     private static final Logger logger = LoggerFactory.getLogger(InstitutionReportGenerator.class);
     private static final int INITIAL_OFFSET = 0;
     private static final String EXCLUDE_CONTRIBUTORS_FIELD = "publicationDetails.contributors";
+    private static final int HTTP_REQUEST_ENTITY_TOO_LARGE = 413;
+    private static final int MIN_PAGE_SIZE = 1;
+    private static final int EXPONENTITAL_PAGE_SIZE_DIVISOR = 2;
     private final SearchClient<NviCandidateIndexDocument> searchClient;
     private final int searchPageSize;
     private final String year;
@@ -62,6 +66,10 @@ public class InstitutionReportGenerator {
         hits.hits().stream().map(Hit::source).forEach(fetchedCandidates::add);
     }
 
+    private static boolean isRequestEntityTooLarge(ResponseException responseException) {
+        return responseException.getResponse().getStatusLine().getStatusCode() == HTTP_REQUEST_ENTITY_TOO_LARGE;
+    }
+
     private Stream<List<String>> orderByHeaderOrder(
         List<Map<InstitutionReportHeader, String>> reportRows) {
         return reportRows.stream().map(InstitutionReportGenerator::sortValuesByHeaderOrder);
@@ -70,14 +78,31 @@ public class InstitutionReportGenerator {
     private List<NviCandidateIndexDocument> fetchNviCandidates() {
         var fetchedCandidates = new ArrayList<NviCandidateIndexDocument>();
         var offset = INITIAL_OFFSET;
-        var hits = search(offset);
-        addHitsToListOfCandidates(hits, fetchedCandidates);
-        while (thereAreMoreHitsToFetch(hits, fetchedCandidates.size())) {
-            logger.info("There are more candidates to fetch. Total hits: {}, fetched candidates: {}",
-                        hits.total().value(), fetchedCandidates.size());
-            offset += searchPageSize;
-            hits = search(offset);
-            addHitsToListOfCandidates(hits, fetchedCandidates);
+        var currentPageSize = searchPageSize;
+
+        while (true) {
+            try {
+                var hits = search(offset, currentPageSize);
+                addHitsToListOfCandidates(hits, fetchedCandidates);
+                if (!thereAreMoreHitsToFetch(hits, fetchedCandidates.size())) {
+                    break;
+                }
+                offset += currentPageSize;
+                currentPageSize = searchPageSize;
+            } catch (ResponseException responseException) {
+                if (isRequestEntityTooLarge(responseException)) {
+                    if (currentPageSize > MIN_PAGE_SIZE) {
+                        currentPageSize /= EXPONENTITAL_PAGE_SIZE_DIVISOR;
+                        offset = Math.max(0, fetchedCandidates.size() - currentPageSize);
+                    } else {
+                        throw new RuntimeException(responseException);
+                    }
+                } else {
+                    throw new RuntimeException(responseException);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
         }
         logNumberOfCandidatesFound(fetchedCandidates);
         return fetchedCandidates;
@@ -88,29 +113,29 @@ public class InstitutionReportGenerator {
                     year);
     }
 
-    private HitsMetadata<NviCandidateIndexDocument> search(int offset) {
-        logger.info("Searching for candidates with page size {} and with offset {}", searchPageSize, offset);
-        return attempt(() -> searchClient.search(buildSearchRequest(offset))).orElseThrow().hits();
+    private HitsMetadata<NviCandidateIndexDocument> search(int offset, int pageSize) throws IOException {
+        logger.info("Searching for candidates with page size {} and with offset {}", pageSize, offset);
+        return searchClient.search(buildSearchRequest(offset, pageSize)).hits();
     }
 
     private boolean thereAreMoreHitsToFetch(HitsMetadata<NviCandidateIndexDocument> hitsMetadata, int size) {
         return hitsMetadata.total().value() > size;
     }
 
-    private CandidateSearchParameters buildSearchRequest(int offset) {
+    private CandidateSearchParameters buildSearchRequest(int offset, int pageSize) {
         var topLevelOrganizationIdentifier = UriWrapper.fromUri(topLevelOrganization).getLastPathElement();
         return CandidateSearchParameters.builder()
                    .withYear(year)
                    .withTopLevelCristinOrg(topLevelOrganization)
                    .withAffiliations(List.of(topLevelOrganizationIdentifier))
-                   .withSearchResultParameters(getSearchRequestParameters(offset))
+                   .withSearchResultParameters(getSearchRequestParameters(offset, pageSize))
                    .withExcludeFields(List.of(EXCLUDE_CONTRIBUTORS_FIELD))
                    .build();
     }
 
-    private SearchResultParameters getSearchRequestParameters(int offset) {
+    private SearchResultParameters getSearchRequestParameters(int offset, int pageSize) {
         return SearchResultParameters.builder()
-                   .withSize(searchPageSize)
+                   .withSize(pageSize)
                    .withOffset(offset)
                    .build();
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -76,7 +76,7 @@ public class InstitutionReportGenerator {
     }
 
     private static boolean thereAreMoreHitsToFetch(Long totalHits, int numberOfFetchedCandidates) {
-        return nonNull(totalHits) && totalHits > numberOfFetchedCandidates;
+        return totalHits > numberOfFetchedCandidates;
     }
 
     private Stream<List<String>> orderByHeaderOrder(

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -93,7 +93,7 @@ public class InstitutionReportGenerator {
                 if (isRequestEntityTooLarge(responseException)) {
                     if (currentPageSize > MIN_PAGE_SIZE) {
                         currentPageSize /= EXPONENTITAL_PAGE_SIZE_DIVISOR;
-                        offset = Math.max(0, fetchedCandidates.size() - currentPageSize);
+                        offset = fetchedCandidates.size();
                     } else {
                         throw new RuntimeException(responseException);
                     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
@@ -30,11 +30,10 @@ public class MockOpenSearchUtil {
     }
 
     public static SearchResponse<NviCandidateIndexDocument> createSearchResponseWithTotal(
-        NviCandidateIndexDocument document, int total) {
-        List<NviCandidateIndexDocument> hits = List.of(document);
+        List<NviCandidateIndexDocument> documents, int total) {
         return defaultBuilder()
                    .hits(new HitsMetadata.Builder<NviCandidateIndexDocument>()
-                             .hits(hits.stream().map(MockOpenSearchUtil::toHit).collect(Collectors.toList()))
+                             .hits(documents.stream().map(MockOpenSearchUtil::toHit).collect(Collectors.toList()))
                              .total(new TotalHits.Builder().relation(TotalHitsRelation.Eq).value(total).build())
                              .build())
                    .build();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
@@ -22,12 +22,15 @@ public class MockOpenSearchUtil {
                    .build();
     }
 
-    public static SearchResponse<NviCandidateIndexDocument> createSearchResponse(List<NviCandidateIndexDocument> documents) {
+    public static SearchResponse<NviCandidateIndexDocument> createSearchResponse(
+        List<NviCandidateIndexDocument> documents) {
         return defaultBuilder()
                    .hits(constructHitsMetadata(documents))
                    .build();
     }
-    public static SearchResponse<NviCandidateIndexDocument> createSearchResponseWithTotal(NviCandidateIndexDocument document, int total) {
+
+    public static SearchResponse<NviCandidateIndexDocument> createSearchResponseWithTotal(
+        NviCandidateIndexDocument document, int total) {
         List<NviCandidateIndexDocument> hits = List.of(document);
         return defaultBuilder()
                    .hits(new HitsMetadata.Builder<NviCandidateIndexDocument>()


### PR DESCRIPTION
Fix bug: Not able to download report for UiO. Lambda failing due to 413-response from OpenSearch

Changes:
- Reduce the page size if OpenSearch responds with 413-error (RequestEntityTooLarge)
- The pageSize is divided by two exponentially, and the offset is adjusted according to the pageSize that was successful
- After a successful search response -> the pageSize should go back to the initial pageSize when doing the next search requests

Tested for UiO in dev ✅ 

Next step: For faster performance: I'm thinking about fetching total number of candidates for institution and year, splitting into batches and parallelising fetching this with async http client. Thoughts?