### PR TITLE
Np 48112 Do not reset candidate approvals on creator sub unit affiliation change

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
@@ -125,7 +125,7 @@ class CristinNviReportEventConsumerTest extends LocalDynamoTest {
                    is(equalTo(expectedPublicationBucketUri(cristinNviReport.publicationIdentifier()))));
         assertThat(candidate.isApplicable(), is(true));
         assertThat(candidate.getPeriod().year(), is(equalTo(String.valueOf(cristinNviReport.yearReported()))));
-        assertThat(candidate.getPublicationDetails().level(), is(equalTo("LevelOne")));
+        assertThat(candidate.getScientificLevel(), is(equalTo("LevelOne")));
         assertThat(candidate.getPublicationDetails().creators(),
                    Matchers.contains(constructExpectedCreator(cristinNviReport)));
         assertThat(candidate.getPublicationDetails().type(), is(equalTo(cristinNviReport.instanceType())));

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -180,12 +180,12 @@ class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
                                                        periodRepository);
         candidate.updateApproval(
             new UpdateStatusRequest(institutionId, ApprovalStatus.APPROVED, randomString(), randomString()));
-        var approval = candidate.toDto().approvals().get(0);
+        var approval = candidate.getApprovals().get(institutionId);
         var newUpsertRequest = createNewUpsertRequestNotAffectingApprovals(upsertCandidateRequest, institutionId);
         Candidate.upsert(newUpsertRequest, candidateRepository, periodRepository);
         var updatedCandidate = Candidate.fetchByPublicationId(newUpsertRequest::publicationId, candidateRepository,
                                                               periodRepository);
-        var updatedApproval = updatedCandidate.toDto().approvals().get(0);
+        var updatedApproval = updatedCandidate.getApprovals().get(institutionId);
 
         assertThat(updatedApproval, is(equalTo(approval)));
     }
