### PR TITLE
Np 47927 One search hit for unique identifiers

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -41,8 +41,10 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import org.opensearch.client.opensearch._types.query_dsl.MatchPhraseQuery;
 import org.opensearch.client.opensearch._types.query_dsl.MultiMatchQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Operator;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
+import org.opensearch.client.opensearch._types.query_dsl.TextQueryType;
 
 public class CandidateQuery {
 
@@ -119,12 +121,15 @@ public class CandidateQuery {
     }
 
     private static Query buildSearchTermQuery(String searchTerm) {
-        return new MultiMatchQuery.Builder().query(searchTerm)
+        return new MultiMatchQuery.Builder()
+                   .query(searchTerm)
                    .fields(IDENTIFIER,
                            jsonPathOf(PUBLICATION_DETAILS, IDENTIFIER),
                            jsonPathOf(PUBLICATION_DETAILS, TITLE),
                            jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, NAME),
                            jsonPathOf(PUBLICATION_DETAILS, ABSTRACT))
+                   .operator(Operator.And)
+                   .type(TextQueryType.CrossFields)
                    .build()
                    ._toQuery();
     }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -475,19 +475,6 @@ public class OpenSearchClientTest {
     }
 
     @Test
-    void shouldReturnOneHitWhenSearchTermExactlyCandidateIdentifier() throws IOException, InterruptedException {
-        var expectedHit = singleNviCandidateIndexDocument().build();
-        var searchTerm = expectedHit.identifier().toString();
-        var someTitleIncludingPartsOfSearchTerm = "Some title including " + searchTerm.split("-")[0];
-        var indexDocuments = List.of(expectedHit, indexDocumentWithTitle(someTitleIncludingPartsOfSearchTerm));
-        addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
-        var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
-        var searchResponse = openSearchClient.search(searchParameters);
-        assertThat(searchResponse.hits().hits(), hasSize(1));
-        assertEquals(expectedHit.identifier(), getFirstHit(searchResponse).identifier());
-    }
-
-    @Test
     void shouldReturnSingleDocumentWhenFilteringByYear() throws InterruptedException, IOException {
         var customer = randomUri();
         var year = randomString();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -65,7 +65,6 @@ import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.document.InstitutionPoints;
 import no.sikt.nva.nvi.index.model.document.InstitutionPoints.CreatorAffiliationPoints;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
-import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument.Builder;
 import no.sikt.nva.nvi.index.model.document.NviContributor;
 import no.sikt.nva.nvi.index.model.document.NviOrganization;
 import no.sikt.nva.nvi.index.model.document.PublicationDate;
@@ -463,7 +462,7 @@ public class OpenSearchClientTest {
     }
 
     @Test
-    void shouldReturnOneHitOnSearchTermPublicationIdentifier() throws IOException, InterruptedException {
+    void shouldReturnOneHitWhenSearchTermExactlyPublicationIdentifier() throws IOException, InterruptedException {
         var expectedHit = singleNviCandidateIndexDocument().build();
         var searchTerm = expectedHit.publicationDetails().identifier();
         var someTitleIncludingPartsOfSearchTerm = "Some title including " + searchTerm.split("-")[0];
@@ -472,7 +471,20 @@ public class OpenSearchClientTest {
         var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
         var searchResponse = openSearchClient.search(searchParameters);
         assertThat(searchResponse.hits().hits(), hasSize(1));
-        assertEquals(expectedHit, getFirstHit(searchResponse));
+        assertEquals(expectedHit.identifier(), getFirstHit(searchResponse).identifier());
+    }
+
+    @Test
+    void shouldReturnOneHitWhenSearchTermExactlyCandidateIdentifier() throws IOException, InterruptedException {
+        var expectedHit = singleNviCandidateIndexDocument().build();
+        var searchTerm = expectedHit.identifier().toString();
+        var someTitleIncludingPartsOfSearchTerm = "Some title including " + searchTerm.split("-")[0];
+        var indexDocuments = List.of(expectedHit, indexDocumentWithTitle(someTitleIncludingPartsOfSearchTerm));
+        addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
+        var searchParameters = defaultSearchParameters().withSearchTerm(searchTerm).build();
+        var searchResponse = openSearchClient.search(searchParameters);
+        assertThat(searchResponse.hits().hits(), hasSize(1));
+        assertEquals(expectedHit.identifier(), getFirstHit(searchResponse).identifier());
     }
 
     @Test


### PR DESCRIPTION
Jira task: NP-47927 Search for unique identifiers should only give one hit

Thanks for the help @StigNorland 😄 

- Modify mulitimatch query, add operator `And` and type `CrossFields`