### PR TITLE
Np 47797 Index document, contributorsPreview

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -13,6 +13,7 @@ public record PublicationDetails(String id,
                                  List<NviContributor> nviContributors,
                                  List<ContributorType> contributors,
                                  List<ContributorType> contributorsPreview,
+                                 int contributorsCount,
                                  PublicationChannel publicationChannel,
                                  Pages pages,
                                  String language) {
@@ -30,6 +31,7 @@ public record PublicationDetails(String id,
         private List<NviContributor> nviContributors;
         private List<ContributorType> contributors;
         private List<ContributorType> contributorsPreview;
+        private int contributorsCount;
         private PublicationChannel publicationChannel;
         private Pages pages;
         private String language;
@@ -59,6 +61,7 @@ public record PublicationDetails(String id,
 
         public Builder withContributors(List<ContributorType> contributors) {
             this.contributors = contributors;
+            this.contributorsCount = contributors.size();
             this.nviContributors = contributors.stream()
                                        .filter(NviContributor.class::isInstance)
                                        .map(NviContributor.class::cast)
@@ -88,7 +91,7 @@ public record PublicationDetails(String id,
 
         public PublicationDetails build() {
             return new PublicationDetails(id, type, title, publicationDate, nviContributors, contributors,
-                                          contributorsPreview, publicationChannel, pages, language);
+                                          contributorsPreview, contributorsCount, publicationChannel, pages, language);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -12,6 +12,7 @@ public record PublicationDetails(String id,
                                  PublicationDate publicationDate,
                                  List<NviContributor> nviContributors,
                                  List<ContributorType> contributors,
+                                 List<ContributorType> contributorsPreview,
                                  PublicationChannel publicationChannel,
                                  Pages pages,
                                  String language) {
@@ -28,6 +29,7 @@ public record PublicationDetails(String id,
         private PublicationDate publicationDate;
         private List<NviContributor> nviContributors;
         private List<ContributorType> contributors;
+        private List<ContributorType> contributorsPreview;
         private PublicationChannel publicationChannel;
         private Pages pages;
         private String language;
@@ -64,6 +66,11 @@ public record PublicationDetails(String id,
             return this;
         }
 
+        public Builder withContributorsPreview(List<ContributorType> contributorsPreview) {
+            this.contributorsPreview = contributorsPreview;
+            return this;
+        }
+
         public Builder withPublicationChannel(PublicationChannel publicationChannel) {
             this.publicationChannel = publicationChannel;
             return this;
@@ -81,7 +88,7 @@ public record PublicationDetails(String id,
 
         public PublicationDetails build() {
             return new PublicationDetails(id, type, title, publicationDate, nviContributors, contributors,
-                                          publicationChannel, pages, language);
+                                          contributorsPreview, publicationChannel, pages, language);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -82,7 +82,7 @@ public final class NviCandidateIndexDocumentGenerator {
     private static final TypeReference<Map<String, String>> TYPE_REF =
         new TypeReference<>() {
         };
-    private static final int DEFAULT_CONTRIBUTORS_PREVIEW_LIMIT = 5;
+    private static final int FALLBACK_CONTRIBUTORS_PREVIEW_LIMIT = 5;
     private final OrganizationRetriever organizationRetriever;
     private final JsonNode expandedResource;
     private final Candidate candidate;
@@ -183,7 +183,7 @@ public final class NviCandidateIndexDocumentGenerator {
         return PublicationDetails.builder()
                    .withId(extractId(expandedResource))
                    .withContributors(contributors)
-                   .withContributorsPreview(extractContributorsPreview(contributors))
+                   .withContributorsPreview(extractContributorsPreviewOrFallback(contributors))
                    .withType(extractInstanceType())
                    .withPublicationDate(extractPublicationDate())
                    .withTitle(extractMainTitle())
@@ -193,11 +193,11 @@ public final class NviCandidateIndexDocumentGenerator {
                    .build();
     }
 
-    private List<ContributorType> extractContributorsPreview(List<ContributorType> contributors) {
+    private List<ContributorType> extractContributorsPreviewOrFallback(List<ContributorType> contributors) {
         return JsonUtils.isNodePresent(expandedResource, JSON_PTR_CONTRIBUTOR_PREVIEW)
                    ? getJsonNodeStream(expandedResource, JSON_PTR_CONTRIBUTOR_PREVIEW).map(this::createContributor)
                          .toList()
-                   : contributors.stream().limit(DEFAULT_CONTRIBUTORS_PREVIEW_LIMIT).toList();
+                   : contributors.stream().limit(FALLBACK_CONTRIBUTORS_PREVIEW_LIMIT).toList();
     }
 
     private String extractLanguage() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -82,7 +82,7 @@ public final class NviCandidateIndexDocumentGenerator {
     private static final TypeReference<Map<String, String>> TYPE_REF =
         new TypeReference<>() {
         };
-    private static final int FALLBACK_CONTRIBUTORS_PREVIEW_LIMIT = 5;
+    private static final int FALLBACK_CONTRIBUTORS_PREVIEW_LIMIT = 10;
     private final OrganizationRetriever organizationRetriever;
     private final JsonNode expandedResource;
     private final Candidate candidate;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -8,6 +8,7 @@ import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_POINTER_JOURNAL_PIS
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PRT_PAGES_END;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_AFFILIATIONS;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CONTRIBUTOR;
+import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CONTRIBUTOR_PREVIEW;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_DAY;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ID;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_IDENTITY;
@@ -180,6 +181,7 @@ public final class NviCandidateIndexDocumentGenerator {
         return PublicationDetails.builder()
                    .withId(extractId(expandedResource))
                    .withContributors(contributors)
+                   .withContributorsPreview(extractContributorsPreview())
                    .withType(extractInstanceType())
                    .withPublicationDate(extractPublicationDate())
                    .withTitle(extractMainTitle())
@@ -187,6 +189,10 @@ public final class NviCandidateIndexDocumentGenerator {
                    .withPages(extractPages())
                    .withLanguage(extractLanguage())
                    .build();
+    }
+
+    private List<ContributorType> extractContributorsPreview() {
+        return getJsonNodeStream(expandedResource, JSON_PTR_CONTRIBUTOR_PREVIEW).map(this::createContributor).toList();
     }
 
     private String extractLanguage() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -53,6 +53,7 @@ import no.sikt.nva.nvi.common.service.model.Approval;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.Creator;
 import no.sikt.nva.nvi.common.service.model.Username;
+import no.sikt.nva.nvi.common.utils.JsonUtils;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.document.Contributor;
 import no.sikt.nva.nvi.index.model.document.ContributorType;
@@ -81,6 +82,7 @@ public final class NviCandidateIndexDocumentGenerator {
     private static final TypeReference<Map<String, String>> TYPE_REF =
         new TypeReference<>() {
         };
+    private static final int DEFAULT_CONTRIBUTORS_PREVIEW_LIMIT = 5;
     private final OrganizationRetriever organizationRetriever;
     private final JsonNode expandedResource;
     private final Candidate candidate;
@@ -181,7 +183,7 @@ public final class NviCandidateIndexDocumentGenerator {
         return PublicationDetails.builder()
                    .withId(extractId(expandedResource))
                    .withContributors(contributors)
-                   .withContributorsPreview(extractContributorsPreview())
+                   .withContributorsPreview(extractContributorsPreview(contributors))
                    .withType(extractInstanceType())
                    .withPublicationDate(extractPublicationDate())
                    .withTitle(extractMainTitle())
@@ -191,8 +193,11 @@ public final class NviCandidateIndexDocumentGenerator {
                    .build();
     }
 
-    private List<ContributorType> extractContributorsPreview() {
-        return getJsonNodeStream(expandedResource, JSON_PTR_CONTRIBUTOR_PREVIEW).map(this::createContributor).toList();
+    private List<ContributorType> extractContributorsPreview(List<ContributorType> contributors) {
+        return JsonUtils.isNodePresent(expandedResource, JSON_PTR_CONTRIBUTOR_PREVIEW)
+                   ? getJsonNodeStream(expandedResource, JSON_PTR_CONTRIBUTOR_PREVIEW).map(this::createContributor)
+                         .toList()
+                   : contributors.stream().limit(DEFAULT_CONTRIBUTORS_PREVIEW_LIMIT).toList();
     }
 
     private String extractLanguage() {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -330,7 +330,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     @Test
     void shouldExtractContributorsPreviewAndContributorsCountFromExpandedResource(){
         var candidate = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
-        var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(candidate);
+        var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(candidate).indexDocument();
         var event = createEvent(candidate.getIdentifier());
         mockUriRetrieverOrgResponse(candidate);
         handler.handleRequest(event, CONTEXT);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -595,6 +595,15 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         return lowLevel;
     }
 
+    private static ObjectNode expandedResourceWithoutContributorsPreview(Candidate candidate) {
+        var expandedResource = createExpandedResource(candidate, true, true);
+        var entityDescriptionCopy = (ObjectNode) expandedResource.get("entityDescription");
+        entityDescriptionCopy.remove("contributorsPreview");
+        var expandedResourceCopy = (ObjectNode) expandedResource;
+        expandedResourceCopy.replace("entityDescription", entityDescriptionCopy);
+        return expandedResourceCopy;
+    }
+
     private Candidate setUpNonApplicableCandidate(URI institutionId) {
         var candidate =
             Candidate.upsert(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
@@ -695,11 +704,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
 
     private NviCandidateIndexDocument setUpExistingResourceMissingContributorsPreviewInS3AndGenerateExpectedDocument(
         Candidate candidate) {
-        var expandedResource = createExpandedResource(candidate, true, true);
-        var entityDescriptionCopy = (ObjectNode) expandedResource.get("entityDescription");
-        entityDescriptionCopy.remove("contributorsPreview");
-        var expandedResourceCopy = (ObjectNode) expandedResource;
-        expandedResourceCopy.replace("entityDescription", entityDescriptionCopy);
+        var expandedResourceCopy = expandedResourceWithoutContributorsPreview(candidate);
         var resourceIndexDocument = createResourceIndexDocument(expandedResourceCopy);
         var resourcePath = extractResourceIdentifier(candidate);
         insertResourceInS3(resourceIndexDocument, UnixPath.of(resourcePath));

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -329,6 +329,17 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     }
 
     @Test
+    void shouldExtractContributorsPreviewFromExpandedResource(){
+        var candidate = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
+        var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(candidate);
+        var event = createEvent(candidate.getIdentifier());
+        mockUriRetrieverOrgResponse(candidate);
+        handler.handleRequest(event, CONTEXT);
+        var actualIndexDocument = parseJson(s3Writer.getFile(createPath(candidate))).indexDocument();
+        assertEquals(expectedIndexDocument, actualIndexDocument);
+    }
+
+    @Test
     void shouldProduceIndexDocumentWithTypeInfo() throws JsonProcessingException {
         var candidate = randomApplicableCandidate();
         setUpExistingResourceInS3AndGenerateExpectedDocument(candidate);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -57,7 +57,6 @@ import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.index.aws.S3StorageWriter;
 import no.sikt.nva.nvi.index.model.PersistedIndexDocumentMessage;
-import no.sikt.nva.nvi.index.model.document.Approval;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.document.ConsumptionAttributes;
 import no.sikt.nva.nvi.index.model.document.IndexDocumentWithConsumptionAttributes;
@@ -329,7 +328,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     }
 
     @Test
-    void shouldExtractContributorsPreviewFromExpandedResource(){
+    void shouldExtractContributorsPreviewAndContributorsCountFromExpandedResource(){
         var candidate = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
         var expectedIndexDocument = setUpExistingResourceInS3AndGenerateExpectedDocument(candidate);
         var event = createEvent(candidate.getIdentifier());

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -703,7 +703,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         var resourceIndexDocument = createResourceIndexDocument(expandedResourceCopy);
         var resourcePath = extractResourceIdentifier(candidate);
         insertResourceInS3(resourceIndexDocument, UnixPath.of(resourcePath));
-        return createExpectedNviIndexDocument(expandedResource, candidate);
+        return createExpectedNviIndexDocument(expandedResourceCopy, candidate);
     }
 
     private IndexDocumentWithConsumptionAttributes setUpExistingResourceInS3AndGenerateExpectedDocument(

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
@@ -3,6 +3,7 @@ package no.sikt.nva.nvi.common.utils;
 public final class JsonPointers {
 
     public static final String JSON_PTR_CONTRIBUTOR = "/entityDescription/contributors";
+    public static final String JSON_PTR_CONTRIBUTOR_PREVIEW = "/entityDescription/contributorsPreview";
     public static final String JSON_PTR_AFFILIATIONS = "/affiliations";
     public static final String JSON_PTR_ID = "/id";
     public static final String JSON_PTR_TYPE = "/type";

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
@@ -34,7 +34,7 @@ public final class JsonUtils {
     }
 
     public static boolean isNodePresent(JsonNode node, String jsonPointer) {
-        return !node.at(jsonPointer).isMissingNode();
+        return isNotMissingNode(node.at(jsonPointer));
     }
 
     private static boolean isNotMissingNode(JsonNode node) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
@@ -33,6 +33,10 @@ public final class JsonUtils {
         return URI.create(extractJsonNodeTextValue(jsonNode, JSON_PTR_ID));
     }
 
+    public static boolean isNodePresent(JsonNode node, String jsonPointer) {
+        return !node.at(jsonPointer).isMissingNode();
+    }
+
     private static boolean isNotMissingNode(JsonNode node) {
         return !node.isMissingNode() && !node.isNull() && node.isValueNode();
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
@@ -65,4 +65,19 @@ class JsonUtilsTest {
         var jsonNode = objectMapper.createObjectNode().put(ID_FIELD, id.toString());
         assertThat(JsonUtils.extractId(jsonNode), is(equalTo(id)));
     }
+
+    @Test
+    void shouldReturnTrueIfNodeIsPresent() {
+        var fieldName = "fieldName";
+        var fieldValue = randomString();
+        var randomJsonNode = objectMapper.createObjectNode().put(fieldName, fieldValue);
+        assertThat(JsonUtils.isNodePresent(randomJsonNode, "/" + fieldName), is(true));
+    }
+
+    @Test
+    void shouldReturnFalseIfNodeIsMissing() {
+        var fieldName = "fieldName";
+        var randomJsonNode = objectMapper.createObjectNode();
+        assertThat(JsonUtils.isNodePresent(randomJsonNode, "/" + fieldName), is(false));
+    }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
@@ -80,4 +80,11 @@ class JsonUtilsTest {
         var randomJsonNode = objectMapper.createObjectNode();
         assertThat(JsonUtils.isNodePresent(randomJsonNode, "/" + fieldName), is(false));
     }
+
+    @Test
+    void shouldReturnFalseIfNodeIsNull() {
+        var fieldName = "fieldName";
+        var randomJsonNode = objectMapper.createObjectNode().set(fieldName, null);
+        assertThat(JsonUtils.isNodePresent(randomJsonNode, "/" + fieldName), is(false));
+    }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -71,7 +71,7 @@ public final class IndexDocumentTestUtils {
     public static final String NVI_CANDIDATES_FOLDER = "nvi-candidates";
     public static final String GZIP_ENDING = ".gz";
     public static final String DELIMITER = "\\.";
-    private static final int CONTRIBUTORS_PREVIEW_LIMIT = 5;
+    private static final int CONTRIBUTORS_PREVIEW_LIMIT = 10;
 
     private IndexDocumentTestUtils() {
     }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -218,7 +218,8 @@ public final class IndexDocumentTestUtils {
     }
 
     private static boolean containsContributorsPreview(JsonNode expandedResource) {
-        return expandedResource.has("entityDescription/contributorsPreview");
+        var entityDescription = expandedResource.at("/entityDescription");
+        return entityDescription.has("contributorsPreview");
     }
 
     private static String extractOptionalLanguage(JsonNode expandedResource) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -219,7 +219,7 @@ public final class IndexDocumentTestUtils {
 
     private static boolean containsContributorsPreview(JsonNode expandedResource) {
         var entityDescription = expandedResource.at("/entityDescription");
-        return entityDescription.has("contributorsPreview");
+        return JsonUtils.isNodePresent(entityDescription, "/contributorsPreview");
     }
 
     private static String extractOptionalLanguage(JsonNode expandedResource) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -8,6 +8,14 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_L
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.NB_FIELD;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractAffiliations;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractContributors;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractContributorsPreview;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractId;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractName;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractOrcid;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractRole;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractTitle;
+import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractType;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomIntBetween;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
@@ -82,12 +90,12 @@ public final class IndexDocumentTestUtils {
 
     public static PublicationDetails expandPublicationDetails(Candidate candidate, JsonNode expandedResource) {
         return PublicationDetails.builder()
-                   .withType(ExpandedResourceGenerator.extractType(expandedResource))
+                   .withType(extractType(expandedResource))
                    .withId(candidate.getPublicationDetails().publicationId().toString())
-                   .withTitle(ExpandedResourceGenerator.extractTitle(expandedResource))
+                   .withTitle(extractTitle(expandedResource))
                    .withPublicationDate(mapToPublicationDate(candidate.getPublicationDetails().publicationDate()))
-                   .withContributors(
-                       mapToContributors(ExpandedResourceGenerator.extractContributors(expandedResource), candidate))
+                   .withContributors(mapToContributors(extractContributors(expandedResource), candidate))
+                   .withContributorsPreview(mapToContributors(extractContributorsPreview(expandedResource), candidate))
                    .withPublicationChannel(getPublicationChannel(expandedResource, candidate.getPublicationDetails()))
                    .withPages(getPages(expandedResource))
                    .withLanguage(extractOptionalLanguage(expandedResource))
@@ -359,10 +367,10 @@ public final class IndexDocumentTestUtils {
 
     private static Contributor generateContributor(JsonNode contributorNode, List<URI> affiliations) {
         return Contributor.builder()
-                   .withId(ExpandedResourceGenerator.extractId(contributorNode))
-                   .withName(ExpandedResourceGenerator.extractName(contributorNode))
-                   .withOrcid(ExpandedResourceGenerator.extractOrcid(contributorNode))
-                   .withRole(ExpandedResourceGenerator.extractRole(contributorNode))
+                   .withId(extractId(contributorNode))
+                   .withName(extractName(contributorNode))
+                   .withOrcid(extractOrcid(contributorNode))
+                   .withRole(extractRole(contributorNode))
                    .withAffiliations(expandAffiliations(affiliations))
                    .build();
     }
@@ -370,10 +378,10 @@ public final class IndexDocumentTestUtils {
     private static ContributorType generateNviContributor(JsonNode contributorNode, Creator value,
                                                           List<URI> affiliations) {
         return NviContributor.builder()
-                   .withId(ExpandedResourceGenerator.extractId(contributorNode))
-                   .withName(ExpandedResourceGenerator.extractName(contributorNode))
-                   .withOrcid(ExpandedResourceGenerator.extractOrcid(contributorNode))
-                   .withRole(ExpandedResourceGenerator.extractRole(contributorNode))
+                   .withId(extractId(contributorNode))
+                   .withName(extractName(contributorNode))
+                   .withOrcid(extractOrcid(contributorNode))
+                   .withRole(extractRole(contributorNode))
                    .withAffiliations(expandAffiliationsWithPartOf(value, affiliations))
                    .build();
     }
@@ -383,7 +391,7 @@ public final class IndexDocumentTestUtils {
                    .creators()
                    .stream()
                    .filter(
-                       creator -> creator.id().toString().equals(ExpandedResourceGenerator.extractId(contributorNode)))
+                       creator -> creator.id().toString().equals(extractId(contributorNode)))
                    .findFirst();
     }
 


### PR DESCRIPTION
Jira task - Search optimizations - NP-47797 Create new trancated field(s) for contributors

Add new field, contributorsPreview, in index document. This will be used in the search response, instead of the contributors list (Ref 413-responses due to too many contributors)

- Extract `contributorsPreview` from expanded resource
- Added fallback logic in cases where expanded resource might not contain `contributorsPreview`