### PR TITLE
InstitutionReportGenerator: Add sort order and optimized page size

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -21,6 +21,7 @@ import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
 import no.sikt.nva.nvi.index.xlsx.ExcelWorkbookGenerator;
 import nva.commons.core.paths.UriWrapper;
 import org.opensearch.client.ResponseException;
+import org.opensearch.client.opensearch._types.SortOrder;
 import org.opensearch.client.opensearch._types.aggregations.FilterAggregate;
 import org.opensearch.client.opensearch.core.search.Hit;
 import org.opensearch.client.opensearch.core.search.HitsMetadata;
@@ -36,6 +37,7 @@ public class InstitutionReportGenerator {
     private static final int EXPONENTIAL_PAGE_SIZE_DIVISOR = 2;
     private static final int PAGE_SIZE_NO_HITS = 0;
     private static final int NO_OFFSET = 0;
+    private static final String SORT_ORDER = SortOrder.Asc.jsonValue();
     private final SearchClient<NviCandidateIndexDocument> searchClient;
     private final int searchPageSize;
     private final String year;
@@ -192,6 +194,7 @@ public class InstitutionReportGenerator {
         return SearchResultParameters.builder()
                    .withSize(pageSize)
                    .withOffset(offset)
+                   .withSortOrder(SORT_ORDER)
                    .build();
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/InstitutionReportGenerator.java
@@ -173,7 +173,9 @@ public class InstitutionReportGenerator {
 
     private HitsMetadata<NviCandidateIndexDocument> search(int offset, int pageSize) throws IOException {
         logger.info("Searching for candidates with page size {} and with offset {}", pageSize, offset);
-        return searchClient.search(buildSearchRequest(offset, pageSize).build()).hits();
+        var searchResponse = searchClient.search(buildSearchRequest(offset, pageSize).build()).hits();
+        logger.info("Response received with page size {} and with offset {}", pageSize, offset);
+        return searchResponse;
     }
 
     private CandidateSearchParameters.Builder buildSearchRequest(int offset, int pageSize) {

--- a/template.yaml
+++ b/template.yaml
@@ -1214,7 +1214,7 @@ Resources:
         Variables:
           ALLOWED_ORIGIN: !Ref AllowedOrigins
           COGNITO_HOST: !Ref CognitoAuthorizationUri
-          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 1000
+          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 400
       Policies:
         - !GetAtt ReadSearchInfrastructureSecretsPolicy.PolicyArn
       Events:

--- a/template.yaml
+++ b/template.yaml
@@ -1214,7 +1214,7 @@ Resources:
         Variables:
           ALLOWED_ORIGIN: !Ref AllowedOrigins
           COGNITO_HOST: !Ref CognitoAuthorizationUri
-          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 100
+          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 300
       Policies:
         - !GetAtt ReadSearchInfrastructureSecretsPolicy.PolicyArn
       Events:

--- a/template.yaml
+++ b/template.yaml
@@ -1214,7 +1214,7 @@ Resources:
         Variables:
           ALLOWED_ORIGIN: !Ref AllowedOrigins
           COGNITO_HOST: !Ref CognitoAuthorizationUri
-          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 300
+          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 100
       Policies:
         - !GetAtt ReadSearchInfrastructureSecretsPolicy.PolicyArn
       Events:

--- a/template.yaml
+++ b/template.yaml
@@ -1214,7 +1214,7 @@ Resources:
         Variables:
           ALLOWED_ORIGIN: !Ref AllowedOrigins
           COGNITO_HOST: !Ref CognitoAuthorizationUri
-          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 400
+          INSTITUTION_REPORT_SEARCH_PAGE_SIZE: 300
       Policies:
         - !GetAtt ReadSearchInfrastructureSecretsPolicy.PolicyArn
       Events:


### PR DESCRIPTION
- Add sort order in search request for deterministic results
- After parallelizing fetch, reducing page size is beneficial (bigger != better:)). Page size 300 seems like the sweet spot 