### PR TITLE
Remove organizationApprovalStatuses from default aggregations

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -48,7 +48,7 @@ public final class Aggregations {
     public static Map<String, Aggregation> generateAggregations(String aggregationType, String username,
                                                                 String topLevelCristinOrg) {
         return aggregationTypeIsNotSpecified(aggregationType)
-                   ? generateAllAggregationTypes(username, topLevelCristinOrg)
+                   ? generateAllDefaultAggregationTypes(username, topLevelCristinOrg)
                    : generateSingleAggregation(aggregationType, username, topLevelCristinOrg);
     }
 
@@ -139,9 +139,9 @@ public final class Aggregations {
         return aggregations;
     }
 
-    private static Map<String, Aggregation> generateAllAggregationTypes(String username, String topLevelCristinOrg) {
+    private static Map<String, Aggregation> generateAllDefaultAggregationTypes(String username, String topLevelCristinOrg) {
         var aggregations = new HashMap<String, Aggregation>();
-        for (var aggregation : SearchAggregation.values()) {
+        for (var aggregation : SearchAggregation.defaultAggregations()) {
             addAggregation(username, topLevelCristinOrg, aggregations, aggregation);
         }
         return aggregations;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/SearchAggregation.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/SearchAggregation.java
@@ -1,5 +1,9 @@
 package no.sikt.nva.nvi.index.query;
 
+import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.APPROVED;
+import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
+import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.PENDING;
+import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.REJECTED;
 import static no.sikt.nva.nvi.index.query.Aggregations.collaborationAggregation;
 import static no.sikt.nva.nvi.index.query.Aggregations.completedAggregation;
 import static no.sikt.nva.nvi.index.query.Aggregations.disputeAggregation;
@@ -7,12 +11,10 @@ import static no.sikt.nva.nvi.index.query.Aggregations.finalizedCollaborationAgg
 import static no.sikt.nva.nvi.index.query.Aggregations.organizationApprovalStatusAggregations;
 import static no.sikt.nva.nvi.index.query.Aggregations.statusAggregation;
 import static no.sikt.nva.nvi.index.query.Aggregations.totalCountAggregation;
-import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.APPROVED;
-import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
-import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.PENDING;
-import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.REJECTED;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiFunction;
+import java.util.stream.Stream;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 
 public enum SearchAggregation {
@@ -54,6 +56,16 @@ public enum SearchAggregation {
                    .filter(type -> type.getAggregationName().equalsIgnoreCase(candidate))
                    .findFirst()
                    .orElse(null);
+    }
+
+    public static List<SearchAggregation> defaultAggregations() {
+        return Stream.of(values())
+                   .filter(SearchAggregation::isNotOrganizationApprovalStatusAggregation)
+                   .toList();
+    }
+
+    private static boolean isNotOrganizationApprovalStatusAggregation(SearchAggregation searchAggregation) {
+        return !ORGANIZATION_APPROVAL_STATUS_AGGREGATION.equals(searchAggregation);
     }
 
     public Aggregation generateAggregation(String username, String topLevelCristinOrg) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -11,6 +11,7 @@ import static no.sikt.nva.nvi.index.query.SearchAggregation.COMPLETED_AGGREGATIO
 import static no.sikt.nva.nvi.index.query.SearchAggregation.DISPUTED_AGG;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.NEW_AGG;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.NEW_COLLABORATION_AGG;
+import static no.sikt.nva.nvi.index.query.SearchAggregation.ORGANIZATION_APPROVAL_STATUS_AGGREGATION;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.PENDING_AGG;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.PENDING_COLLABORATION_AGG;
 import static no.sikt.nva.nvi.index.query.SearchAggregation.REJECTED_AGG;
@@ -247,13 +248,17 @@ public class OpenSearchClientTest {
     }
 
     @Test
-    void shouldReturnAllAggregationsWhenAggregationTypeAll() throws IOException {
+    void shouldReturnDefaultAggregationsWhenAggregationTypeAll() throws IOException {
         var searchParameters = CandidateSearchParameters.builder()
                                    .withAggregationType("all")
                                    .build();
         var searchResponse = openSearchClient.search(searchParameters);
         var aggregations = searchResponse.aggregations();
-        assertEquals(SearchAggregation.values().length, aggregations.keySet().size());
+        var expectedAggregations = Arrays.stream(SearchAggregation.values())
+                                       .filter(
+                                           aggregation -> !aggregation.equals(ORGANIZATION_APPROVAL_STATUS_AGGREGATION))
+                                       .toList();
+        assertEquals(expectedAggregations.size(), aggregations.keySet().size());
     }
 
     @Test

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -256,7 +256,7 @@ public class OpenSearchClientTest {
         var aggregations = searchResponse.aggregations();
         var expectedAggregations = Arrays.stream(SearchAggregation.values())
                                        .filter(
-                                           aggregation -> !aggregation.equals(ORGANIZATION_APPROVAL_STATUS_AGGREGATION))
+                                           aggregation -> !ORGANIZATION_APPROVAL_STATUS_AGGREGATION.equals(aggregation))
                                        .toList();
         assertEquals(expectedAggregations.size(), aggregations.keySet().size());
     }


### PR DESCRIPTION
Jira task: NP-47595 Search optimizations, remove organizationApprovalStatuses -aggregation from default aggregations

`organizationApprovalStatuses`-aggregations is a heavier aggregation, and is not necessary as a default aggregation

Also, when we merge https://github.com/BIBSYSDEV/nva-nvi/pull/390 (increase size limit for terms aggregations), this will affect performance more