### PR TITLE
Np 47910 Search term: hits for candidate identifier, publication identifier, title, contributor name

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -3,10 +3,12 @@ package no.sikt.nva.nvi.index.model.document;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.util.List;
+import nva.commons.core.paths.UriWrapper;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
 public record PublicationDetails(String id,
+                                 String publicationIdentifier,
                                  String type,
                                  String title,
                                  PublicationDate publicationDate,
@@ -24,6 +26,7 @@ public record PublicationDetails(String id,
     public static final class Builder {
 
         private String id;
+        private String publicationIdentifier;
         private String type;
         private String title;
         private PublicationDate publicationDate;
@@ -39,6 +42,7 @@ public record PublicationDetails(String id,
 
         public Builder withId(String id) {
             this.id = id;
+            this.publicationIdentifier = UriWrapper.fromUri(id).getLastPathElement();
             return this;
         }
 
@@ -83,8 +87,8 @@ public record PublicationDetails(String id,
         }
 
         public PublicationDetails build() {
-            return new PublicationDetails(id, type, title, publicationDate, nviContributors, contributors,
-                                          contributorsCount, publicationChannel, pages, language);
+            return new PublicationDetails(id, publicationIdentifier, type, title, publicationDate, nviContributors,
+                                          contributors, contributorsCount, publicationChannel, pages, language);
         }
     }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/PublicationDetails.java
@@ -8,7 +8,7 @@ import nva.commons.core.paths.UriWrapper;
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 @JsonSerialize
 public record PublicationDetails(String id,
-                                 String publicationIdentifier,
+                                 String identifier,
                                  String type,
                                  String title,
                                  PublicationDate publicationDate,
@@ -26,7 +26,7 @@ public record PublicationDetails(String id,
     public static final class Builder {
 
         private String id;
-        private String publicationIdentifier;
+        private String identifier;
         private String type;
         private String title;
         private PublicationDate publicationDate;
@@ -42,7 +42,7 @@ public record PublicationDetails(String id,
 
         public Builder withId(String id) {
             this.id = id;
-            this.publicationIdentifier = UriWrapper.fromUri(id).getLastPathElement();
+            this.identifier = UriWrapper.fromUri(id).getLastPathElement();
             return this;
         }
 
@@ -87,7 +87,7 @@ public record PublicationDetails(String id,
         }
 
         public PublicationDetails build() {
-            return new PublicationDetails(id, publicationIdentifier, type, title, publicationDate, nviContributors,
+            return new PublicationDetails(id, identifier, type, title, publicationDate, nviContributors,
                                           contributors, contributorsCount, publicationChannel, pages, language);
         }
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -117,6 +117,13 @@ public class CandidateQuery {
                    .orElse(null);
     }
 
+    private static Query buildSearchTermQuery(String searchTerm) {
+        return new MultiMatchQuery.Builder().query(searchTerm)
+                   .fields(jsonPathOf(PUBLICATION_DETAILS, IDENTIFIER))
+                   .build()
+                   ._toQuery();
+    }
+
     private List<Query> specificMatch() {
         var institutionQuery = affiliations.isEmpty() ? Optional.<Query>empty() : createInstitutionQuery();
         var filterQuery = constructQueryWithFilter();
@@ -178,7 +185,7 @@ public class CandidateQuery {
     }
 
     private Optional<Query> createSearchTermQuery(String searchTerm) {
-        return nonNull(searchTerm) ? Optional.of(new MultiMatchQuery.Builder().query(searchTerm).build()._toQuery())
+        return nonNull(searchTerm) ? Optional.of(buildSearchTermQuery(searchTerm))
                    : Optional.empty();
     }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -120,7 +120,8 @@ public class CandidateQuery {
     private static Query buildSearchTermQuery(String searchTerm) {
         return new MultiMatchQuery.Builder().query(searchTerm)
                    .fields(jsonPathOf(PUBLICATION_DETAILS, IDENTIFIER),
-                           jsonPathOf(PUBLICATION_DETAILS, TITLE))
+                           jsonPathOf(PUBLICATION_DETAILS, TITLE),
+                           jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, NAME))
                    .build()
                    ._toQuery();
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -119,7 +119,8 @@ public class CandidateQuery {
 
     private static Query buildSearchTermQuery(String searchTerm) {
         return new MultiMatchQuery.Builder().query(searchTerm)
-                   .fields(jsonPathOf(PUBLICATION_DETAILS, IDENTIFIER))
+                   .fields(jsonPathOf(PUBLICATION_DETAILS, IDENTIFIER),
+                           jsonPathOf(PUBLICATION_DETAILS, TITLE))
                    .build()
                    ._toQuery();
     }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -119,7 +119,8 @@ public class CandidateQuery {
 
     private static Query buildSearchTermQuery(String searchTerm) {
         return new MultiMatchQuery.Builder().query(searchTerm)
-                   .fields(jsonPathOf(PUBLICATION_DETAILS, IDENTIFIER),
+                   .fields(IDENTIFIER,
+                           jsonPathOf(PUBLICATION_DETAILS, IDENTIFIER),
                            jsonPathOf(PUBLICATION_DETAILS, TITLE),
                            jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, NAME))
                    .build()

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -178,7 +178,7 @@ public final class NviCandidateIndexDocumentGenerator {
 
     private PublicationDetails expandPublicationDetails(List<ContributorType> contributors) {
         return PublicationDetails.builder()
-                   .withId(extractId(expandedResource))
+                   .withId(candidate.getPublicationDetails().publicationId().toString())
                    .withContributors(contributors)
                    .withType(extractInstanceType())
                    .withPublicationDate(extractPublicationDate())

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -398,9 +398,9 @@ public class OpenSearchClientTest {
 
     @Test
     void shouldReturnHitOnSearchTermPublicationIdentifier() throws IOException, InterruptedException {
-        var candidatesInIndex = generateNumberOfCandidates(5);
-        addDocumentsToIndex(candidatesInIndex.toArray(new NviCandidateIndexDocument[0]));
-        var searchTerm = candidatesInIndex.get(2).publicationDetails().identifier();
+        var indexDocuments = generateNumberOfCandidates(5);
+        addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
+        var searchTerm = indexDocuments.get(2).publicationDetails().identifier();
         var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
@@ -409,13 +409,25 @@ public class OpenSearchClientTest {
 
     @Test
     void shouldReturnHitOnSearchTermPublicationTitle() throws IOException, InterruptedException {
-        var candidatesInIndex = generateNumberOfCandidates(5);
-        addDocumentsToIndex(candidatesInIndex.toArray(new NviCandidateIndexDocument[0]));
-        var searchTerm = candidatesInIndex.get(2).publicationDetails().title();
+        var indexDocuments = generateNumberOfCandidates(5);
+        addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
+        var searchTerm = indexDocuments.get(2).publicationDetails().title();
         var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
         assertEquals(searchTerm, searchResponse.hits().hits().get(0).source().publicationDetails().title());
+    }
+
+    @Test
+    void shouldReturnHitOnSearchTermContributorName() throws IOException, InterruptedException {
+        var indexDocuments = generateNumberOfCandidates(5);
+        addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
+        var expectedHit = indexDocuments.get(2);
+        var searchTerm = expectedHit.publicationDetails().contributors().get(0).name();
+        var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
+        var searchResponse = openSearchClient.search(searchParameters);
+        assertThat(searchResponse.hits().hits(), hasSize(1));
+        assertEquals(expectedHit.identifier(), searchResponse.hits().hits().get(0).source().identifier());
     }
 
     @Test
@@ -817,7 +829,8 @@ public class OpenSearchClientTest {
                    .withTitle(randomString())
                    .withPublicationDate(PublicationDate.builder().withYear(YEAR).build())
                    .withPublicationChannel(randomPublicationChannel())
-                   .withPages(randomPages());
+                   .withPages(randomPages())
+                   .withContributors(List.of(randomNviContributor(randomUri())));
     }
 
     private static void addDocumentsToIndex(NviCandidateIndexDocument... documents) throws InterruptedException {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -375,28 +375,6 @@ public class OpenSearchClientTest {
     }
 
     @Test
-    void shouldReturnSingleDocumentWhenFilteringBySearchTerm() throws InterruptedException, IOException {
-        var customer = randomUri();
-        var searchTerm = randomString().concat(" ").concat(randomString()).concat(" ").concat(randomString());
-        var document = singleNviCandidateIndexDocumentWithCustomer(customer,
-                                                                   searchTerm, randomString(),
-                                                                   YEAR, randomString());
-        addDocumentsToIndex(document, singleNviCandidateIndexDocumentWithCustomer(
-            customer, randomString(), randomString(), randomString(), randomString()));
-
-        var searchParameters =
-            defaultSearchParameters().withAffiliations(List.of(getLastPathElement(customer)))
-                .withSearchTerm(getRandomWord(searchTerm))
-                .withYear(YEAR)
-                .build();
-
-        var searchResponse =
-            openSearchClient.search(searchParameters);
-
-        assertThat(searchResponse.hits().hits(), hasSize(1));
-    }
-
-    @Test
     void shouldReturnHitOnSearchTermPublicationIdentifier() throws IOException, InterruptedException {
         var indexDocuments = generateNumberOfCandidates(5);
         addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
@@ -428,6 +406,15 @@ public class OpenSearchClientTest {
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
         assertEquals(expectedHit.identifier(), searchResponse.hits().hits().get(0).source().identifier());
+    }
+
+    @Test
+    void shouldReturnAllWhenSearchTermNotProvided() throws InterruptedException, IOException {
+        var indexDocuments = generateNumberOfCandidates(5);
+        addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
+        var searchParameters = defaultSearchParameters().build();
+        var searchResponse = openSearchClient.search(searchParameters);
+        assertThat(searchResponse.hits().hits(), hasSize(5));
     }
 
     @Test

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -386,6 +386,17 @@ public class OpenSearchClientTest {
     }
 
     @Test
+    void shouldReturnHitOnSearchTermCandidateIdentifier() throws IOException, InterruptedException {
+        var indexDocuments = generateNumberOfCandidates(5);
+        addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
+        var searchTerm = indexDocuments.get(2).identifier().toString();
+        var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
+        var searchResponse = openSearchClient.search(searchParameters);
+        assertThat(searchResponse.hits().hits(), hasSize(1));
+        assertEquals(searchTerm, searchResponse.hits().hits().get(0).source().identifier().toString());
+    }
+
+    @Test
     void shouldReturnHitOnSearchTermPublicationTitle() throws IOException, InterruptedException {
         var indexDocuments = generateNumberOfCandidates(5);
         addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -410,12 +410,12 @@ public class OpenSearchClientTest {
     @Test
     void shouldReturnHitsOnSearchTermsPartOfPublicationTitle() throws IOException, InterruptedException {
         var firstTitle = "Start of sentence. Lorem ipsum dolor sit amet, consectetur adipiscing elit";
-        var secondTitle = "Another hit. Lorem ipsum dolor sit amet, something else";
+        var secondTitle = "Another hit. First word lorem ipsum dolor sit amet, something else";
         var thirdTitleShouldNotGetHit = "Some other title";
         var indexDocuments = List.of(indexDocumentWithTitle(firstTitle), indexDocumentWithTitle(secondTitle),
                                      indexDocumentWithTitle(thirdTitleShouldNotGetHit));
         addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
-        var searchTerm = "Lorem ipsum";
+        var searchTerm = "lorem ipsum";
         var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(2));

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -382,7 +382,7 @@ public class OpenSearchClientTest {
         var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
-        assertEquals(searchTerm, searchResponse.hits().hits().get(0).source().publicationDetails().identifier());
+        assertEquals(searchTerm, getFirstHit(searchResponse).publicationDetails().identifier());
     }
 
     @Test
@@ -393,7 +393,7 @@ public class OpenSearchClientTest {
         var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
-        assertEquals(searchTerm, searchResponse.hits().hits().get(0).source().identifier().toString());
+        assertEquals(searchTerm, getFirstHit(searchResponse).identifier().toString());
     }
 
     @Test
@@ -404,7 +404,7 @@ public class OpenSearchClientTest {
         var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
-        assertEquals(searchTerm, searchResponse.hits().hits().get(0).source().publicationDetails().title());
+        assertEquals(searchTerm, getFirstHit(searchResponse).publicationDetails().title());
     }
 
     @Test
@@ -416,7 +416,7 @@ public class OpenSearchClientTest {
         var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
-        assertEquals(expectedHit.identifier(), searchResponse.hits().hits().get(0).source().identifier());
+        assertEquals(expectedHit.identifier(), getFirstHit(searchResponse).identifier());
     }
 
     @Test
@@ -624,8 +624,12 @@ public class OpenSearchClientTest {
                                    .withExcludeFields(List.of("publicationDetails.contributors"))
                                    .build();
         var searchResponse = openSearchClient.search(searchParameters);
-        var firstHit = searchResponse.hits().hits().get(0).source();
+        var firstHit = getFirstHit(searchResponse);
         assertNull(requireNonNull(firstHit).publicationDetails().contributors());
+    }
+
+    private static NviCandidateIndexDocument getFirstHit(SearchResponse<NviCandidateIndexDocument> searchResponse) {
+        return searchResponse.hits().hits().get(0).source();
     }
 
     private static List<NviCandidateIndexDocument> generateNumberOfCandidates(int number) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -408,6 +408,17 @@ public class OpenSearchClientTest {
     }
 
     @Test
+    void shouldReturnHitOnSearchTermPublicationTitle() throws IOException, InterruptedException {
+        var candidatesInIndex = generateNumberOfCandidates(5);
+        addDocumentsToIndex(candidatesInIndex.toArray(new NviCandidateIndexDocument[0]));
+        var searchTerm = candidatesInIndex.get(2).publicationDetails().title();
+        var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
+        var searchResponse = openSearchClient.search(searchParameters);
+        assertThat(searchResponse.hits().hits(), hasSize(1));
+        assertEquals(searchTerm, searchResponse.hits().hits().get(0).source().publicationDetails().title());
+    }
+
+    @Test
     void shouldReturnSingleDocumentWhenFilteringByYear() throws InterruptedException, IOException {
         var customer = randomUri();
         var year = randomString();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -397,6 +397,17 @@ public class OpenSearchClientTest {
     }
 
     @Test
+    void shouldReturnHitOnSearchTermPublicationIdentifier() throws IOException, InterruptedException {
+        var candidatesInIndex = generateNumberOfCandidates(5);
+        addDocumentsToIndex(candidatesInIndex.toArray(new NviCandidateIndexDocument[0]));
+        var searchTerm = candidatesInIndex.get(2).publicationDetails().identifier();
+        var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
+        var searchResponse = openSearchClient.search(searchParameters);
+        assertThat(searchResponse.hits().hits(), hasSize(1));
+        assertEquals(searchTerm, searchResponse.hits().hits().get(0).source().publicationDetails().identifier());
+    }
+
+    @Test
     void shouldReturnSingleDocumentWhenFilteringByYear() throws InterruptedException, IOException {
         var customer = randomUri();
         var year = randomString();
@@ -596,6 +607,12 @@ public class OpenSearchClientTest {
         assertNull(requireNonNull(firstHit).publicationDetails().contributors());
     }
 
+    private static List<NviCandidateIndexDocument> generateNumberOfCandidates(int number) {
+        return IntStream.range(0, number)
+                   .mapToObj(i -> singleNviCandidateIndexDocument().build())
+                   .toList();
+    }
+
     private static NviCandidateIndexDocument documentWithContributors() {
         return singleNviCandidateIndexDocument()
                    .withPublicationDetails(publicationDetailsBuilder()
@@ -785,6 +802,7 @@ public class OpenSearchClientTest {
 
     private static PublicationDetails.Builder publicationDetailsBuilder() {
         return PublicationDetails.builder()
+                   .withId(randomUri().toString())
                    .withTitle(randomString())
                    .withPublicationDate(PublicationDate.builder().withYear(YEAR).build())
                    .withPublicationChannel(randomPublicationChannel())


### PR DESCRIPTION
Jira task: NP-47910 Search query: hits for publicationIdentifier, title, contributor name
- Adding `publicationDetails.identifier` as new field in index document
- Making searcTerm query more specific, adding fields `identifier`, `publicationDetails.identifier`, `publicationDetails.title` and `publicationDetails.contributor.name`