@@ -279,11 +279,12 @@ class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
 
     private UpsertCandidateRequest createNewUpsertRequestNotAffectingApprovals(UpsertCandidateRequest request,
                                                                                URI institutionId) {
-        var creatorId = request.creators().keySet().stream().toList().get(0);
+        var creatorId = request.creators().keySet().stream().toList().getFirst();
         var creator = new NviCreator(creatorId, List.of(institutionId));
         return getBuilder(request.publicationId(), request.publicationBucketUri(), creator)
                    .withInstanceType(request.instanceType())
                    .withLevel(request.level())
+                   .withPublicationChannelId(request.publicationChannelId())
                    .withDate(new PublicationDate(null, "3", Year.now().toString()))
                    .withVerifiedCreators(List.of(new NviCreator(creatorId, List.of(institutionId))))
                    .withInstitutionPoints(request.institutionPoints())

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -230,17 +230,17 @@ public final class NviCandidateIndexDocumentGenerator {
     }
 
     private PublicationChannel buildPublicationChannel() {
-        var publication = candidate.getPublicationDetails();
+        var publicationChannel = candidate.getPublicationDetails().publicationChannel();
         var publicationChannelBuilder = PublicationChannel.builder()
-                                            .withScientificValue(ScientificValue.parse(publication.level()));
+                                            .withScientificValue(ScientificValue.parse(publicationChannel.level()));
 
-        if (nonNull(publication.publicationChannelId())) { // Might be null for candidates imported via Cristin
-            publicationChannelBuilder.withId(publication.publicationChannelId());
+        if (nonNull(publicationChannel.id())) { // Might be null for candidates imported via Cristin
+            publicationChannelBuilder.withId(publicationChannel.id());
         }
-        if (nonNull(publication.channelType())) { // Might be null for candidates imported via Cristin
-            publicationChannelBuilder.withType(publication.channelType().getValue());
-            publicationChannelBuilder.withName(extractName(publication.channelType()));
-            publicationChannelBuilder.withPrintIssn(extractPrintIssn(publication.channelType()));
+        if (nonNull(publicationChannel.channelType())) { // Might be null for candidates imported via Cristin
+            publicationChannelBuilder.withType(publicationChannel.channelType().getValue());
+            publicationChannelBuilder.withName(extractName(publicationChannel.channelType()));
+            publicationChannelBuilder.withPrintIssn(extractPrintIssn(publicationChannel.channelType()));
         }
         return publicationChannelBuilder.build();
     }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Approval.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Approval.java
@@ -103,11 +103,25 @@ public class Approval {
         Approval approval = (Approval) o;
         return Objects.equals(identifier, approval.identifier)
                && Objects.equals(institutionId, approval.institutionId)
-               && status == approval.status
+               && Objects.equals(status, approval.status)
                && Objects.equals(assignee, approval.assignee)
                && Objects.equals(finalizedBy, approval.finalizedBy)
                && Objects.equals(finalizedDate, approval.finalizedDate)
                && Objects.equals(reason, approval.reason);
+    }
+
+    @Override
+    @JacocoGenerated
+    public String toString() {
+        return "Approval{" +
+               "identifier=" + identifier +
+               ", institutionId=" + institutionId +
+               ", status=" + status +
+               ", assignee=" + assignee +
+               ", finalizedBy=" + finalizedBy +
+               ", finalizedDate=" + finalizedDate +
+               ", reason='" + reason + '\'' +
+               '}';
     }
 
     private DbApprovalStatus updateAssignee(UpdateAssigneeRequest request) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -465,7 +465,7 @@ public final class Candidate {
     }
 
     private static boolean levelIsUpdated(UpsertCandidateRequest request, Candidate candidate) {
-        return !Objects.equals(request.level(), candidate.getPublicationDetails().publicationChannel().level());
+        return !Objects.equals(request.level(), candidate.getScientificLevel());
     }
 
     private static void createCandidate(UpsertCandidateRequest request, CandidateRepository repository) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -442,10 +442,15 @@ public final class Candidate {
 
     private static boolean shouldResetCandidate(UpsertCandidateRequest request, Candidate candidate) {
         return levelIsUpdated(request, candidate)
+               || publicationChannelIsUpdated(request, candidate)
                || instanceTypeIsUpdated(request, candidate)
                || creatorsAreUpdated(request, candidate)
                || pointsAreUpdated(request, candidate)
                || publicationYearIsUpdated(request, candidate);
+    }
+
+    private static boolean publicationChannelIsUpdated(UpsertCandidateRequest request, Candidate candidate) {
+        return !request.publicationChannelId().equals(candidate.getPublicationChannelId());
     }
 
     private static boolean publicationYearIsUpdated(UpsertCandidateRequest request, Candidate candidate) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -453,7 +453,7 @@ public final class Candidate {
     }
 
     private static boolean levelIsUpdated(UpsertCandidateRequest request, Candidate candidate) {
-        return !Objects.equals(request.level(), candidate.getPublicationDetails().level());
+        return !Objects.equals(request.level(), candidate.getPublicationDetails().publicationChannel().level());
     }
 
     private static void createCandidate(UpsertCandidateRequest request, CandidateRepository repository) {
@@ -603,9 +603,9 @@ public final class Candidate {
                                   .applicable(applicable)
                                   .creators(mapToDbCreators(publicationDetails.creators()))
                                   .creatorShareCount(creatorShareCount)
-                                  .channelType(publicationDetails.channelType())
-                                  .channelId(publicationDetails.publicationChannelId())
-                                  .level(DbLevel.parse(publicationDetails.level()))
+                                  .channelType(publicationDetails.publicationChannel().channelType())
+                                  .channelId(publicationDetails.publicationChannel().id())
+                                  .level(DbLevel.parse(publicationDetails.publicationChannel().level()))
                                   .instanceType(publicationDetails.type())
                                   .publicationDate(mapToPublicationDate(publicationDetails.publicationDate()))
                                   .internationalCollaboration(internationalCollaboration)
@@ -644,9 +644,9 @@ public final class Candidate {
                                       request.instanceType().getValue(),
                                       request.publicationDate(),
                                       mapToCreators(request.creators()),
-                                      ChannelType.parse(request.channelType()),
-                                      request.publicationChannelId(),
-                                      request.level());
+                                      new PublicationChannel(ChannelType.parse(request.channelType()),
+                                                             request.publicationChannelId(),
+                                                             request.level()));
     }
 
     private void setUserAsAssigneeIfApprovalIsUnassigned(String username, URI institutionId) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -280,6 +280,18 @@ public final class Candidate {
         }
     }
 
+    public String getScientificLevel() {
+        return publicationDetails.publicationChannel().level();
+    }
+
+    public ChannelType getPublicationChannelType() {
+        return publicationDetails.publicationChannel().channelType();
+    }
+
+    public URI getPublicationChannelId() {
+        return publicationDetails.publicationChannel().id();
+    }
+
     public CandidateDto toDto() {
         return CandidateDto.builder()
                    .withId(getId())
@@ -603,9 +615,9 @@ public final class Candidate {
                                   .applicable(applicable)
                                   .creators(mapToDbCreators(publicationDetails.creators()))
                                   .creatorShareCount(creatorShareCount)
-                                  .channelType(publicationDetails.publicationChannel().channelType())
-                                  .channelId(publicationDetails.publicationChannel().id())
-                                  .level(DbLevel.parse(publicationDetails.publicationChannel().level()))
+                                  .channelType(getPublicationChannelType())
+                                  .channelId(getPublicationChannelId())
+                                  .level(DbLevel.parse(getScientificLevel()))
                                   .instanceType(publicationDetails.type())
                                   .publicationDate(mapToPublicationDate(publicationDetails.publicationDate()))
                                   .internationalCollaboration(internationalCollaboration)

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -612,10 +612,6 @@ public final class Candidate {
                    .build();
     }
 
-    private Set<URI> getApprovingOrganizations() {
-        return approvals.keySet();
-    }
-
     private Set<URI> getNviCreatorIds() {
         return publicationDetails.getNviCreatorIds();
     }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -379,6 +379,10 @@ public final class Candidate {
             .orElseThrow(CandidateNotFoundException::new);
     }
 
+    public String getInstanceType() {
+        return publicationDetails.type();
+    }
+
     private static CandidateDao updateVersion(CandidateRepository candidateRepository, CandidateDao candidateDao) {
         var candidateWithNewVersion = candidateDao.copy().version(randomUUID().toString()).build();
         candidateRepository.updateCandidate(candidateWithNewVersion);

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationChannel.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationChannel.java
@@ -1,0 +1,10 @@
+package no.sikt.nva.nvi.common.service.model;
+
+import java.net.URI;
+import no.sikt.nva.nvi.common.db.model.ChannelType;
+
+public record PublicationChannel(ChannelType channelType,
+                                 URI id,
+                                 String level) {
+
+}

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
@@ -27,7 +27,7 @@ public record PublicationDetails(URI publicationId,
                                           .toList(),
                                       new PublicationChannel(dbCandidate.channelType(),
                                                              dbCandidate.channelId(),
-                                                             dbCandidate.level().toString()));
+                                                             dbCandidate.level().getValue()));
     }
 
     public List<URI> getNviCreatorAffiliations() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
@@ -3,6 +3,8 @@ package no.sikt.nva.nvi.common.service.model;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.net.URI;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
@@ -35,6 +37,12 @@ public record PublicationDetails(URI publicationId,
                    .map(Creator::affiliations)
                    .flatMap(List::stream)
                    .toList();
+    }
+
+    public Set<URI> getNviCreatorIds() {
+        return creators.stream()
+                   .map(Creator::id)
+                   .collect(Collectors.toSet());
     }
 
     public record PublicationDate(String year, String month, String day) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
@@ -6,7 +6,6 @@ import java.util.List;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbPublicationDate;
-import no.sikt.nva.nvi.common.db.model.ChannelType;
 
 @JsonSerialize
 public record PublicationDetails(URI publicationId,
@@ -14,9 +13,7 @@ public record PublicationDetails(URI publicationId,
                                  String type,
                                  PublicationDate publicationDate,
                                  List<Creator> creators,
-                                 ChannelType channelType,
-                                 URI publicationChannelId,
-                                 String level) {
+                                 PublicationChannel publicationChannel) {
 
     public static PublicationDetails from(CandidateDao candidateDao) {
         var dbCandidate = candidateDao.candidate();
@@ -28,10 +25,9 @@ public record PublicationDetails(URI publicationId,
                                           .stream()
                                           .map(Creator::from)
                                           .toList(),
-                                      dbCandidate.channelType(),
-                                      dbCandidate.channelId(),
-                                      dbCandidate.level().getValue());
-
+                                      new PublicationChannel(dbCandidate.channelType(),
+                                                             dbCandidate.channelId(),
+                                                             dbCandidate.level().toString()));
     }
 
     public List<URI> getNviCreatorAffiliations() {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -447,7 +447,7 @@ class CandidateTest extends LocalDynamoTest {
                                                             true,
                                                             candidate.getPublicationDetails().publicationDate(),
                                                             Map.of(HARDCODED_CREATOR_ID, List.of(
-                                                                HARDCODED_INSTITUTION_ID)),
+                                                                newSubUnitInSameOrganization)),
                                                             InstanceType.parse(candidate.getInstanceType()),
                                                             candidate.getPublicationChannelType().getValue(),
                                                             candidate.getPublicationChannelId(),

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -446,10 +446,10 @@ class CandidateTest extends LocalDynamoTest {
         assertEquals(candidate.getPublicationDetails().publicationDate(), publicationDate);
         assertCorrectCreatorData(creators, candidate);
         assertEquals(candidate.getPublicationDetails().type(), instanceType.getValue());
-        assertEquals(candidate.getPublicationDetails().publicationChannel().channelType().getValue(),
+        assertEquals(candidate.getPublicationChannelType().getValue(),
                      createRequest.channelType());
-        assertEquals(candidate.getPublicationDetails().publicationChannel().id(), createRequest.publicationChannelId());
-        assertEquals(candidate.getPublicationDetails().publicationChannel().level(), createRequest.level());
+        assertEquals(candidate.getPublicationChannelId(), createRequest.publicationChannelId());
+        assertEquals(candidate.getScientificLevel(), createRequest.level());
         assertEquals(candidate.getBasePoints(), adjustScaleAndRoundingMode(createRequest.basePoints()));
         assertEquals(candidate.isInternationalCollaboration(),
                      createRequest.isInternationalCollaboration());

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -556,12 +556,7 @@ class CandidateTest extends LocalDynamoTest {
         assertNotEquals(dao.version(), updatedDao.version());
     }
 
-    private static Stream<Arguments> candidateNotResetCauseProvider() {
-        return Stream.of(Arguments.of(Named.of("creator name changed",
-                                               null),
-                                      Arguments.of(Named.of("creator sub unit affiliation changed",
-                                                            null))));
-    }
+
 
     private static Stream<Arguments> candidateResetCauseProvider() {
         var defaultInstitutionPoints = List.of(new InstitutionPoints(HARDCODED_INSTITUTION_ID, DEFAULT_POINTS,
@@ -839,7 +834,7 @@ class CandidateTest extends LocalDynamoTest {
 
             @Override
             public URI publicationChannelId() {
-                return null;
+                return request.publicationChannelId();
             }
 
             @Override

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -592,7 +592,49 @@ class CandidateTest extends LocalDynamoTest {
                                                                      Collections.emptyList()));
         var defaultCreator = new Creator(HARDCODED_CREATOR_ID, List.of(HARDCODED_INSTITUTION_ID));
         var defaultCreators = List.of(defaultCreator);
-        return Stream.of(Arguments.of(Named.of("creator added",
+        return Stream.of(Arguments.of(Named.of("channel changed",
+                                               new CandidateResetCauseArgument(
+                                                   new PublicationChannel(ChannelType.JOURNAL,
+                                                                          URI.create("https://example.org"
+                                                                                     + "/someOtherChannel"),
+                                                                          HARDCODED_LEVEL),
+                                                   DEFAULT_INSTANCE_TYPE,
+                                                   defaultInstitutionPoints, defaultCreators))),
+                         Arguments.of(Named.of("level changed",
+                                               new CandidateResetCauseArgument(
+                                                   new PublicationChannel(ChannelType.JOURNAL, HARDCODED_CHANNEL_ID,
+                                                                          "LevelTwo"),
+                                                   DEFAULT_INSTANCE_TYPE,
+                                                   defaultInstitutionPoints, defaultCreators))),
+                         Arguments.of(Named.of("instance type changed",
+                                               new CandidateResetCauseArgument(DEFAULT_PUBLICATION_CHANNEL,
+                                                                               InstanceType.ACADEMIC_MONOGRAPH,
+                                                                               defaultInstitutionPoints,
+                                                                               defaultCreators))),
+                         Arguments.of(Named.of("points changed",
+                                               new CandidateResetCauseArgument(DEFAULT_PUBLICATION_CHANNEL,
+                                                                               DEFAULT_INSTANCE_TYPE,
+                                                                               List.of(new InstitutionPoints(
+                                                                                   HARDCODED_INSTITUTION_ID,
+                                                                                   BigDecimal.TWO,
+                                                                                   null)), defaultCreators))),
+                         Arguments.of(Named.of("creator changed",
+                                               new CandidateResetCauseArgument(DEFAULT_PUBLICATION_CHANNEL,
+                                                                               DEFAULT_INSTANCE_TYPE,
+                                                                               defaultInstitutionPoints,
+                                                                               List.of(new Creator(
+                                                                                   URI.create("https://example"
+                                                                                              + ".org"
+                                                                                              +
+                                                                                              "/someOtherCreator"),
+                                                                                   List.of(
+                                                                                       HARDCODED_INSTITUTION_ID)))))),
+                         Arguments.of(Named.of("creator removed",
+                                               new CandidateResetCauseArgument(DEFAULT_PUBLICATION_CHANNEL,
+                                                                               DEFAULT_INSTANCE_TYPE,
+                                                                               defaultInstitutionPoints,
+                                                                               Collections.emptyList()))),
+                         Arguments.of(Named.of("creator added",
                                                new CandidateResetCauseArgument(DEFAULT_PUBLICATION_CHANNEL,
                                                                                DEFAULT_INSTANCE_TYPE,
                                                                                defaultInstitutionPoints,
@@ -602,7 +644,20 @@ class CandidateTest extends LocalDynamoTest {
                                                                                               +
                                                                                               "/someOtherCreator"),
                                                                                    List.of(
-                                                                                       HARDCODED_INSTITUTION_ID)))))));
+                                                                                       HARDCODED_INSTITUTION_ID)))))),
+                         Arguments.of(Named.of("top level affiliation changed",
+                                               new CandidateResetCauseArgument(DEFAULT_PUBLICATION_CHANNEL,
+                                                                               DEFAULT_INSTANCE_TYPE,
+                                                                               defaultInstitutionPoints,
+                                                                               List.of(new Creator(HARDCODED_CREATOR_ID,
+                                                                                                   List.of(
+                                                                                                       URI.create(
+                                                                                                           "https"
+                                                                                                           +
+                                                                                                           "://example"
+                                                                                                           + ".org"
+                                                                                                           +
+                                                                                                           "/someOtherInstitution"))))))));
     }
 
     @Deprecated

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -877,7 +877,7 @@ class CandidateTest extends LocalDynamoTest {
             return new Builder();
         }
 
-        private static class Builder {
+        private static final class Builder {
 
             private static final Creator DEFAULT_CREATOR = new Creator(HARDCODED_CREATOR_ID,
                                                                        List.of(HARDCODED_SUBUNIT_ID));

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -107,9 +107,6 @@ class CandidateTest extends LocalDynamoTest {
     private static final URI HARDCODED_CHANNEL_ID = URI.create(
         "https://example.org/publication-channels-v2/journal/123/2018");
     private static final String HARDCODED_LEVEL = "LevelOne";
-    private static final PublicationChannel HARDCODED_PUBLICATION_CHANNEL = new PublicationChannel(ChannelType.JOURNAL,
-                                                                                                   HARDCODED_CHANNEL_ID,
-                                                                                                   HARDCODED_LEVEL);
     private static final URI HARDCODED_CREATOR_ID = URI.create("https://example.org/someCreator");
     private static final InstanceType HARDCODED_INSTANCE_TYPE = InstanceType.ACADEMIC_ARTICLE;
     private static final BigDecimal HARDCODED_POINTS = BigDecimal.ONE.setScale(EXPECTED_SCALE, EXPECTED_ROUNDING_MODE);
@@ -721,9 +718,9 @@ class CandidateTest extends LocalDynamoTest {
                                             new PublicationDate(String.valueOf(CURRENT_YEAR), null, null),
                                             Map.of(HARDCODED_CREATOR_ID, List.of(HARDCODED_SUBUNIT_ID)),
                                             HARDCODED_INSTANCE_TYPE,
-                                            HARDCODED_PUBLICATION_CHANNEL.channelType().getValue(),
-                                            HARDCODED_PUBLICATION_CHANNEL.id(),
-                                            HARDCODED_PUBLICATION_CHANNEL.level(),
+                                            ChannelType.JOURNAL.getValue(),
+                                            HARDCODED_CHANNEL_ID,
+                                            HARDCODED_LEVEL,
                                             List.of(
                                                 new InstitutionPoints(HARDCODED_INSTITUTION_ID, HARDCODED_POINTS,
                                                                       List.of(
@@ -884,7 +881,9 @@ class CandidateTest extends LocalDynamoTest {
 
             private static final Creator DEFAULT_CREATOR = new Creator(HARDCODED_CREATOR_ID,
                                                                        List.of(HARDCODED_SUBUNIT_ID));
-            private PublicationChannel channel = HARDCODED_PUBLICATION_CHANNEL;
+            private PublicationChannel channel = new PublicationChannel(ChannelType.JOURNAL,
+                                                                        HARDCODED_CHANNEL_ID,
+                                                                        HARDCODED_LEVEL);
             private InstanceType type = HARDCODED_INSTANCE_TYPE;
             private List<InstitutionPoints> institutionPoints = List.of(
                 new InstitutionPoints(HARDCODED_INSTITUTION_ID, HARDCODED_POINTS,

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -873,11 +873,11 @@ class CandidateTest extends LocalDynamoTest {
     private record CandidateResetCauseArgument(PublicationChannel channel, InstanceType type,
                                                List<InstitutionPoints> institutionPoints, List<Creator> creators) {
 
-        public static CandidateResetCauseArgument.Builder defaultBuilder() {
+        private static CandidateResetCauseArgument.Builder defaultBuilder() {
             return new Builder();
         }
 
-        public static class Builder {
+        private static class Builder {
 
             private static final Creator DEFAULT_CREATOR = new Creator(HARDCODED_CREATOR_ID,
                                                                        List.of(HARDCODED_SUBUNIT_ID));
@@ -895,27 +895,27 @@ class CandidateTest extends LocalDynamoTest {
             private Builder() {
             }
 
-            public Builder withType(InstanceType type) {
+            private Builder withType(InstanceType type) {
                 this.type = type;
                 return this;
             }
 
-            public Builder withCreators(List<Creator> creators) {
+            private Builder withCreators(List<Creator> creators) {
                 this.creators = creators;
                 return this;
             }
 
-            public Builder withChannelId(URI publicationChannelId) {
+            private Builder withChannelId(URI publicationChannelId) {
                 this.channel = new PublicationChannel(ChannelType.JOURNAL, publicationChannelId, HARDCODED_LEVEL);
                 return this;
             }
 
-            public Builder withLevel(String level) {
+            private Builder withLevel(String level) {
                 this.channel = new PublicationChannel(ChannelType.JOURNAL, HARDCODED_CHANNEL_ID, level);
                 return this;
             }
 
-            public Builder withPointsForInstitution(BigDecimal institutionPoints) {
+            private Builder withPointsForInstitution(BigDecimal institutionPoints) {
                 this.institutionPoints = List.of(new InstitutionPoints(HARDCODED_INSTITUTION_ID, institutionPoints,
                                                                        List.of(new CreatorAffiliationPoints(
                                                                            HARDCODED_CREATOR_ID,
@@ -924,7 +924,7 @@ class CandidateTest extends LocalDynamoTest {
                 return this;
             }
 
-            public CandidateResetCauseArgument build() {
+            private CandidateResetCauseArgument build() {
                 return new CandidateResetCauseArgument(channel, type, institutionPoints, creators);
             }
         }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
@@ -154,10 +154,10 @@ public final class ExpandedResourceGenerator {
     }
 
     private static ObjectNode createAndPopulatePublicationContext(Candidate candidate, boolean populateIssn) {
-        if (isNull(candidate.getPublicationDetails().publicationChannel().channelType())) {
+        if (isNull(candidate.getPublicationChannelType())) {
             return objectMapper.createObjectNode();
         }
-        return switch (candidate.getPublicationDetails().publicationChannel().channelType()) {
+        return switch (candidate.getPublicationChannelType()) {
             case JOURNAL -> createJournalPublicationContext(candidate, populateIssn);
             case SERIES -> createSeriesPublicationContext(candidate, populateIssn);
             case PUBLISHER -> createPublisherPublicationContext(candidate);
@@ -167,8 +167,8 @@ public final class ExpandedResourceGenerator {
     private static ObjectNode createPublisherPublicationContext(Candidate candidate) {
         var publisher = objectMapper.createObjectNode();
         publisher.put(TYPE, "Publisher");
-        publisher.put("id", candidate.getPublicationDetails().publicationChannel().id().toString());
-        publisher.put("level", candidate.getPublicationDetails().publicationChannel().level());
+        publisher.put("id", candidate.getPublicationChannelId().toString());
+        publisher.put("level", candidate.getScientificLevel());
         publisher.put(NAME, randomString());
         var publicationContext = objectMapper.createObjectNode();
         publicationContext.set("publisher", publisher);
@@ -178,8 +178,8 @@ public final class ExpandedResourceGenerator {
     private static ObjectNode createSeriesPublicationContext(Candidate candidate, boolean populateIssn) {
         var series = objectMapper.createObjectNode();
         series.put(TYPE, "Series");
-        series.put("id", candidate.getPublicationDetails().publicationChannel().id().toString());
-        series.put("level", candidate.getPublicationDetails().publicationChannel().level());
+        series.put("id", candidate.getPublicationChannelId().toString());
+        series.put("level", candidate.getScientificLevel());
         series.put(NAME, randomString());
         if (populateIssn) {
             series.put("printIssn", randomString());
@@ -192,8 +192,8 @@ public final class ExpandedResourceGenerator {
     private static ObjectNode createJournalPublicationContext(Candidate candidate, boolean populateIssn) {
         var journal = objectMapper.createObjectNode();
         journal.put(TYPE, "Journal");
-        journal.put("id", candidate.getPublicationDetails().publicationChannel().id().toString());
-        journal.put("level", candidate.getPublicationDetails().publicationChannel().level());
+        journal.put("id", candidate.getPublicationChannelId().toString());
+        journal.put("level", candidate.getScientificLevel());
         journal.put(NAME, randomString());
         if (populateIssn) {
             journal.put("printIssn", randomString());

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/ExpandedResourceGenerator.java
@@ -154,10 +154,10 @@ public final class ExpandedResourceGenerator {
     }
 
     private static ObjectNode createAndPopulatePublicationContext(Candidate candidate, boolean populateIssn) {
-        if (isNull(candidate.getPublicationDetails().channelType())) {
+        if (isNull(candidate.getPublicationDetails().publicationChannel().channelType())) {
             return objectMapper.createObjectNode();
         }
-        return switch (candidate.getPublicationDetails().channelType()) {
+        return switch (candidate.getPublicationDetails().publicationChannel().channelType()) {
             case JOURNAL -> createJournalPublicationContext(candidate, populateIssn);
             case SERIES -> createSeriesPublicationContext(candidate, populateIssn);
             case PUBLISHER -> createPublisherPublicationContext(candidate);
@@ -167,8 +167,8 @@ public final class ExpandedResourceGenerator {
     private static ObjectNode createPublisherPublicationContext(Candidate candidate) {
         var publisher = objectMapper.createObjectNode();
         publisher.put(TYPE, "Publisher");
-        publisher.put("id", candidate.getPublicationDetails().publicationChannelId().toString());
-        publisher.put("level", candidate.getPublicationDetails().level());
+        publisher.put("id", candidate.getPublicationDetails().publicationChannel().id().toString());
+        publisher.put("level", candidate.getPublicationDetails().publicationChannel().level());
         publisher.put(NAME, randomString());
         var publicationContext = objectMapper.createObjectNode();
         publicationContext.set("publisher", publisher);
@@ -178,8 +178,8 @@ public final class ExpandedResourceGenerator {
     private static ObjectNode createSeriesPublicationContext(Candidate candidate, boolean populateIssn) {
         var series = objectMapper.createObjectNode();
         series.put(TYPE, "Series");
-        series.put("id", candidate.getPublicationDetails().publicationChannelId().toString());
-        series.put("level", candidate.getPublicationDetails().level());
+        series.put("id", candidate.getPublicationDetails().publicationChannel().id().toString());
+        series.put("level", candidate.getPublicationDetails().publicationChannel().level());
         series.put(NAME, randomString());
         if (populateIssn) {
             series.put("printIssn", randomString());
@@ -192,8 +192,8 @@ public final class ExpandedResourceGenerator {
     private static ObjectNode createJournalPublicationContext(Candidate candidate, boolean populateIssn) {
         var journal = objectMapper.createObjectNode();
         journal.put(TYPE, "Journal");
-        journal.put("id", candidate.getPublicationDetails().publicationChannelId().toString());
-        journal.put("level", candidate.getPublicationDetails().level());
+        journal.put("id", candidate.getPublicationDetails().publicationChannel().id().toString());
+        journal.put("level", candidate.getPublicationDetails().publicationChannel().level());
         journal.put(NAME, randomString());
         if (populateIssn) {
             journal.put("printIssn", randomString());

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -223,12 +223,12 @@ public final class IndexDocumentTestUtils {
 
     private static PublicationChannel getPublicationChannel(
         JsonNode expandedResource, no.sikt.nva.nvi.common.service.model.PublicationDetails publicationDetails) {
-        var channelType = publicationDetails.channelType();
+        var channelType = publicationDetails.publicationChannel().channelType();
         var publicationChannelBuilder = PublicationChannel.builder()
-                                            .withScientificValue(ScientificValue.parse(publicationDetails.level()))
+                                            .withScientificValue(ScientificValue.parse(publicationDetails.publicationChannel().level()))
                                             .withName(extractChannelName(expandedResource, channelType));
-        if (nonNull(publicationDetails.publicationChannelId())) {
-            publicationChannelBuilder.withId(publicationDetails.publicationChannelId());
+        if (nonNull(publicationDetails.publicationChannel().id())) {
+            publicationChannelBuilder.withId(publicationDetails.publicationChannel().id());
         }
         if (nonNull(channelType)) {
             publicationChannelBuilder.withType(channelType.getValue());

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/IndexDocumentTestUtils.java
@@ -92,7 +92,7 @@ public final class IndexDocumentTestUtils {
                    .withPublicationDate(mapToPublicationDate(candidate.getPublicationDetails().publicationDate()))
                    .withContributors(
                        mapToContributors(ExpandedResourceGenerator.extractContributors(expandedResource), candidate))
-                   .withPublicationChannel(getPublicationChannel(expandedResource, candidate.getPublicationDetails()))
+                   .withPublicationChannel(getPublicationChannel(expandedResource, candidate))
                    .withPages(getPages(expandedResource))
                    .withLanguage(extractOptionalLanguage(expandedResource))
                    .build();
@@ -221,14 +221,13 @@ public final class IndexDocumentTestUtils {
                    .build();
     }
 
-    private static PublicationChannel getPublicationChannel(
-        JsonNode expandedResource, no.sikt.nva.nvi.common.service.model.PublicationDetails publicationDetails) {
-        var channelType = publicationDetails.publicationChannel().channelType();
+    private static PublicationChannel getPublicationChannel(JsonNode expandedResource, Candidate candidate) {
+        var channelType = candidate.getPublicationChannelType();
         var publicationChannelBuilder = PublicationChannel.builder()
-                                            .withScientificValue(ScientificValue.parse(publicationDetails.publicationChannel().level()))
+                                            .withScientificValue(ScientificValue.parse(candidate.getScientificLevel()))
                                             .withName(extractChannelName(expandedResource, channelType));
-        if (nonNull(publicationDetails.publicationChannel().id())) {
-            publicationChannelBuilder.withId(publicationDetails.publicationChannel().id());
+        if (nonNull(candidate.getPublicationChannelId())) {
+            publicationChannelBuilder.withId(candidate.getPublicationChannelId());
         }
         if (nonNull(channelType)) {
             publicationChannelBuilder.withType(channelType.getValue());


### PR DESCRIPTION
Jira task: NP-48112 Update reset-requirements for approved/rejected candidate

Changes in `shouldResetCandidate()` checks:
- Reset if publication channel `id` is updated
- Reset if creator `id`s (not affiliations) are updated
- Do not reset if creator affiliation changes within same top level organization

Next step/PR: Do not reset if creator is identified (no `id` -> `id`) without affiliation changes