### PR TITLE
Np 47798 index document remove contributors preview

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -12,8 +12,6 @@ public record PublicationDetails(String id,
                                  PublicationDate publicationDate,
                                  List<NviContributor> nviContributors,
                                  List<ContributorType> contributors,
-                                 List<ContributorType> contributorsPreview,
-                                 int contributorsCount,
                                  PublicationChannel publicationChannel,
                                  Pages pages,
                                  String language) {
@@ -30,8 +28,6 @@ public record PublicationDetails(String id,
         private PublicationDate publicationDate;
         private List<NviContributor> nviContributors;
         private List<ContributorType> contributors;
-        private List<ContributorType> contributorsPreview;
-        private int contributorsCount;
         private PublicationChannel publicationChannel;
         private Pages pages;
         private String language;
@@ -61,16 +57,10 @@ public record PublicationDetails(String id,
 
         public Builder withContributors(List<ContributorType> contributors) {
             this.contributors = contributors;
-            this.contributorsCount = contributors.size();
             this.nviContributors = contributors.stream()
                                        .filter(NviContributor.class::isInstance)
                                        .map(NviContributor.class::cast)
                                        .toList();
-            return this;
-        }
-
-        public Builder withContributorsPreview(List<ContributorType> contributorsPreview) {
-            this.contributorsPreview = contributorsPreview;
             return this;
         }
 
@@ -91,7 +81,7 @@ public record PublicationDetails(String id,
 
         public PublicationDetails build() {
             return new PublicationDetails(id, type, title, publicationDate, nviContributors, contributors,
-                                          contributorsPreview, contributorsCount, publicationChannel, pages, language);
+                                          publicationChannel, pages, language);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -12,6 +12,7 @@ public record PublicationDetails(String id,
                                  PublicationDate publicationDate,
                                  List<NviContributor> nviContributors,
                                  List<ContributorType> contributors,
+                                 int contributorsCount,
                                  PublicationChannel publicationChannel,
                                  Pages pages,
                                  String language) {
@@ -28,6 +29,7 @@ public record PublicationDetails(String id,
         private PublicationDate publicationDate;
         private List<NviContributor> nviContributors;
         private List<ContributorType> contributors;
+        private int contributorsCount;
         private PublicationChannel publicationChannel;
         private Pages pages;
         private String language;
@@ -57,6 +59,7 @@ public record PublicationDetails(String id,
 
         public Builder withContributors(List<ContributorType> contributors) {
             this.contributors = contributors;
+            this.contributorsCount = contributors.size();
             this.nviContributors = contributors.stream()
                                        .filter(NviContributor.class::isInstance)
                                        .map(NviContributor.class::cast)
@@ -81,7 +84,7 @@ public record PublicationDetails(String id,
 
         public PublicationDetails build() {
             return new PublicationDetails(id, type, title, publicationDate, nviContributors, contributors,
-                                          publicationChannel, pages, language);
+                                          contributorsCount, publicationChannel, pages, language);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -8,7 +8,6 @@ import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_POINTER_JOURNAL_PIS
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PRT_PAGES_END;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_AFFILIATIONS;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CONTRIBUTOR;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CONTRIBUTOR_PREVIEW;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_DAY;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ID;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_IDENTITY;
@@ -53,7 +52,6 @@ import no.sikt.nva.nvi.common.service.model.Approval;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.Creator;
 import no.sikt.nva.nvi.common.service.model.Username;
-import no.sikt.nva.nvi.common.utils.JsonUtils;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.document.Contributor;
 import no.sikt.nva.nvi.index.model.document.ContributorType;
@@ -82,7 +80,6 @@ public final class NviCandidateIndexDocumentGenerator {
     private static final TypeReference<Map<String, String>> TYPE_REF =
         new TypeReference<>() {
         };
-    private static final int FALLBACK_CONTRIBUTORS_PREVIEW_LIMIT = 10;
     private final OrganizationRetriever organizationRetriever;
     private final JsonNode expandedResource;
     private final Candidate candidate;
@@ -183,7 +180,6 @@ public final class NviCandidateIndexDocumentGenerator {
         return PublicationDetails.builder()
                    .withId(extractId(expandedResource))
                    .withContributors(contributors)
-                   .withContributorsPreview(extractContributorsPreviewOrFallback(contributors))
                    .withType(extractInstanceType())
                    .withPublicationDate(extractPublicationDate())
                    .withTitle(extractMainTitle())
@@ -191,13 +187,6 @@ public final class NviCandidateIndexDocumentGenerator {
                    .withPages(extractPages())
                    .withLanguage(extractLanguage())
                    .build();
-    }
-
-    private List<ContributorType> extractContributorsPreviewOrFallback(List<ContributorType> contributors) {
-        return JsonUtils.isNodePresent(expandedResource, JSON_PTR_CONTRIBUTOR_PREVIEW)
-                   ? getJsonNodeStream(expandedResource, JSON_PTR_CONTRIBUTOR_PREVIEW).map(this::createContributor)
-                         .toList()
-                   : contributors.stream().limit(FALLBACK_CONTRIBUTORS_PREVIEW_LIMIT).toList();
     }
 
     private String extractLanguage() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
@@ -3,7 +3,6 @@ package no.sikt.nva.nvi.common.utils;
 public final class JsonPointers {
 
     public static final String JSON_PTR_CONTRIBUTOR = "/entityDescription/contributors";
-    public static final String JSON_PTR_CONTRIBUTOR_PREVIEW = "/entityDescription/contributorsPreview";
     public static final String JSON_PTR_AFFILIATIONS = "/affiliations";
     public static final String JSON_PTR_ID = "/id";
     public static final String JSON_PTR_TYPE = "/type";

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
@@ -33,10 +33,6 @@ public final class JsonUtils {
         return URI.create(extractJsonNodeTextValue(jsonNode, JSON_PTR_ID));
     }
 
-    public static boolean isNodePresent(JsonNode node, String jsonPointer) {
-        return isNotMissingNode(node.at(jsonPointer));
-    }
-
     private static boolean isNotMissingNode(JsonNode node) {
         return !node.isMissingNode() && !node.isNull() && node.isValueNode();
     }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
@@ -65,26 +65,4 @@ class JsonUtilsTest {
         var jsonNode = objectMapper.createObjectNode().put(ID_FIELD, id.toString());
         assertThat(JsonUtils.extractId(jsonNode), is(equalTo(id)));
     }
-
-    @Test
-    void shouldReturnTrueIfNodeIsPresent() {
-        var fieldName = "fieldName";
-        var fieldValue = randomString();
-        var randomJsonNode = objectMapper.createObjectNode().put(fieldName, fieldValue);
-        assertThat(JsonUtils.isNodePresent(randomJsonNode, "/" + fieldName), is(true));
-    }
-
-    @Test
-    void shouldReturnFalseIfNodeIsMissing() {
-        var fieldName = "fieldName";
-        var randomJsonNode = objectMapper.createObjectNode();
-        assertThat(JsonUtils.isNodePresent(randomJsonNode, "/" + fieldName), is(false));
-    }
-
-    @Test
-    void shouldReturnFalseIfNodeIsNull() {
-        var fieldName = "fieldName";
-        var randomJsonNode = objectMapper.createObjectNode().set(fieldName, null);
-        assertThat(JsonUtils.isNodePresent(randomJsonNode, "/" + fieldName), is(false));
-    }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.test;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
-import static no.sikt.nva.nvi.common.utils.JsonUtils.streamNode;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -51,12 +50,6 @@ public final class ExpandedResourceGenerator {
 
         entityDescription.set("contributors", contributors);
 
-        entityDescription.put("contributorsCount", contributors.size());
-
-        var contributorsPreview = createContributorsPreview(contributors);
-
-        entityDescription.set("contributorsPreview", contributorsPreview);
-
         entityDescription.put("mainTitle", randomString());
 
         var publicationDate = createAndPopulatePublicationDate(candidate.getPublicationDetails().publicationDate());
@@ -95,12 +88,8 @@ public final class ExpandedResourceGenerator {
         return (ArrayNode) expandedResource.at("/entityDescription/contributors");
     }
 
-    public static ArrayNode extractContributorsPreview(JsonNode expandedResource) {
-        return (ArrayNode) expandedResource.at("/entityDescription/contributorsPreview");
-    }
-
     public static List<URI> extractAffiliations(JsonNode contributorNode) {
-        return streamNode(contributorNode.at("/affiliations"))
+        return JsonUtils.streamNode(contributorNode.at("/affiliations"))
                    .map(affiliationNode -> affiliationNode.at("/id"))
                    .map(JsonNode::asText)
                    .map(URI::create)
@@ -126,12 +115,6 @@ public final class ExpandedResourceGenerator {
     public static String extractType(JsonNode expandedResource) {
         return JsonUtils.extractJsonNodeTextValue(expandedResource,
                                                   "/entityDescription/reference/publicationInstance/type");
-    }
-
-    private static ArrayNode createContributorsPreview(ArrayNode contributors) {
-        return streamNode(contributors)
-                   .limit(10)
-                   .collect(objectMapper::createArrayNode, ArrayNode::add, ArrayNode::addAll);
     }
 
     private static ObjectNode createAndPopulatePublicationInstance(Candidate candidate) {
@@ -243,18 +226,18 @@ public final class ExpandedResourceGenerator {
         var contributors = objectMapper.createArrayNode();
         var creators = candidate.getPublicationDetails().creators();
         creators.stream()
-            .map(creator -> createContributorNode(creator.affiliations(), creator.id(), true))
+            .map(creator -> createContributorNode(creator.affiliations(), creator.id()))
             .forEach(contributors::add);
         addOtherRandomContributors(contributors, nonNviContributorAffiliationIds);
         return contributors;
     }
 
     private static void addOtherRandomContributors(ArrayNode contributors, List<URI> affiliationsIds) {
-        IntStream.range(0, 10).mapToObj(i -> createContributorNode(affiliationsIds, URI.create(randomString()), true))
+        IntStream.range(0, 10).mapToObj(i -> createContributorNode(affiliationsIds, URI.create(randomString())))
             .forEach(contributors::add);
     }
 
-    private static ObjectNode createContributorNode(List<URI> affiliationsUris, URI contributorId, boolean verified) {
+    private static ObjectNode createContributorNode(List<URI> affiliationsUris, URI contributorId) {
         var contributorNode = objectMapper.createObjectNode();
 
         contributorNode.put("type", "Contributor");
@@ -271,7 +254,6 @@ public final class ExpandedResourceGenerator {
         identity.put("id", contributorId.toString());
         identity.put("name", randomString());
         identity.put("orcid", randomString());
-        identity.put("verificationStatus", verified ? "Verified" : "NonVerified");
 
         contributorNode.set("identity", identity);
         return contributorNode;

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -8,14 +8,6 @@ import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_ENGLISH_L
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.HARDCODED_NORWEGIAN_LABEL;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.NB_FIELD;
 import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractAffiliations;
-import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractContributors;
-import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractContributorsPreview;
-import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractId;
-import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractName;
-import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractOrcid;
-import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractRole;
-import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractTitle;
-import static no.sikt.nva.nvi.test.ExpandedResourceGenerator.extractType;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomIntBetween;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
@@ -71,7 +63,6 @@ public final class IndexDocumentTestUtils {
     public static final String NVI_CANDIDATES_FOLDER = "nvi-candidates";
     public static final String GZIP_ENDING = ".gz";
     public static final String DELIMITER = "\\.";
-    private static final int CONTRIBUTORS_PREVIEW_LIMIT = 10;
 
     private IndexDocumentTestUtils() {
     }
@@ -90,17 +81,13 @@ public final class IndexDocumentTestUtils {
     }
 
     public static PublicationDetails expandPublicationDetails(Candidate candidate, JsonNode expandedResource) {
-        List<ContributorType> contributors = mapToContributors(extractContributors(expandedResource), candidate);
         return PublicationDetails.builder()
-                   .withType(extractType(expandedResource))
+                   .withType(ExpandedResourceGenerator.extractType(expandedResource))
                    .withId(candidate.getPublicationDetails().publicationId().toString())
-                   .withTitle(extractTitle(expandedResource))
+                   .withTitle(ExpandedResourceGenerator.extractTitle(expandedResource))
                    .withPublicationDate(mapToPublicationDate(candidate.getPublicationDetails().publicationDate()))
-                   .withContributors(contributors)
-                   .withContributorsPreview(containsContributorsPreview(expandedResource)
-                                                ? mapToContributors(extractContributorsPreview(expandedResource),
-                                                                    candidate)
-                                                : contributors.stream().limit(CONTRIBUTORS_PREVIEW_LIMIT).toList())
+                   .withContributors(
+                       mapToContributors(ExpandedResourceGenerator.extractContributors(expandedResource), candidate))
                    .withPublicationChannel(getPublicationChannel(expandedResource, candidate.getPublicationDetails()))
                    .withPages(getPages(expandedResource))
                    .withLanguage(extractOptionalLanguage(expandedResource))
@@ -215,11 +202,6 @@ public final class IndexDocumentTestUtils {
                        nviOrganization(randomUri()),
                        randomNonNviAffiliation()))
                    .build();
-    }
-
-    private static boolean containsContributorsPreview(JsonNode expandedResource) {
-        var entityDescription = expandedResource.at("/entityDescription");
-        return JsonUtils.isNodePresent(entityDescription, "/contributorsPreview");
     }
 
     private static String extractOptionalLanguage(JsonNode expandedResource) {
@@ -377,10 +359,10 @@ public final class IndexDocumentTestUtils {
 
     private static Contributor generateContributor(JsonNode contributorNode, List<URI> affiliations) {
         return Contributor.builder()
-                   .withId(extractId(contributorNode))
-                   .withName(extractName(contributorNode))
-                   .withOrcid(extractOrcid(contributorNode))
-                   .withRole(extractRole(contributorNode))
+                   .withId(ExpandedResourceGenerator.extractId(contributorNode))
+                   .withName(ExpandedResourceGenerator.extractName(contributorNode))
+                   .withOrcid(ExpandedResourceGenerator.extractOrcid(contributorNode))
+                   .withRole(ExpandedResourceGenerator.extractRole(contributorNode))
                    .withAffiliations(expandAffiliations(affiliations))
                    .build();
     }
@@ -388,10 +370,10 @@ public final class IndexDocumentTestUtils {
     private static ContributorType generateNviContributor(JsonNode contributorNode, Creator value,
                                                           List<URI> affiliations) {
         return NviContributor.builder()
-                   .withId(extractId(contributorNode))
-                   .withName(extractName(contributorNode))
-                   .withOrcid(extractOrcid(contributorNode))
-                   .withRole(extractRole(contributorNode))
+                   .withId(ExpandedResourceGenerator.extractId(contributorNode))
+                   .withName(ExpandedResourceGenerator.extractName(contributorNode))
+                   .withOrcid(ExpandedResourceGenerator.extractOrcid(contributorNode))
+                   .withRole(ExpandedResourceGenerator.extractRole(contributorNode))
                    .withAffiliations(expandAffiliationsWithPartOf(value, affiliations))
                    .build();
     }
@@ -401,7 +383,7 @@ public final class IndexDocumentTestUtils {
                    .creators()
                    .stream()
                    .filter(
-                       creator -> creator.id().toString().equals(extractId(contributorNode)))
+                       creator -> creator.id().toString().equals(ExpandedResourceGenerator.extractId(contributorNode)))
                    .findFirst();
     }
 


### PR DESCRIPTION
Jira task: NP-47862 Remove `contributorsPreview` from index document, use `nviContributors` for "preview" in frontend

(Almost a revert of previous commit, just keeping `contributorsCount` field)