### PR TITLE
Np 47798 Remove contributors-list from search response

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -44,12 +44,14 @@ public record CandidateSearchParameters(String searchTerm,
     private static final String DEFAULT_STRING = StringUtils.EMPTY_STRING;
     private static final int DEFAULT_QUERY_SIZE = 10;
     private static final int DEFAULT_OFFSET_SIZE = 0;
+    private static final String CONTRIBUTORS_EXCLUDED_TO_REDUCE_RESPONSE_SIZE = "publicationDetails.contributors";
 
     public static Builder builder() {
         return new Builder();
     }
 
-    public static CandidateSearchParameters fromRequestInfo(RequestInfo requestInfo, List<String> affiliationIdentifiers)
+    public static CandidateSearchParameters fromRequestInfo(RequestInfo requestInfo,
+                                                            List<String> affiliationIdentifiers)
         throws UnauthorizedException, BadRequestException {
         var aggregationType = extractQueryParamAggregationType(requestInfo);
         return CandidateSearchParameters.builder()
@@ -66,6 +68,7 @@ public record CandidateSearchParameters(String searchTerm,
                    .withAggregationType(aggregationType)
                    .withSearchResultParameters(getResultParameters(requestInfo))
                    .withTopLevelCristinOrg(requestInfo.getTopLevelOrgCristinId().orElse(null))
+                   .withExcludeFields(List.of(CONTRIBUTORS_EXCLUDED_TO_REDUCE_RESPONSE_SIZE))
                    .build();
     }
 
@@ -164,6 +167,7 @@ public record CandidateSearchParameters(String searchTerm,
 
         private Builder() {
         }
+
         public Builder withSearchTerm(String searchTerm) {
             this.searchTerm = searchTerm;
             return this;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -27,7 +27,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
@@ -71,7 +70,6 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
-import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -430,7 +428,7 @@ public class SearchNviCandidatesHandlerTest {
     @Test
     void shouldExcludeContributorsInSearchResponse() throws IOException {
         var userName = randomString();
-        var expectedExcludeFields = List.of("contributors");
+        var expectedExcludeFields = List.of("publicationDetails.contributors");
         mockIdentityService(userName);
         handler.handleRequest(requestWithoutQueryParameters(userName), output, context);
         Mockito.verify(openSearchClient, times(1))

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -27,7 +27,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.matches;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -69,6 +71,8 @@ import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.zalando.problem.Problem;
@@ -421,6 +425,16 @@ public class SearchNviCandidatesHandlerTest {
               "docCount" : 1
             }""";
         assertEquals(expectedFilterAggregation, objectMapper.writeValueAsString(actualAggregate));
+    }
+
+    @Test
+    void shouldExcludeContributorsInSearchResponse() throws IOException {
+        var userName = randomString();
+        var expectedExcludeFields = List.of("contributors");
+        mockIdentityService(userName);
+        handler.handleRequest(requestWithoutQueryParameters(userName), output, context);
+        Mockito.verify(openSearchClient, times(1))
+            .search(argThat(argument -> argument.excludeFields().equals(expectedExcludeFields)));
     }
 
     private static void mockOpenSearchClientWithParameterMatchingViewingScope(List<String> usersViewingScope)


### PR DESCRIPTION
Jira task: NP-47798 Nvi Search: Remove contributors-list from search response

After frontend has migrated to fields `nviContributors` and `contributorsCount`, remove contributors-list from search response. This is to reduce the response size on "monsterposter" 😄 

`OpenSearchClient` is mocked in `SearchNviCandidatesHandlerTest`
There is a test in `OpenSearchClientTest` verifying that this functionality works, see `shouldExcludeFields()`