### PR TITLE
Np 48157 Aggregation organizationApprovalStatuses should not contain rejected points

### DIFF
--- a/buildSrc/src/main/groovy/nva.nvi.java-conventions.gradle
+++ b/buildSrc/src/main/groovy/nva.nvi.java-conventions.gradle
@@ -32,7 +32,7 @@ tasks.named('test') {
 }
 
 pmd {
-    toolVersion = '7.7.0'
+    toolVersion = '7.8.0'
     ruleSetConfig = rootProject.resources.text.fromFile('config/pmd/ruleset.xml')
     ruleSets = []
     ignoreFailures = false

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -58,7 +58,6 @@
 
     <!-- Sometimes it is useful in debugging to assign the return value to a local variable  -->
     <exclude name="UnnecessaryLocalBeforeReturn"/>
-    <exclude name="JUnitAssertionsShouldIncludeMessage"/>
   </rule>
 
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -28,6 +28,7 @@
     <exclude name="AvoidPrintStackTrace"/>
     <exclude name="UnitTestAssertionsShouldIncludeMessage"/>
     <exclude name="UnitTestContainsTooManyAsserts"/>
+    <exclude name="JUnitAssertionsShouldIncludeMessage"/>
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->
     <exclude name="PreserveStackTrace"/>
@@ -57,7 +58,6 @@
 
     <!-- Sometimes it is useful in debugging to assign the return value to a local variable  -->
     <exclude name="UnnecessaryLocalBeforeReturn"/>
-    <exclude name="JUnitAssertionsShouldIncludeMessage"/>
   </rule>
 
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -31,6 +31,8 @@
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->
     <exclude name="PreserveStackTrace"/>
+    <!-- //TODO: This is complaining on private methods that are used?  -->
+    <exclude name="UnusedPrivateMethod"/>
 
   </rule>
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -26,8 +26,7 @@
     <exclude name="SystemPrintln"/>
     <exclude name="GuardLogStatement"/>
     <exclude name="AvoidPrintStackTrace"/>
-    <exclude name="UnitTestAssertionsShouldIncludeMessage"/>
-    <exclude name="UnitTestContainsTooManyAsserts"/>
+
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->
     <exclude name="PreserveStackTrace"/>
@@ -59,7 +58,8 @@
     <!-- Sometimes it is useful in debugging to assign the return value to a local variable  -->
     <exclude name="UnnecessaryLocalBeforeReturn"/>
     <exclude name="JUnitAssertionsShouldIncludeMessage"/>
-
+    <exclude name="UnitTestAssertionsShouldIncludeMessage"/>
+    <exclude name="UnitTestContainsTooManyAsserts"/>
   </rule>
 
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -58,6 +58,7 @@
 
     <!-- Sometimes it is useful in debugging to assign the return value to a local variable  -->
     <exclude name="UnnecessaryLocalBeforeReturn"/>
+    <exclude name="JUnitAssertionsShouldIncludeMessage"/>
   </rule>
 
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -26,7 +26,8 @@
     <exclude name="SystemPrintln"/>
     <exclude name="GuardLogStatement"/>
     <exclude name="AvoidPrintStackTrace"/>
-
+    <exclude name="UnitTestAssertionsShouldIncludeMessage"/>
+    <exclude name="UnitTestContainsTooManyAsserts"/>
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->
     <exclude name="PreserveStackTrace"/>
@@ -58,8 +59,6 @@
     <!-- Sometimes it is useful in debugging to assign the return value to a local variable  -->
     <exclude name="UnnecessaryLocalBeforeReturn"/>
     <exclude name="JUnitAssertionsShouldIncludeMessage"/>
-    <exclude name="UnitTestAssertionsShouldIncludeMessage"/>
-    <exclude name="UnitTestContainsTooManyAsserts"/>
   </rule>
 
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -31,6 +31,7 @@
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->
     <exclude name="PreserveStackTrace"/>
+
     <!-- //TODO: This is complaining on private methods that are used?  -->
     <exclude name="UnusedPrivateMethod"/>
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -28,7 +28,6 @@
     <exclude name="AvoidPrintStackTrace"/>
     <exclude name="UnitTestAssertionsShouldIncludeMessage"/>
     <exclude name="UnitTestContainsTooManyAsserts"/>
-    <exclude name="JUnitAssertionsShouldIncludeMessage"/>
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->
     <exclude name="PreserveStackTrace"/>

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -34,12 +34,12 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 
 public final class Aggregations {
 
-    public static final String APPROVAL_STATUS_PATH = joinWithDelimiter(APPROVALS, APPROVAL_STATUS);
-    public static final String INSTITUTION_ID_PATH = joinWithDelimiter(APPROVALS, INSTITUTION_ID);
-    public static final String DISPUTE_AGGREGATION = "dispute";
-    public static final String POINTS_AGGREGATION = "points";
-    public static final String DISPUTE = "Dispute";
     public static final String APPROVAL_ORGANIZATIONS_AGGREGATION = "organizations";
+    private static final String APPROVAL_STATUS_PATH = joinWithDelimiter(APPROVALS, APPROVAL_STATUS);
+    private static final String INSTITUTION_ID_PATH = joinWithDelimiter(APPROVALS, INSTITUTION_ID);
+    private static final String DISPUTE_AGGREGATION = "dispute";
+    private static final String POINTS_AGGREGATION = "points";
+    private static final String DISPUTE = "Dispute";
     private static final String TOTAL_POINTS_SUM_AGGREGATION = "totalPoints";
     private static final String ALL_AGGREGATIONS = "all";
     private static final String STATUS_AGGREGATION = "status";

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -40,6 +40,7 @@ public final class Aggregations {
     public static final String POINTS_AGGREGATION = "points";
     public static final String DISPUTE = "Dispute";
     public static final String APPROVAL_ORGANIZATIONS_AGGREGATION = "organizations";
+    private static final String TOTAL_POINTS_SUM_AGGREGATION = "totalPoints";
     private static final String ALL_AGGREGATIONS = "all";
     private static final String STATUS_AGGREGATION = "status";
     private static final int ORGANIZATION_SUB_UNITS_TERMS_AGGREGATION_SIZE = 1000;
@@ -56,10 +57,7 @@ public final class Aggregations {
 
     public static Aggregation organizationApprovalStatusAggregations(String topLevelCristinOrg) {
         var statusAggregation = termsAggregation(APPROVALS, APPROVAL_STATUS)._toAggregation();
-        var pointAggregation = filterAggregation(
-            mustNotMatch(ApprovalStatus.REJECTED.getValue(), joinWithDelimiter(APPROVALS, APPROVAL_STATUS)),
-            Map.of("totalPoints", sumAggregation(APPROVALS, POINTS, INSTITUTION_POINTS))
-        );
+        var pointAggregation = filterNotRegectedPointsAggregation();
         var disputeAggregation = filterStatusDisputeAggregation();
         var organizationAggregation = new Aggregation.Builder()
                                           .terms(new TermsAggregation.Builder()
@@ -116,6 +114,13 @@ public final class Aggregations {
 
     public static Aggregation disputeAggregation(String topLevelCristinOrg) {
         return filterAggregation(mustMatch(globalStatusDisputeForInstitution(topLevelCristinOrg)));
+    }
+
+    private static Aggregation filterNotRegectedPointsAggregation() {
+        return filterAggregation(
+            mustNotMatch(ApprovalStatus.REJECTED.getValue(), joinWithDelimiter(APPROVALS, APPROVAL_STATUS)),
+            Map.of(TOTAL_POINTS_SUM_AGGREGATION, sumAggregation(APPROVALS, POINTS, INSTITUTION_POINTS))
+        );
     }
 
     private static Aggregation filterStatusDisputeAggregation() {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -40,7 +40,7 @@ public final class Aggregations {
     private static final String DISPUTE_AGGREGATION = "dispute";
     private static final String POINTS_AGGREGATION = "points";
     private static final String DISPUTE = "Dispute";
-    private static final String TOTAL_POINTS_SUM_AGGREGATION = "totalPoints";
+    private static final String TOTAL_POINTS_SUM_AGGREGATION = "total";
     private static final String ALL_AGGREGATIONS = "all";
     private static final String STATUS_AGGREGATION = "status";
     private static final int ORGANIZATION_SUB_UNITS_TERMS_AGGREGATION_SIZE = 1000;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -11,11 +11,11 @@ import static no.sikt.nva.nvi.index.utils.AggregationFunctions.termsAggregation;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.assignmentsQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.containsNonFinalizedStatusQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.fieldValueQuery;
-import static no.sikt.nva.nvi.index.utils.QueryFunctions.notDisputeQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.multipleApprovalsQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.mustMatch;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.mustNotMatch;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.nestedQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.notDisputeQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.statusQuery;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVALS;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.APPROVAL_STATUS;
@@ -56,7 +56,10 @@ public final class Aggregations {
 
     public static Aggregation organizationApprovalStatusAggregations(String topLevelCristinOrg) {
         var statusAggregation = termsAggregation(APPROVALS, APPROVAL_STATUS)._toAggregation();
-        var pointAggregation = sumAggregation(APPROVALS, POINTS, INSTITUTION_POINTS);
+        var pointAggregation = filterAggregation(
+            mustNotMatch(ApprovalStatus.REJECTED.getValue(), joinWithDelimiter(APPROVALS, APPROVAL_STATUS)),
+            Map.of("totalPoints", sumAggregation(APPROVALS, POINTS, INSTITUTION_POINTS))
+        );
         var disputeAggregation = filterStatusDisputeAggregation();
         var organizationAggregation = new Aggregation.Builder()
                                           .terms(new TermsAggregation.Builder()

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -129,6 +129,7 @@ class OpenSearchClientTest {
         "document_organization_aggregation_dispute.json";
     private static final String DOCUMENT_WITH_CONTRIBUTOR_FROM_NTNU_SUBUNIT_JSON =
         "document_with_contributor_from_ntnu_subunit.json";
+    private static final String UNEXPECTED_KEY = "Unexpected key: ";
     private static RestClient restClient;
     private static OpenSearchClient openSearchClient;
 
@@ -652,7 +653,7 @@ class OpenSearchClientTest {
             } else if (SIKT_LEVEL_3_ID.equals(key)) {
                 assertEquals(3.0, pointSum.value());
             } else {
-                throw new RuntimeException("Unexpected key: " + key);
+                throw new RuntimeException(UNEXPECTED_KEY + key);
             }
         });
     }
@@ -760,7 +761,7 @@ class OpenSearchClientTest {
         } else if (SIKT_LEVEL_3_ID.equals(key)) {
             assertEquals(3.0, pointSum.value());
         } else {
-            throw new RuntimeException("Unexpected key: " + key);
+            throw new RuntimeException(UNEXPECTED_KEY + key);
         }
     }
 
@@ -772,7 +773,7 @@ class OpenSearchClientTest {
         } else if (SIKT_LEVEL_3_ID.equals(key)) {
             assertEquals(0, disputeAggregation.docCount());
         } else {
-            throw new RuntimeException("Unexpected key: " + key);
+            throw new RuntimeException(UNEXPECTED_KEY + key);
         }
     }
 
@@ -789,7 +790,7 @@ class OpenSearchClientTest {
             var expectedKeys = List.of(PENDING.getValue());
             assertExpectedSubAggregations(statusAggregation, expectedKeys);
         } else {
-            throw new RuntimeException("Unexpected key: " + key);
+            throw new RuntimeException(UNEXPECTED_KEY + key);
         }
     }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -643,13 +643,14 @@ class OpenSearchClientTest {
         var actualOrgBuckets = ((StringTermsAggregate) filterAggregate._get()).buckets();
         actualOrgBuckets.array().forEach(bucket -> {
             var key = bucket.key();
-            var pointAggregation = (SumAggregate) bucket.aggregations().get("points")._get();
+            var pointFilterAggregate = (FilterAggregate) bucket.aggregations().get("points")._get();
+            var pointSum = (SumAggregate) pointFilterAggregate.aggregations().get("totalPoints")._get();
             if (SIKT_INSTITUTION_ID.toString().equals(key)) {
-                assertEquals(4.0, pointAggregation.value());
+                assertEquals(4.0, pointSum.value());
             } else if (SIKT_LEVEL_2_ID.equals(key)) {
-                assertEquals(4.0, pointAggregation.value());
+                assertEquals(4.0, pointSum.value());
             } else if (SIKT_LEVEL_3_ID.equals(key)) {
-                assertEquals(3.0, pointAggregation.value());
+                assertEquals(3.0, pointSum.value());
             } else {
                 throw new RuntimeException("Unexpected key: " + key);
             }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -751,13 +751,14 @@ class OpenSearchClientTest {
 
     private static void assertExpectedPointAggregations(StringTermsBucket bucket) {
         var key = bucket.key();
-        var pointAggregation = (SumAggregate) bucket.aggregations().get("points")._get();
+        var pointFilterAggregate = (FilterAggregate) bucket.aggregations().get("points")._get();
+        var pointSum = (SumAggregate) pointFilterAggregate.aggregations().get("totalPoints")._get();
         if (SIKT_INSTITUTION_ID.toString().equals(key)) {
-            assertEquals(4.0, pointAggregation.value());
+            assertEquals(4.0, pointSum.value());
         } else if (SIKT_LEVEL_2_ID.equals(key)) {
-            assertEquals(4.0, pointAggregation.value());
+            assertEquals(4.0, pointSum.value());
         } else if (SIKT_LEVEL_3_ID.equals(key)) {
-            assertEquals(3.0, pointAggregation.value());
+            assertEquals(3.0, pointSum.value());
         } else {
             throw new RuntimeException("Unexpected key: " + key);
         }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -745,7 +745,7 @@ class OpenSearchClientTest {
     private static void assertExpectedPointAggregations(StringTermsBucket bucket) {
         var key = bucket.key();
         var pointFilterAggregate = (FilterAggregate) bucket.aggregations().get("points")._get();
-        var pointSum = (SumAggregate) pointFilterAggregate.aggregations().get("totalPoints")._get();
+        var pointSum = (SumAggregate) pointFilterAggregate.aggregations().get("total")._get();
         if (SIKT_INSTITUTION_ID.toString().equals(key)) {
             assertEquals(4.0, pointSum.value());
         } else if (SIKT_LEVEL_2_ID.equals(key)) {

--- a/index-handlers/src/test/resources/document_organization_aggregation_rejected.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_rejected.json
@@ -1,0 +1,64 @@
+{
+  "@context": "https://bibsysdev.github.io/src/nvi-context.json",
+  "type": "NviCandidate",
+  "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e57929",
+  "numberOfApprovals": 1,
+  "publicationDetails": {
+    "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
+    "type": "AcademicArticle",
+    "title": "SomeTitle",
+    "publicationDate": {
+      "year": "2023"
+    },
+    "nviContributors": [
+      {
+        "type": "NviContributor",
+        "id": "https://api.dev.nva.aws.unit.no/cristin/person/1",
+        "name": "Kir",
+        "affiliations": [
+          {
+            "type": "NviOrganization",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.0.0",
+            "partOf": [
+              "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0"
+            ]
+          }
+        ],
+        "role": "Creator"
+      },
+      {
+        "type": "NviContributor",
+        "id": "https://api.dev.nva.aws.unit.no/cristin/person/2",
+        "name": "Mona",
+        "affiliations": [
+          {
+            "type": "NviOrganization",
+            "id": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.1.0",
+            "partOf": [
+              "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+              "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.0.0"
+            ]
+          }
+        ],
+        "role": "Creator"
+      }
+    ]
+  },
+  "approvals": [
+    {
+      "type": "Approval",
+      "assignee": "user1",
+      "institutionId": "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+      "involvedOrganizations": [
+        "https://api.dev.nva.aws.unit.no/cristin/organization/20754.0.0.0",
+        "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.0.0",
+        "https://api.dev.nva.aws.unit.no/cristin/organization/20754.1.1.0"
+      ],
+      "approvalStatus": "Rejected",
+      "points": {
+        "type": "InstitutionPoints",
+        "institutionPoints": 3
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Jira task: NP-48157 Institution Status Report: Aggregated points should not contain rejected points

Change:
- Filter out rejected approvals when aggregating total points in `organizationApprovalStatusAggregation`
- (Yes, this is a breaking change for FE, coordinating deplyoment with FE)
- Updated to pmd 7.8.0. See release notes, [fixed issues](https://github.com/pmd/pmd/releases#fixed-issues)