### PR TITLE
Use enum InstanceType in evaluated candidate and upsert request

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -108,7 +108,7 @@ public class EvaluatorService {
                    .withPublicationId(publicationId)
                    .withPublicationBucketUri(publicationBucketUri)
                    .withDate(date)
-                   .withInstanceType(pointCalculation.instanceType().getValue())
+                   .withInstanceType(pointCalculation.instanceType())
                    .withBasePoints(pointCalculation.basePoints())
                    .withPublicationChannelId(pointCalculation.publicationChannelId())
                    .withChannelType(pointCalculation.channelType().getValue())

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/model/NviCandidate.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import no.sikt.nva.nvi.common.service.model.InstanceType;
 import no.sikt.nva.nvi.common.service.model.InstitutionPoints;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
@@ -17,7 +18,7 @@ import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
 @JsonSerialize
 public record NviCandidate(URI publicationId,
                            URI publicationBucketUri,
-                           String instanceType,
+                           InstanceType instanceType,
                            @JsonProperty("publicationDate") PublicationDate date,
                            List<NviCreator> nviCreators,
                            String channelType,
@@ -68,7 +69,7 @@ public record NviCandidate(URI publicationId,
 
         private URI publicationId;
         private URI publicationBucketUri;
-        private String instanceType;
+        private InstanceType instanceType;
         private PublicationDate date;
         private List<NviCreator> nviCreatorWithAffiliationPoints;
         private String channelType;
@@ -94,7 +95,7 @@ public record NviCandidate(URI publicationId,
             return this;
         }
 
-        public Builder withInstanceType(String instanceType) {
+        public Builder withInstanceType(InstanceType instanceType) {
             this.instanceType = instanceType;
             return this;
         }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -235,7 +235,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
         var expectedPoints = BigDecimal.valueOf(1).setScale(SCALE, ROUNDING_MODE);
-        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(InstanceType.ACADEMIC_ARTICLE.getValue(),
+        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(InstanceType.ACADEMIC_ARTICLE,
                                                                    expectedPoints,
                                                                    fileUri, JOURNAL,
                                                                    ONE, expectedPoints);
@@ -251,7 +251,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
         var expectedPoints = BigDecimal.valueOf(1).setScale(SCALE, ROUNDING_MODE);
-        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(InstanceType.ACADEMIC_CHAPTER.getValue(),
+        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(InstanceType.ACADEMIC_CHAPTER,
                                                                    expectedPoints,
                                                                    fileUri, SERIES,
                                                                    ONE, expectedPoints);
@@ -267,7 +267,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
         var expectedPoints = BigDecimal.valueOf(5).setScale(SCALE, ROUNDING_MODE);
-        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_MONOGRAPH.getValue(),
+        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_MONOGRAPH,
                                                                    expectedPoints,
                                                                    fileUri, SERIES,
                                                                    BigDecimal.valueOf(5), expectedPoints
@@ -284,7 +284,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
         var expectedPoints = BigDecimal.valueOf(5).setScale(SCALE, ROUNDING_MODE);
-        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_COMMENTARY.getValue(),
+        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_COMMENTARY,
           expectedPoints,
           fileUri, SERIES,
           BigDecimal.valueOf(5), expectedPoints
@@ -301,7 +301,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
         var expectedPoints = BigDecimal.valueOf(1).setScale(SCALE, ROUNDING_MODE);
-        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_LITERATURE_REVIEW.getValue(),
+        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_LITERATURE_REVIEW,
                                                                    expectedPoints,
                                                                    fileUri, JOURNAL,
                                                                    ONE, expectedPoints);
@@ -518,7 +518,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
         var expectedPoints = BigDecimal.valueOf(5).setScale(SCALE, ROUNDING_MODE);
-        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_MONOGRAPH.getValue(),
+        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(ACADEMIC_MONOGRAPH,
                                                                    expectedPoints,
                                                                    fileUri, SERIES,
                                                                    BigDecimal.valueOf(5), expectedPoints);
@@ -536,7 +536,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         handler.handleRequest(event, context);
         var messageBody = getMessageBody();
         var expectedPoints = ONE.setScale(SCALE, ROUNDING_MODE);
-        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(InstanceType.ACADEMIC_ARTICLE.getValue(),
+        var expectedEvaluatedMessage = getExpectedEvaluatedMessage(InstanceType.ACADEMIC_ARTICLE,
                                                                    expectedPoints,
                                                                    fileUri, JOURNAL,
                                                                    BigDecimal.valueOf(1), expectedPoints);
@@ -550,7 +550,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
         }
     }
 
-    private static CandidateEvaluatedMessage getExpectedEvaluatedMessage(String instanceType,
+    private static CandidateEvaluatedMessage getExpectedEvaluatedMessage(InstanceType instanceType,
                                                                          BigDecimal points, URI bucketUri,
                                                                          PublicationChannel publicationChannel,
                                                                          BigDecimal basePoints,
@@ -564,7 +564,7 @@ class EvaluateNviCandidateHandlerTest extends LocalDynamoTest {
                    .build();
     }
 
-    private static NviCandidate createExpectedCandidate(String instanceType, Map<URI, BigDecimal> institutionPoints,
+    private static NviCandidate createExpectedCandidate(InstanceType instanceType, Map<URI, BigDecimal> institutionPoints,
                                                         PublicationChannel channelType, String level,
                                                         BigDecimal basePoints, BigDecimal totalPoints,
                                                         URI publicationBucketUri) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -156,7 +156,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
         var identifier = UUID.randomUUID();
         var publicationId = generatePublicationId(identifier);
         var dto = Candidate.upsert(
-            createUpsertCandidateRequest(publicationId, randomUri(), true, InstanceType.ACADEMIC_ARTICLE.getValue(), 1,
+            createUpsertCandidateRequest(publicationId, randomUri(), true, InstanceType.ACADEMIC_ARTICLE, 1,
                                          randomBigDecimal(),
                                          randomLevelExcluding(DbLevel.NON_CANDIDATE).getValue(),
                                          TestUtils.CURRENT_YEAR,
@@ -202,7 +202,8 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
     private static Builder getBuilder(URI publicationId, URI publicationBucketUri, NviCreator creator) {
         return NviCandidate.builder()
                    .withPublicationId(publicationId)
-                   .withPublicationBucketUri(publicationBucketUri).withInstanceType(randomInstanceType().getValue())
+                   .withPublicationBucketUri(publicationBucketUri)
+                   .withInstanceType(randomInstanceType())
                    .withLevel(randomElement(DbLevel.values()).getValue())
                    .withTotalPoints(randomBigDecimal(4))
                    .withBasePoints(randomBigDecimal(4))
@@ -299,7 +300,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                    .applicable(true)
                    .publicationId(evaluatedNviCandidate.publicationId())
                    .publicationBucketUri(evaluatedNviCandidate.publicationBucketUri())
-                   .instanceType(evaluatedNviCandidate.instanceType())
+                   .instanceType(evaluatedNviCandidate.instanceType().getValue())
                    .level(DbLevel.parse(evaluatedNviCandidate.level()))
                    .publicationDate(new DbPublicationDate(date.year(), date.month(), date.day()))
                    .channelType(ChannelType.parse(evaluatedNviCandidate.channelType()))

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -426,7 +426,7 @@ public final class Candidate {
     }
 
     private static boolean instanceTypeIsUpdated(UpsertCandidateRequest request, CandidateDao existingCandidateDao) {
-        return !Objects.equals(request.instanceType(), existingCandidateDao.candidate().instanceType());
+        return !Objects.equals(request.instanceType().getValue(), existingCandidateDao.candidate().instanceType());
     }
 
     private static boolean levelIsUpdated(UpsertCandidateRequest request, CandidateDao existingCandidateDao) {
@@ -454,7 +454,6 @@ public final class Candidate {
 
     private static void validateCandidate(UpsertCandidateRequest candidate) {
         attempt(() -> {
-            InstanceType.parse(candidate.instanceType());
             Objects.requireNonNull(candidate.instanceType());
             Objects.requireNonNull(candidate.publicationBucketUri());
             Objects.requireNonNull(candidate.institutionPoints());
@@ -512,7 +511,7 @@ public final class Candidate {
                    .channelType(ChannelType.parse(request.channelType()))
                    .channelId(request.publicationChannelId())
                    .level(DbLevel.parse(request.level()))
-                   .instanceType(request.instanceType())
+                   .instanceType(request.instanceType().getValue())
                    .publicationDate(mapToPublicationDate(request.publicationDate()))
                    .internationalCollaboration(request.isInternationalCollaboration())
                    .collaborationFactor(adjustScaleAndRoundingMode(request.collaborationFactor()))
@@ -535,7 +534,7 @@ public final class Candidate {
                                   .channelType(ChannelType.parse(request.channelType()))
                                   .channelId(request.publicationChannelId())
                                   .level(DbLevel.parse(request.level()))
-                                  .instanceType(request.instanceType())
+                                  .instanceType(request.instanceType().getValue())
                                   .publicationDate(mapToPublicationDate(request.publicationDate()))
                                   .internationalCollaboration(request.isInternationalCollaboration())
                                   .collaborationFactor(adjustScaleAndRoundingMode(request.collaborationFactor()))

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/InstanceType.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/InstanceType.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.common.service.model;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import java.util.Arrays;
 
 public enum InstanceType {
@@ -20,6 +21,11 @@ public enum InstanceType {
                    .filter(instanceType -> instanceType.getValue().equalsIgnoreCase(value))
                    .findFirst()
                    .orElseThrow();
+    }
+
+    @JsonValue
+    public String getInstanceType() {
+        return value;
     }
 
     public String getValue() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/requests/UpsertCandidateRequest.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/requests/UpsertCandidateRequest.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
+import no.sikt.nva.nvi.common.service.model.InstanceType;
 import no.sikt.nva.nvi.common.service.model.InstitutionPoints;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
 
@@ -25,7 +26,7 @@ public interface UpsertCandidateRequest {
 
     String level();
 
-    String instanceType();
+    InstanceType instanceType();
 
     PublicationDate publicationDate();
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -13,6 +13,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.model.InstanceType;
 import no.sikt.nva.nvi.common.service.model.InstitutionPoints;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
@@ -100,7 +101,7 @@ class CandidateRepositoryTest extends LocalDynamoTest {
             }
 
             @Override
-            public String instanceType() {
+            public InstanceType instanceType() {
                 return request.instanceType();
             }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalDtoTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalDtoTest.java
@@ -98,7 +98,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
     void shouldResetApprovalWhenChangingToPending(ApprovalStatus oldStatus) {
         var institutionId = randomUri();
         var upsertCandidateRequest = createUpsertCandidateRequest(randomUri(), randomUri(), true,
-                                                                  InstanceType.ACADEMIC_MONOGRAPH.getValue(), 1,
+                                                                  InstanceType.ACADEMIC_MONOGRAPH, 1,
                                                                   randomBigDecimal(),
                                                                   randomLevelExcluding(
                                                                       DbLevel.NON_CANDIDATE).getValue(),
@@ -142,7 +142,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
                             .orElseThrow();
         var updateRequest = createUpsertCandidateRequest(candidate.toDto().publicationId(),
                                                          randomUri(), true,
-                                                         InstanceType.ACADEMIC_MONOGRAPH.getValue(), 2,
+                                                         InstanceType.ACADEMIC_MONOGRAPH, 2,
                                                          randomBigDecimal(),
                                                          randomLevelExcluding(DbLevel.NON_CANDIDATE)
                                                              .getValue(), TestUtils.CURRENT_YEAR,
@@ -161,7 +161,7 @@ public class CandidateApprovalDtoTest extends LocalDynamoTest {
         var createCandidateRequest = createUpsertCandidateRequest(keepInstitutionId, deleteInstitutionId, randomUri());
         Candidate.upsert(createCandidateRequest, candidateRepository, periodRepository);
         var updateRequest = createUpsertCandidateRequest(
-            createCandidateRequest.publicationId(), randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH.getValue(), 2,
+            createCandidateRequest.publicationId(), randomUri(), true, InstanceType.ACADEMIC_MONOGRAPH, 2,
             randomBigDecimal(), randomLevelExcluding(DbLevel.NON_CANDIDATE).getValue(),
             TestUtils.CURRENT_YEAR,
             keepInstitutionId,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -289,7 +289,7 @@ class CandidateTest extends LocalDynamoTest {
         var institutionToApprove = randomUri();
         var totalPoints = randomBigDecimal();
         var createRequest = createUpsertCandidateRequest(randomUri(), randomUri(), true,
-                                                         InstanceType.ACADEMIC_MONOGRAPH.getValue(), 4, totalPoints,
+                                                         InstanceType.ACADEMIC_MONOGRAPH, 4, totalPoints,
                                                          randomLevelExcluding(DbLevel.NON_CANDIDATE)
                                                              .getValue(), CURRENT_YEAR,
                                                          institutionToApprove, randomUri(), institutionToReject);
@@ -340,7 +340,7 @@ class CandidateTest extends LocalDynamoTest {
         var points = List.of(createInstitutionPoints(institutionId, institutionPoints, creatorId));
         var totalPoints = randomBigDecimal();
         var publicationDate = new PublicationDate(String.valueOf(CURRENT_YEAR), null, null);
-        var instanceType = randomInstanceType().getValue();
+        var instanceType = randomInstanceType();
         var createRequest = createUpsertCandidateRequest(publicationId, publicationBucketUri,
                                                          isApplicable,
                                                          publicationDate,
@@ -361,7 +361,7 @@ class CandidateTest extends LocalDynamoTest {
         assertEquals(candidate.getInstitutionPoints(), points);
         assertEquals(candidate.getPublicationDetails().publicationDate(), publicationDate);
         assertCorrectCreatorData(creators, candidate);
-        assertEquals(candidate.getPublicationDetails().type(), instanceType);
+        assertEquals(candidate.getPublicationDetails().type(), instanceType.getValue());
         assertEquals(candidate.getPublicationDetails().channelType().getValue(), createRequest.channelType());
         assertEquals(candidate.getPublicationDetails().publicationChannelId(), createRequest.publicationChannelId());
         assertEquals(candidate.getPublicationDetails().level(), createRequest.level());
@@ -472,7 +472,7 @@ class CandidateTest extends LocalDynamoTest {
     @DisplayName("Should reset approvals when updating fields effecting approvals")
     void shouldResetApprovalsWhenUpdatingFieldsEffectingApprovals(CandidateResetCauseArgument arguments) {
         var originalLevel = DbLevel.LEVEL_TWO;
-        var originalType = InstanceType.ACADEMIC_MONOGRAPH.getValue();
+        var originalType = InstanceType.ACADEMIC_MONOGRAPH;
         var institutionId = randomUri();
         var creatorId = randomUri();
         var upsertCandidateRequest = getUpsertCandidateRequest(creatorId, institutionId, originalType, originalLevel);
@@ -587,7 +587,7 @@ class CandidateTest extends LocalDynamoTest {
         return createUpsertCandidateRequest(randomUri(), randomUri(), true,
                                             new PublicationDate(String.valueOf(CURRENT_YEAR), null, null),
                                             creators,
-                                            randomInstanceType().getValue(),
+                                            randomInstanceType(),
                                             randomElement(ChannelType.values()).getValue(), randomUri(),
                                             randomLevelExcluding(DbLevel.NON_CANDIDATE).getValue(), points,
                                             randomInteger(), randomBoolean(),
@@ -651,7 +651,7 @@ class CandidateTest extends LocalDynamoTest {
                                             randomUri(), true,
                                             new PublicationDate(String.valueOf(CURRENT_YEAR), null, null),
                                             creators,
-                                            arguments.type().getValue(),
+                                            arguments.type(),
                                             randomString(), randomUri(),
                                             arguments.level().getValue(),
                                             createPoints(creators),
@@ -660,7 +660,7 @@ class CandidateTest extends LocalDynamoTest {
     }
 
     private UpsertCandidateRequest getUpsertCandidateRequest(URI creatorId, URI institutionId,
-                                                             String type,
+                                                             InstanceType type,
                                                              DbLevel level) {
         return createUpsertCandidateRequest(URI.create("publicationId"), randomUri(), true,
                                             new PublicationDate(String.valueOf(CURRENT_YEAR), null, null),
@@ -705,7 +705,7 @@ class CandidateTest extends LocalDynamoTest {
                                     .publicationBucketUri(request.publicationBucketUri())
                                     .publicationDate(mapToDbPublicationDate(request.publicationDate()))
                                     .applicable(request.isApplicable())
-                                    .instanceType(request.instanceType())
+                                    .instanceType(request.instanceType().getValue())
                                     .channelType(ChannelType.parse(request.channelType()))
                                     .channelId(request.publicationChannelId())
                                     .level(DbLevel.parse(request.level()))
@@ -777,7 +777,7 @@ class CandidateTest extends LocalDynamoTest {
             }
 
             @Override
-            public String instanceType() {
+            public InstanceType instanceType() {
                 return request.instanceType();
             }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/InstanceTypeTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/InstanceTypeTest.java
@@ -1,5 +1,8 @@
 package no.sikt.nva.nvi.common.service.model;
 
+import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
+import static nva.commons.core.StringUtils.EMPTY_STRING;
+import static nva.commons.core.attempt.Try.attempt;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.util.NoSuchElementException;
@@ -15,6 +18,21 @@ class InstanceTypeTest {
     void shouldParseValidStrings(String value) {
         var instanceType = InstanceType.parse(value);
         assertEquals(value, instanceType.getValue());
+    }
+
+    @Test
+    void shouldSerializeUsingValue() {
+        var instanceType = InstanceType.ACADEMIC_ARTICLE;
+        var serialized = attempt(() -> objectMapper.writeValueAsString(instanceType)).orElseThrow();
+        assertEquals(instanceType.getValue(), serialized.replace("\"", EMPTY_STRING));
+    }
+
+    @Test
+    void shouldSerializeAndDeserializeUsingValue() {
+        var instanceType = InstanceType.ACADEMIC_ARTICLE;
+        var serialized = attempt(() -> objectMapper.writeValueAsString(instanceType)).orElseThrow();
+        var deserialized = attempt(() -> objectMapper.readValue(serialized, InstanceType.class)).orElseThrow();
+        assertEquals(instanceType, deserialized);
     }
 
     @Test

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/ExceptionMapperTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/ExceptionMapperTest.java
@@ -20,63 +20,63 @@ class ExceptionMapperTest {
 
     @Test
     void shouldReturnNotFoundExceptionWhenMappingNotFoundException() {
-        var failure = new Failure(new CandidateNotFoundException());
+        var failure = new Failure<>(new CandidateNotFoundException());
         var exception = ExceptionMapper.map(failure);
         assertEquals(NotFoundException.class, exception.getClass());
     }
 
     @Test
     void shouldReturnNotFoundExceptionWhenMappingNoSuchElementException() {
-        var failure = new Failure(new NoSuchElementException());
+        var failure = new Failure<>(new NoSuchElementException());
         var exception = ExceptionMapper.map(failure);
         assertEquals(NotFoundException.class, exception.getClass());
     }
 
     @Test
     void shouldReturnNotFoundExceptionWhenMappingCandidateNotFoundException() {
-        var failure = new Failure(new CandidateNotFoundException());
+        var failure = new Failure<>(new CandidateNotFoundException());
         var exception = ExceptionMapper.map(failure);
         assertEquals(NotFoundException.class, exception.getClass());
     }
 
     @Test
     void shouldReturnBadRequestExceptionWhenMappingIllegalArgumentException() {
-        var failure = new Failure(new IllegalArgumentException());
+        var failure = new Failure<>(new IllegalArgumentException());
         var exception = ExceptionMapper.map(failure);
         assertEquals(BadRequestException.class, exception.getClass());
     }
 
     @Test
     void shouldReturnBadRequestExceptionWhenMappingUnsupportedOperationException() {
-        var failure = new Failure(new UnsupportedOperationException());
+        var failure = new Failure<>(new UnsupportedOperationException());
         var exception = ExceptionMapper.map(failure);
         assertEquals(BadRequestException.class, exception.getClass());
     }
 
     @Test
     void shouldReturnConflictExceptionWhenMappingIllegalStateException() {
-        var failure = new Failure(new IllegalStateException());
+        var failure = new Failure<>(new IllegalStateException());
         var exception = ExceptionMapper.map(failure);
         assertEquals(ConflictException.class, exception.getClass());
     }
 
     @Test
     void shouldReturnUnauthorizedExceptionWhenMappingUnauthorizedOperationException() {
-        var failure = new Failure(new UnauthorizedOperationException(randomString()));
+        var failure = new Failure<>(new UnauthorizedOperationException(randomString()));
         var exception = ExceptionMapper.map(failure);
         assertEquals(UnauthorizedException.class, exception.getClass());
     }
 
     @Test
     void shouldReturnUnauthorizedExceptionWhenMappingUnauthorizedException() {
-        var failure = new Failure(new UnauthorizedOperationException(randomString()));
+        var failure = new Failure<>(new UnauthorizedOperationException(randomString()));
         var exception = ExceptionMapper.map(failure);
         assertEquals(UnauthorizedException.class, exception.getClass());
     }
 
     @Test
     void shouldReturnMethodNotAllowedExceptionWhenMappingNotApplicableException() {
-        var failure = new Failure(new NotApplicableException());
+        var failure = new Failure<>(new NotApplicableException());
         var exception = ExceptionMapper.map(failure);
         assertEquals(MethodNotAllowedException.class, exception.getClass());
         assertEquals(HttpURLConnection.HTTP_BAD_METHOD, exception.getStatusCode());
@@ -84,7 +84,7 @@ class ExceptionMapperTest {
 
     @Test
     void shouldReturnBadGatewayExceptionWhenMappingOtherExceptions() {
-        var failure = new Failure(new Exception());
+        var failure = new Failure<>(new Exception());
         var exception = ExceptionMapper.map(failure);
         assertEquals(BadGatewayException.class, exception.getClass());
     }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -260,12 +260,12 @@ public final class TestUtils {
     }
 
     public static UpsertCandidateRequest createUpsertCandidateRequestWithLevel(String level, URI... institutions) {
-        return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceType().getValue(),
+        return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceType(),
                                             1, randomBigDecimal(), level, CURRENT_YEAR, institutions);
     }
 
     public static UpsertCandidateRequest createUpsertCandidateRequest(int year) {
-        return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceType().getValue(),
+        return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceType(),
                                             1, randomBigDecimal(),
                                             randomLevelExcluding(DbLevel.NON_CANDIDATE).getValue(),
                                             year,
@@ -273,7 +273,7 @@ public final class TestUtils {
     }
 
     public static UpsertCandidateRequest createUpsertCandidateRequest(URI... institutions) {
-        return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceType().getValue(),
+        return createUpsertCandidateRequest(randomUri(), randomUri(), true, randomInstanceType(),
                                             1, randomBigDecimal(),
                                             randomLevelExcluding(DbLevel.NON_CANDIDATE).getValue(),
                                             CURRENT_YEAR,
@@ -294,7 +294,7 @@ public final class TestUtils {
 
         return createUpsertCandidateRequest(randomUri(), randomUri(), true,
                                             new PublicationDate(String.valueOf(CURRENT_YEAR), null, null), creators,
-                                            randomInstanceType().getValue(),
+                                            randomInstanceType(),
                                             channelType.getValue(), randomUri(),
                                             randomLevelExcluding(DbLevel.NON_CANDIDATE).getValue(), institutionPoints,
                                             randomInteger(), randomBoolean(),
@@ -304,7 +304,7 @@ public final class TestUtils {
     public static UpsertCandidateRequest createUpsertCandidateRequest(URI publicationId,
                                                                       URI publicationBucketUri,
                                                                       boolean isApplicable,
-                                                                      String instanceType,
+                                                                      InstanceType instanceType,
                                                                       int creatorCount,
                                                                       BigDecimal totalPoints,
                                                                       String level, int year,
@@ -337,7 +337,7 @@ public final class TestUtils {
                                                                       boolean isApplicable,
                                                                       final PublicationDate publicationDate,
                                                                       Map<URI, List<URI>> creators,
-                                                                      String instanceType,
+                                                                      InstanceType instanceType,
                                                                       String channelType, URI channelId,
                                                                       String level,
                                                                       List<InstitutionPoints> points,
@@ -390,7 +390,7 @@ public final class TestUtils {
             }
 
             @Override
-            public String instanceType() {
+            public InstanceType instanceType() {
                 return instanceType;
             }
 


### PR DESCRIPTION
Jira task: NP-48030 NVI missing validation of instance type

- Change `instanceType` `type` in evaluated `NviCandidate` and  `UpsertCandidateRequest` to `InstanceType` (enum)
- Keeping `Candidate.publicationDetails.type` and `DbCandidate.instanceType` `String`s because these also represent imported candidates from Cristin, which may include other unknown instance types