### PR TITLE
Np 48035 Candidate.upsert() void

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandler.java
@@ -14,7 +14,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.queue.NviQueueClient;
 import no.sikt.nva.nvi.common.queue.QueueClient;
 import no.sikt.nva.nvi.common.service.model.Candidate;
@@ -36,22 +35,18 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
     private static final String UPSERT_CANDIDATE_DLQ_QUEUE_URL = "UPSERT_CANDIDATE_DLQ_QUEUE_URL";
     private static final String UPSERT_CANDIDATE_FAILED_MESSAGE = "Failed to upsert candidate for publication: {}";
     private final CandidateRepository repository;
-    private final PeriodRepository periodRepository;
-
     private final QueueClient queueClient;
     private final String dlqUrl;
 
     @JacocoGenerated
     public UpsertNviCandidateHandler() {
-        this(new CandidateRepository(defaultDynamoClient()), new PeriodRepository(defaultDynamoClient()),
-             new NviQueueClient(), new Environment());
+        this(new CandidateRepository(defaultDynamoClient()), new NviQueueClient(), new Environment());
     }
 
-    public UpsertNviCandidateHandler(CandidateRepository repository, PeriodRepository periodRepository,
+    public UpsertNviCandidateHandler(CandidateRepository repository,
                                      QueueClient queueClient,
                                      Environment environment) {
         this.repository = repository;
-        this.periodRepository = periodRepository;
         this.queueClient = queueClient;
         this.dlqUrl = environment.readEnv(UPSERT_CANDIDATE_DLQ_QUEUE_URL);
     }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandler.java
@@ -99,7 +99,7 @@ public class UpsertNviCandidateHandler implements RequestHandler<SQSEvent, Void>
         try {
             validateMessage(evaluatedCandidate);
             if (evaluatedCandidate.candidate() instanceof NviCandidate candidate) {
-                Candidate.upsert(candidate, repository, periodRepository);
+                Candidate.upsert(candidate, repository);
             } else {
                 var nonNviCandidate = (NonNviCandidate) evaluatedCandidate.candidate();
                 Candidate.updateNonCandidate(nonNviCandidate, repository);

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -46,10 +46,11 @@ import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.db.model.KeyField;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
 import no.sikt.nva.nvi.common.model.ListingResult;
-import no.sikt.nva.nvi.common.utils.BatchScanUtil;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.utils.BatchScanUtil;
 import no.sikt.nva.nvi.events.model.ScanDatabaseRequest;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.events.models.AwsEventBridgeEvent;
 import no.unit.nva.stubs.FakeEventBridgeClient;
@@ -377,9 +378,7 @@ class EventBasedBatchScanHandlerTest extends LocalDynamoTest {
     private Stream<Candidate> createRandomCandidates(int i) {
         return IntStream.range(0, i)
                    .boxed()
-                   .map(item -> Candidate.upsert(createUpsertCandidateRequest(randomUri()), candidateRepository,
-                                                 periodRepository))
-                   .map(Optional::orElseThrow)
+                   .map(item -> TestUtils.randomApplicableCandidate(candidateRepository, periodRepository))
                    .map(a -> a.createNote(new CreateNoteRequest(randomString(), randomString(), randomUri())));
     }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.events.batch;
 
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -95,7 +95,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
         queueClient = mock(QueueClient.class);
         environment = mock(Environment.class);
         when(environment.readEnv("UPSERT_CANDIDATE_DLQ_QUEUE_URL")).thenReturn(DLQ_QUEUE_URL);
-        handler = new UpsertNviCandidateHandler(candidateRepository, periodRepository, queueClient, environment);
+        handler = new UpsertNviCandidateHandler(candidateRepository, queueClient, environment);
     }
 
     @Test
@@ -117,7 +117,7 @@ public class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
     @Test
     void shouldSendMessageToDlqWhenUnexpectedErrorOccurs() {
         candidateRepository = mock(CandidateRepository.class);
-        handler = new UpsertNviCandidateHandler(candidateRepository, periodRepository, queueClient, environment);
+        handler = new UpsertNviCandidateHandler(candidateRepository, queueClient, environment);
         when(candidateRepository.create(any(), any())).thenThrow(RuntimeException.class);
 
         handler.handleRequest(createEvent(randomCandidateEvaluatedMessage()), CONTEXT);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -54,7 +54,6 @@ import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.service.model.Candidate;
-import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.sikt.nva.nvi.index.aws.S3StorageWriter;
 import no.sikt.nva.nvi.index.model.PersistedIndexDocumentMessage;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
@@ -600,7 +599,7 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     private Candidate setUpNonApplicableCandidate(URI institutionId) {
         var request = createUpsertCandidateRequest(institutionId);
         Candidate.upsert(request, candidateRepository);
-        var candidate =  Candidate.fetchByPublicationId(request::publicationId, candidateRepository, periodRepository);
+        var candidate = Candidate.fetchByPublicationId(request::publicationId, candidateRepository, periodRepository);
         return Candidate.updateNonCandidate(
             createUpsertNonCandidateRequest(candidate.getPublicationId()),
             candidateRepository).orElseThrow();
@@ -755,7 +754,6 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
         var request = createUpsertCandidateRequest(topLevelOrg, affiliation);
         Candidate.upsert(request, candidateRepository);
         return Candidate.fetchByPublicationId(request::publicationId, candidateRepository, periodRepository);
-
     }
 
     private Candidate randomApplicableCandidate(URI topLevelOrg, URI affiliation, ChannelType channelType) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -54,6 +54,7 @@ import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.sikt.nva.nvi.index.aws.S3StorageWriter;
 import no.sikt.nva.nvi.index.model.PersistedIndexDocumentMessage;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
@@ -597,9 +598,9 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     }
 
     private Candidate setUpNonApplicableCandidate(URI institutionId) {
-        var candidate =
-            Candidate.upsert(createUpsertCandidateRequest(institutionId), candidateRepository, periodRepository)
-                .orElseThrow();
+        var request = createUpsertCandidateRequest(institutionId);
+        Candidate.upsert(request, candidateRepository);
+        var candidate =  Candidate.fetchByPublicationId(request::publicationId, candidateRepository, periodRepository);
         return Candidate.updateNonCandidate(
             createUpsertNonCandidateRequest(candidate.getPublicationId()),
             candidateRepository).orElseThrow();
@@ -747,21 +748,19 @@ public class IndexDocumentHandlerTest extends LocalDynamoTest {
     }
 
     private Candidate randomApplicableCandidate() {
-        return Candidate.upsert(createUpsertCandidateRequest(SOME_REPORTING_YEAR), candidateRepository,
-                                periodRepository)
-                   .orElseThrow();
+        return TestUtils.randomApplicableCandidate(candidateRepository, periodRepository);
     }
 
     private Candidate randomApplicableCandidate(URI topLevelOrg, URI affiliation) {
-        return Candidate.upsert(createUpsertCandidateRequest(topLevelOrg, affiliation), candidateRepository,
-                                periodRepository)
-                   .orElseThrow();
+        var request = createUpsertCandidateRequest(topLevelOrg, affiliation);
+        Candidate.upsert(request, candidateRepository);
+        return Candidate.fetchByPublicationId(request::publicationId, candidateRepository, periodRepository);
+
     }
 
     private Candidate randomApplicableCandidate(URI topLevelOrg, URI affiliation, ChannelType channelType) {
-        return Candidate.upsert(createUpsertCandidateRequest(topLevelOrg, affiliation, channelType),
-                                candidateRepository,
-                                periodRepository)
-                   .orElseThrow();
+        var request = createUpsertCandidateRequest(topLevelOrg, affiliation, channelType);
+        Candidate.upsert(request, candidateRepository);
+        return Candidate.fetchByPublicationId(request::publicationId, candidateRepository, periodRepository);
     }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
@@ -35,6 +35,7 @@ import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.test.ExpandedResourceGenerator;
 import no.sikt.nva.nvi.test.FakeSqsClient;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
 import nva.commons.core.Environment;
@@ -183,7 +184,6 @@ class UpdateIndexHandlerTest extends LocalDynamoTest {
     }
 
     private Candidate randomApplicableCandidate() {
-        return Candidate.upsert(createUpsertCandidateRequest(2023), candidateRepository, periodRepository)
-                   .orElseThrow();
+        return TestUtils.randomApplicableCandidate(candidateRepository, periodRepository);
     }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
@@ -5,7 +5,6 @@ import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.createPath;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandApprovals;
 import static no.sikt.nva.nvi.test.IndexDocumentTestUtils.expandPublicationDetails;
 import static no.sikt.nva.nvi.test.QueueServiceTestUtils.invalidSqsMessage;
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.unit.nva.s3.S3Driver.S3_SCHEME;
 import static nva.commons.core.attempt.Try.attempt;

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -135,12 +135,10 @@ public final class Candidate {
         return new Candidate(repository, candidateDao, approvalDaoList, noteDaoList, periodStatus);
     }
 
-    public static Optional<Candidate> upsert(UpsertCandidateRequest request, CandidateRepository repository,
-                                             PeriodRepository periodRepository) {
+    public static void upsert(UpsertCandidateRequest request, CandidateRepository repository) {
         var optionalCandidate = repository.findByPublicationId(request.publicationId());
-        return optionalCandidate.map(
-                candidateDao -> handleExistingCandidate(request, repository, periodRepository, candidateDao))
-                   .orElseGet(() -> Optional.of(createCandidate(request, repository, periodRepository)));
+        optionalCandidate.ifPresentOrElse(candidateDao -> updateExistingCandidate(request, repository, candidateDao),
+                                          (() -> createCandidate(request, repository)));
     }
 
     public static Optional<Candidate> updateNonCandidate(UpdateNonCandidateRequest request,
@@ -336,15 +334,13 @@ public final class Candidate {
             .orElseThrow(CandidateNotFoundException::new);
     }
 
-    private static Optional<Candidate> handleExistingCandidate(UpsertCandidateRequest request,
-                                                               CandidateRepository repository,
-                                                               PeriodRepository periodRepository,
-                                                               CandidateDao existingCandidate) {
+    private static void updateExistingCandidate(UpsertCandidateRequest request,
+                                                CandidateRepository repository,
+                                                CandidateDao existingCandidate) {
         if (existingCandidate.isReported()) {
             throw new IllegalCandidateUpdateException("Can not update reported candidate");
         } else {
-            return Optional.of(updateCandidate(request, repository, periodRepository,
-                                               existingCandidate));
+            updateCandidate(request, repository, existingCandidate);
         }
     }
 
@@ -364,13 +360,13 @@ public final class Candidate {
                              PeriodStatus.builder().withStatus(Status.NO_PERIOD).build());
     }
 
-    private static Candidate updateCandidate(UpsertCandidateRequest request, CandidateRepository repository,
-                                             PeriodRepository periodRepository, CandidateDao existingCandidateDao) {
+    private static void updateCandidate(UpsertCandidateRequest request, CandidateRepository repository,
+                                        CandidateDao existingCandidateDao) {
         validateCandidate(request);
         if (shouldResetCandidate(request, existingCandidateDao) || isNotApplicable(existingCandidateDao)) {
-            return resetCandidate(request, repository, periodRepository, existingCandidateDao);
+            resetCandidate(request, repository, existingCandidateDao);
         } else {
-            return updateCandidateKeepingApprovalsAndNotes(request, repository, periodRepository, existingCandidateDao);
+            updateCandidateKeepingApprovalsAndNotes(request, repository, existingCandidateDao);
         }
     }
 
@@ -378,28 +374,18 @@ public final class Candidate {
         return !candidateDao.candidate().applicable();
     }
 
-    private static Candidate resetCandidate(UpsertCandidateRequest request, CandidateRepository repository,
-                                            PeriodRepository periodRepository, CandidateDao existingCandidateDao) {
+    private static void resetCandidate(UpsertCandidateRequest request, CandidateRepository repository,
+                                       CandidateDao existingCandidateDao) {
         var newApprovals = mapToApprovals(request.institutionPoints());
         var newCandidateDao = updateCandidateDaoFromRequest(existingCandidateDao, request);
         repository.updateCandidate(existingCandidateDao.identifier(), newCandidateDao, newApprovals);
-        var notes = repository.getNotes(existingCandidateDao.identifier());
-        var periodStatus = findPeriodStatus(periodRepository,
-                                            existingCandidateDao.candidate().publicationDate().year());
-        var approvals = mapToApprovalsDaos(newCandidateDao.identifier(), newApprovals);
-        return new Candidate(repository, newCandidateDao, approvals, notes, periodStatus);
     }
 
-    private static Candidate updateCandidateKeepingApprovalsAndNotes(UpsertCandidateRequest request,
-                                                                     CandidateRepository repository,
-                                                                     PeriodRepository periodRepository,
-                                                                     CandidateDao existingCandidateDao) {
+    private static void updateCandidateKeepingApprovalsAndNotes(UpsertCandidateRequest request,
+                                                                CandidateRepository repository,
+                                                                CandidateDao existingCandidateDao) {
         var updatedCandidate = updateCandidateDaoFromRequest(existingCandidateDao, request);
-        var approvalDaoList = repository.fetchApprovals(updatedCandidate.identifier());
         repository.updateCandidate(updatedCandidate);
-        var noteDaoList = repository.getNotes(updatedCandidate.identifier());
-        var periodStatus = findPeriodStatus(periodRepository, updatedCandidate.candidate().publicationDate().year());
-        return new Candidate(repository, updatedCandidate, approvalDaoList, noteDaoList, periodStatus);
     }
 
     private static boolean shouldResetCandidate(UpsertCandidateRequest request, CandidateDao candidate) {
@@ -437,23 +423,9 @@ public final class Candidate {
         return !Objects.equals(DbLevel.parse(request.level()), existingCandidateDao.candidate().level());
     }
 
-    private static Candidate createCandidate(UpsertCandidateRequest request, CandidateRepository repository,
-                                             PeriodRepository periodRepository) {
+    private static void createCandidate(UpsertCandidateRequest request, CandidateRepository repository) {
         validateCandidate(request);
-        var candidateDao = repository.create(mapToCandidate(request), mapToApprovals(request.institutionPoints()));
-        var approvals1 = repository.fetchApprovals(candidateDao.identifier());
-        var notes1 = repository.getNotes(candidateDao.identifier());
-        var periodStatus1 = findPeriodStatus(periodRepository, candidateDao.candidate().publicationDate().year());
-
-        return new Candidate(repository, candidateDao, approvals1, notes1, periodStatus1);
-    }
-
-    private static List<ApprovalStatusDao> mapToApprovalsDaos(UUID identifier, List<DbApprovalStatus> newApprovals) {
-        return newApprovals.stream().map(app -> mapToApprovalDao(identifier, app)).toList();
-    }
-
-    private static ApprovalStatusDao mapToApprovalDao(UUID identifier, DbApprovalStatus app) {
-        return ApprovalStatusDao.builder().identifier(identifier).approvalStatus(app).build();
+        repository.create(mapToCandidate(request), mapToApprovals(request.institutionPoints()));
     }
 
     private static void validateCandidate(UpsertCandidateRequest candidate) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -138,7 +138,7 @@ public final class Candidate {
     public static void upsert(UpsertCandidateRequest request, CandidateRepository repository) {
         var optionalCandidate = repository.findByPublicationId(request.publicationId());
         optionalCandidate.ifPresentOrElse(candidateDao -> updateExistingCandidate(request, repository, candidateDao),
-                                          (() -> createCandidate(request, repository)));
+                                          () -> createCandidate(request, repository));
     }
 
     public static Optional<Candidate> updateNonCandidate(UpdateNonCandidateRequest request,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -4,7 +4,6 @@ import static java.util.Collections.emptyList;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createNoteRequest;
 import static no.sikt.nva.nvi.test.TestUtils.createUpdateStatusRequest;
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidate;
 import static no.sikt.nva.nvi.test.TestUtils.randomCandidateBuilder;
@@ -16,9 +15,9 @@ import java.net.URI;
 import java.util.Map.Entry;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
-import no.sikt.nva.nvi.common.utils.BatchScanUtil;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.utils.BatchScanUtil;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.sikt.nva.nvi.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,6 +48,7 @@ public class MigrationTests extends LocalDynamoTest {
                                                 periodRepository);
         assertEquals(candidate, migratedCandidate);
     }
+
     @Test
     void shouldSetPeriodYearIfMissingWhenMigrating() {
         var dbCandidate = randomCandidate();

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -20,6 +20,7 @@ import no.sikt.nva.nvi.common.utils.BatchScanUtil;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.sikt.nva.nvi.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -72,9 +73,7 @@ public class MigrationTests extends LocalDynamoTest {
     }
 
     private Candidate setupCandidateWithApprovalAndNotes() {
-        var candidate = Candidate.upsert(createUpsertCandidateRequest(CURRENT_YEAR), candidateRepository,
-                                         periodRepository)
-                            .orElseThrow()
+        var candidate = TestUtils.randomApplicableCandidate(candidateRepository, periodRepository)
                             .createNote(createNoteRequest(randomString(), randomString()));
 
         return candidate.updateApproval(createUpdateStatusRequest(ApprovalStatus.REJECTED,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -24,13 +24,11 @@ import org.junit.jupiter.api.Test;
 class CandidateRepositoryTest extends LocalDynamoTest {
 
     private CandidateRepository candidateRepository;
-    private PeriodRepository periodRepository;
 
     @BeforeEach
     public void setUp() {
         localDynamo = initializeTestDatabase();
         candidateRepository = new CandidateRepository(localDynamo);
-        periodRepository = new PeriodRepository(localDynamo);
     }
 
     @Test

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -46,12 +46,13 @@ class CandidateRepositoryTest extends LocalDynamoTest {
     @Test
     public void shouldOverwriteExistingCandidateWhenUpdating() {
         var originalRequest = createUpsertCandidateRequest(randomUri());
-        var candidate = Candidate.upsert(originalRequest, candidateRepository, periodRepository).orElseThrow();
-        var originalDbCandidate = candidateRepository.findCandidateById(candidate.getIdentifier()).get().candidate();
+        Candidate.upsert(originalRequest, candidateRepository);
+        var candidateDao = candidateRepository.findByPublicationId(originalRequest.publicationId()).get();
+        var originalDbCandidate = candidateDao.candidate();
 
         var newUpsertRequest = copyRequestWithNewInstanceType(originalRequest, randomUri());
-        Candidate.upsert(newUpsertRequest, candidateRepository, periodRepository).orElseThrow();
-        var updatedDbCandidate = candidateRepository.findCandidateById(candidate.getIdentifier()).get().candidate();
+        Candidate.upsert(newUpsertRequest, candidateRepository);
+        var updatedDbCandidate = candidateRepository.findCandidateById(candidateDao.identifier()).get().candidate();
 
         assertThat(scanDB().count(), is(equalTo(3)));
         assertThat(updatedDbCandidate, is(not(equalTo(originalDbCandidate))));

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateNotesTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateNotesTest.java
@@ -21,7 +21,6 @@ import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.service.exception.UnauthorizedOperationException;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.requests.DeleteNoteRequest;
-import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateNotesTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateNotesTest.java
@@ -21,6 +21,7 @@ import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.service.exception.UnauthorizedOperationException;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.requests.DeleteNoteRequest;
+import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -117,8 +118,9 @@ public class CandidateNotesTest extends LocalDynamoTest {
     }
 
     private Candidate createCandidate(URI institutionId) {
-        return Candidate.upsert(createUpsertCandidateRequest(institutionId), candidateRepository,
-                                periodRepository).orElseThrow();
+        var request = createUpsertCandidateRequest(institutionId);
+        Candidate.upsert(request, candidateRepository);
+        return Candidate.fetchByPublicationId(request::publicationId, candidateRepository, periodRepository);
     }
 
     private Candidate createCandidate() {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -89,8 +89,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.junit.platform.commons.function.Try;
-import org.mockito.Mockito;
 
 class CandidateTest extends LocalDynamoTest {
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -807,8 +807,6 @@ class CandidateTest extends LocalDynamoTest {
         };
     }
 
-    //TODO; add xDto to DTO classes
-
     private record CandidateResetCauseArgument(DbLevel level, InstanceType type, URI... institutionIds) {
 
     }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.rest.remove;
 
 import static no.sikt.nva.nvi.rest.fetch.FetchNviCandidateHandler.CANDIDATE_IDENTIFIER;
 import static no.sikt.nva.nvi.rest.remove.RemoveNoteHandler.PARAM_NOTE_IDENTIFIER;
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomUsername;
@@ -30,6 +29,7 @@ import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.rest.create.NviNoteRequest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
+import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
@@ -145,8 +145,7 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
     }
 
     private Candidate createCandidate() {
-        return Candidate.upsert(createUpsertCandidateRequest(randomUri()), candidateRepository,
-                                periodRepository).orElseThrow();
+        return TestUtils.randomApplicableCandidate(candidateRepository, periodRepository);
     }
 
     private HandlerRequestBuilder<NviNoteRequest> createRequest(UUID candidateIdentifier, UUID noteIdentifier,

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -32,7 +32,6 @@ import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
-import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.sikt.nva.nvi.rest.model.UpsertAssigneeRequest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
 import no.sikt.nva.nvi.test.LocalDynamoTest;

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -45,6 +45,7 @@ import no.sikt.nva.nvi.common.db.model.Username;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
+import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.CreatePeriodRequest;
 import no.sikt.nva.nvi.common.service.model.InstanceType;
 import no.sikt.nva.nvi.common.service.model.InstitutionPoints;
@@ -83,6 +84,13 @@ public final class TestUtils {
 
     public static URI generatePublicationId(UUID identifier) {
         return UriWrapper.fromHost(API_HOST).addChild(PUBLICATION_API_PATH).addChild(identifier.toString()).getUri();
+    }
+
+    public static Candidate randomApplicableCandidate(CandidateRepository candidateRepository,
+                                                      PeriodRepository periodRepository) {
+        var request = createUpsertCandidateRequest(randomUri());
+        Candidate.upsert(request, candidateRepository);
+        return Candidate.fetchByPublicationId(request::publicationId, candidateRepository, periodRepository);
     }
 
     public static DbCandidate.Builder randomCandidateBuilder(boolean applicable, URI institutionId) {


### PR DESCRIPTION
Jira task: NP-48035 - CloudWath Alarm: NVI Persisting candidate failed

Due to:
```
java.lang.NullPointerException: Cannot invoke \"no.sikt.nva.nvi.common.db.CandidateDao.identifier()\" because \"candidateDao\" is null\n\t
at no.sikt.nva.nvi.common.service.model.Candidate.createCandidate(Candidate.java:441)\n\tat 
no.sikt.nva.nvi.common.service.model.Candidate.upsert(Candidate.java:141)\n\tat 
...
```

Anlalysis: Persisting the candidate has not _actually_ failed, but _fetching_ the candidate immediately after creating it in some very few cases returns `null`. I think this is due to the eventual consistency model of DynamoDB.

Discussed following alternatives with @LarsV123:
1. Use `GetItemEnhancedRequest` with `consistentRead` set to `true` when fetching the candidate immediately after creating it. This ensures that a read immediately following a write will always return the latest data, but is slower and more expensive.
2. If fetching the candidate immediately after creating it returns `null`, retry?
3. The return value of method `Candidate.upsert()` is actually never used (in production code) - therefore: Change return type to void?

Option 3. is implemented in this PR, but feel free to disagree or suggest other alternatives.