### PR TITLE
refactor: Add names to parameterized tests

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/QueuePersistedResourceHandlerTest.java
@@ -44,7 +44,7 @@ class QueuePersistedResourceHandlerTest {
         assertThat(appender.getMessages(), containsString("Invalid EventReference, missing uri"));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldNotQueueResourcesThatAreNotPublications {0}")
     @ValueSource(strings = {"s3://persisted-resources-884807050265/tickets/123.gz",
         "https://example.com/someOtherThing/123"})
     void shouldNotQueueResourcesThatAreNotPublications(String uri) throws IOException {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -119,7 +119,7 @@ class EventBasedBatchScanHandlerTest extends LocalDynamoTest {
         assertTrue(hasUpdatedVersions(daos), "All candidates should have been updated with new version");
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "shouldUpdateDataEntriesWithGivenTypeWhenRequestContainsType: {0}")
     @ValueSource(strings = {CandidateDao.TYPE, ApprovalStatusDao.TYPE, NoteDao.TYPE, NviPeriodDao.TYPE})
     void shouldUpdateDataEntriesWithGivenTypeWhenRequestContainsType(String type) {
         createPeriod();

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/db/DataEntryUpdateHandlerTest.java
@@ -93,7 +93,7 @@ class DataEntryUpdateHandlerTest {
         handler = new DataEntryUpdateHandler(snsClient, ENVIRONMENT, queueClient);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldConvertDynamoDbEventToDataEntryUpdateEvent {index}")
     @MethodSource("dynamoDbEventProvider")
     void shouldConvertDynamoDbEventToDataEntryUpdateEvent(Dao oldImage, Dao newImage, String expectedTopic,
                                                           OperationType operationType) {
@@ -105,7 +105,7 @@ class DataEntryUpdateHandlerTest {
         assertEquals(expectedPublishedMessage, snsClient.getPublishedMessages().get(0));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldDoNothingWhenReceivingEventWithOtherDaoTypes {index}")
     @MethodSource("otherDaoTypesProvider")
     void shouldDoNothingWhenReceivingEventWithOtherDaoTypes(Dao dao) {
         var event = createEvent(dao, dao, randomElement(OperationType.values()));

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -104,7 +104,7 @@ class UpsertNviCandidateHandlerTest extends LocalDynamoTest {
         assertThat(appender.getMessages(), containsString(ERROR_MESSAGE_BODY_INVALID));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name= "should send message to DLQ when message invalid: {0}")
     @MethodSource("invalidCandidateEvaluatedMessages")
     void shouldSendMessageToDlqWhenMessageInvalid(CandidateEvaluatedMessage message) {
         handler.handleRequest(createEvent(message), CONTEXT);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -310,7 +310,7 @@ class IndexDocumentHandlerTest extends LocalDynamoTest {
         assertEquals(expectedConsumptionAttributes, actualIndexDocument.consumptionAttributes());
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "shouldExtractLanguageFromExpandedResource: {0}")
     @ValueSource(booleans = {true, false})
     void shouldExtractOptionalLanguageFromExpandedResource(boolean languageExists) {
         var candidate = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());
@@ -326,7 +326,7 @@ class IndexDocumentHandlerTest extends LocalDynamoTest {
         assertEquals(expectedIndexDocument, actualIndexDocument);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name= "shouldExtractOptionalPrintIssnFromExpandedResource: {0}")
     @MethodSource("channelTypeIssnProvider")
     void shouldExtractOptionalPrintIssnFromExpandedResource(ChannelType channelType, boolean printIssnExists) {
         var candidate = randomApplicableCandidate(channelType);
@@ -342,7 +342,7 @@ class IndexDocumentHandlerTest extends LocalDynamoTest {
         assertEquals(expectedIndexDocument, actualIndexDocument);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name= "shouldGenerateIndexDocumentForAllPublicationChannelTypes: {0}")
     @EnumSource(ChannelType.class)
     void shouldGenerateIndexDocumentForAllPublicationChannelTypes(ChannelType channelType) {
         var candidate = randomApplicableCandidate(channelType);
@@ -359,7 +359,7 @@ class IndexDocumentHandlerTest extends LocalDynamoTest {
         assertEquals(expectedIndexDocument, actualIndexDocument);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name= "shouldExtractOptionalAbstractFromExpandedResource: {0}")
     @ValueSource(booleans = {true, false})
     void shouldExtractOptionalAbstractFromExpandedResource(boolean abstractExists) {
         var candidate = randomApplicableCandidate(HARD_CODED_TOP_LEVEL_ORG, randomUri());

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -157,7 +157,7 @@ class FetchInstitutionReportHandlerTest {
         assertThat(response.getStatusCode(), is(Matchers.equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldReturnCandidatesWithApprovalsBelongingToUsersTopLevelOrganization {0}")
     @MethodSource("listSupportedMediaTypes")
     void shouldReturnCandidatesWithApprovalsBelongingToUsersTopLevelOrganization(String mediaType)
         throws IOException {
@@ -172,7 +172,7 @@ class FetchInstitutionReportHandlerTest {
         assertEquals(expected, actual);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldReturnReportWithLanguageLabel {0}")
     @MethodSource("listSupportedLanguages")
     void shouldReturnReportWithLanguageLabel(String languageUri) throws IOException {
         var topLevelCristinOrg = randomCristinOrgUri();
@@ -317,7 +317,7 @@ class FetchInstitutionReportHandlerTest {
         assertEquals(expected, actual);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldReturnRequestedContentType {0}")
     @MethodSource("listSupportedMediaTypes")
     void shouldReturnRequestedContentType(String mediaType) throws IOException {
         var topLevelCristinOrg = randomCristinOrgUri();
@@ -328,7 +328,7 @@ class FetchInstitutionReportHandlerTest {
         assertThat(response.getHeaders().get(CONTENT_TYPE), is(mediaType));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldReturnBase64EncodedOutputStream {0}")
     @MethodSource("listSupportedMediaTypes")
     void shouldReturnBase64EncodedOutputStream(String mediaType) throws IOException {
         var topLevelCristinOrg = randomCristinOrgUri();

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -187,7 +187,7 @@ class OpenSearchClientTest {
         assertThat(searchResponse.hits().hits().size(), is(equalTo(expectedNumberOfHitsReturned)));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "shouldOrderResult {0}")
     @ValueSource(strings = {"asc", "desc"})
     void shouldOrderResult(String sortOrder) throws InterruptedException, IOException {
         var createdFirst = documentWithCreatedDate(Instant.now());
@@ -238,7 +238,7 @@ class OpenSearchClientTest {
         assertThat(nviCandidateIndexDocument, hasSize(0));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "shouldReturnAggregationsWithExpectedCount {0}")
     @MethodSource("aggregationNameAndExpectedCountProvider")
     void shouldReturnAggregationsWithExpectedCount(Entry<String, Integer> entry)
         throws IOException, InterruptedException {
@@ -346,7 +346,7 @@ class OpenSearchClientTest {
         assertThat(searchResponse.hits().hits(), hasSize(1));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldReturnSearchResultsUsingFilter {0}")
     @MethodSource("filterNameProvider")
     void shouldReturnSearchResultsUsingFilter(Entry<String, Integer> entry)
         throws IOException, InterruptedException {
@@ -549,7 +549,7 @@ class OpenSearchClientTest {
         assertThat(searchResponse.hits().hits(), hasSize(1));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldReturnSearchResultsUsingFilterAndSearchTermCombined {0}")
     @MethodSource("filterNameProvider")
     void shouldReturnSearchResultsUsingFilterAndSearchTermCombined(Entry<String, Integer> entry)
         throws IOException, InterruptedException {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/PeriodStatusTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/PeriodStatusTest.java
@@ -57,7 +57,7 @@ class PeriodStatusTest {
         assertThat(actualDto.year(), is(equalTo(expectedDto.year())));
     }
 
-    @ParameterizedTest()
+    @ParameterizedTest(name="shouldConvertPeriodToPeriodStatusCorrectly {index}")
     @MethodSource("periodToPeriodStatusProvider")
     void shouldConvertPeriodToPeriodStatusCorrectly(DbNviPeriod period, Status expectedStatus) {
         var actualStatus = PeriodStatus.fromPeriod(period);

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
@@ -105,7 +105,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
         assertThat(actualNewStatus, is(equalTo(newStatus)));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="Should reset approval when changing to pending from {0}")
     @EnumSource(value = ApprovalStatus.class, names = {"REJECTED", APPROVED})
     void shouldResetApprovalWhenChangingToPending(ApprovalStatus oldStatus) {
         var institutionId = randomUri();
@@ -122,7 +122,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
         assertThat(approvalStatus.getFinalizedDate(), is(nullValue()));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="Should remove reason when updating from rejection status to {0}")
     @EnumSource(value = ApprovalStatus.class, names = {"PENDING", APPROVED})
     void shouldRemoveReasonWhenUpdatingFromRejectionStatusToNewStatus(ApprovalStatus newStatus) {
         var institutionId = randomUri();
@@ -180,7 +180,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
                      () -> Candidate.upsert(updateRequest, candidateRepository, periodRepository));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldThrowUnsupportedOperationWhenRejectingWithoutReason {0}")
     @EnumSource(value = ApprovalStatus.class, names = {"PENDING", APPROVED})
     void shouldThrowUnsupportedOperationWhenRejectingWithoutReason(ApprovalStatus oldStatus) {
         var institutionId = randomUri();
@@ -193,7 +193,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
             createRejectionRequestWithoutReason(institutionId, randomString())));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldThrowIllegalArgumentExceptionWhenUpdateStatusWithoutUsername {0}")
     @EnumSource(value = ApprovalStatus.class, names = {"PENDING", APPROVED, "REJECTED"})
     void shouldThrowIllegalArgumentExceptionWhenUpdateStatusWithoutUsername(ApprovalStatus newStatus) {
         var institutionId = randomUri();
@@ -241,7 +241,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
         assertThrows(IllegalArgumentException.class, () -> candidateBO.updateApproval(() -> institutionId));
     }
 
-    @ParameterizedTest()
+    @ParameterizedTest(name="Should not allow to update approval when candidate is not within period {0}")
     @MethodSource("periodRepositoryProvider")
     void shouldNotAllowToUpdateApprovalWhenCandidateIsNotWithinPeriod(PeriodRepository periodRepository) {
         var candidate = randomApplicableCandidate(candidateRepository, periodRepository);
@@ -342,9 +342,9 @@ class CandidateApprovalTest extends CandidateTestSetup {
         assertThat(updatedCandidate.getApprovals().size(), is(greaterThan(0)));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="Should reset approvals when {0}")
     @MethodSource("candidateResetCauseProvider")
-    @DisplayName("Should reset approvals when updating fields effecting approvals")
+    @DisplayName("Should reset approvals when updating fields affecting approvals")
     void shouldResetApprovalsWhenUpdatingFieldsEffectingApprovals(CandidateResetCauseArgument arguments) {
         var upsertCandidateRequest = getUpsertCandidateRequestWithHardcodedValues();
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -80,7 +80,7 @@ class CandidateTest extends CandidateTestSetup {
     }
 
     @Deprecated
-    @ParameterizedTest
+    @ParameterizedTest(name="Should persist new candidate with correct level {0}")
     @MethodSource("levelValues")
     void shouldPersistNewCandidateWithCorrectLevelBasedOnVersionTwoLevelValues(DbLevel expectedLevel,
                                                                                String versionTwoValue) {
@@ -103,7 +103,7 @@ class CandidateTest extends CandidateTestSetup {
         assertEquals(expectedCandidate, actualPersistedCandidate);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="Should persist new candidate with correct level {0}")
     @ValueSource(ints = {0, 1, 4})
     void shouldPersistNewCandidateWithCorrectScaleForAllDecimals(int scale) {
         var request = createUpsertRequestWithDecimalScale(scale, randomUri());
@@ -115,7 +115,7 @@ class CandidateTest extends CandidateTestSetup {
         assertEquals(expectedCandidate, actualPersistedCandidate);
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="Should update candidate with correct level {0}")
     @ValueSource(ints = {0, 1, 4})
     void shouldUpdateCandidateWithCorrectScaleForAllDecimals(int scale) {
         var request = randomUpsertRequestBuilder()

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/InstanceTypeTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/InstanceTypeTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 class InstanceTypeTest {
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldParseValidStrings {0}")
     @ValueSource(strings = {"AcademicCommentary", "AcademicMonograph", "AcademicChapter", "AcademicArticle",
         "AcademicLiteratureReview"})
     void shouldParseValidStrings(String value) {

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -166,7 +166,7 @@ class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
         assertThat(actualApproval.status(), is(equalTo(expectedStatus)));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldResetFinalizedValuesWhenUpdatingStatusToPending from old status {0}")
     @EnumSource(value = ApprovalStatus.class, names = {"REJECTED", "APPROVED"})
     void shouldResetFinalizedValuesWhenUpdatingStatusToPending(ApprovalStatus oldStatus) throws IOException {
         var institutionId = randomUri();
@@ -183,7 +183,7 @@ class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
         assertThat(actualApproval.status(), is(equalTo(ApprovalStatusDto.NEW)));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldUpdateApprovalStatusToRejectedWithReason from old status {0}")
     @EnumSource(value = ApprovalStatus.class, names = {"PENDING", "APPROVED"})
     void shouldUpdateApprovalStatusToRejectedWithReason(ApprovalStatus oldStatus) throws IOException {
         var institutionId = randomUri();
@@ -201,7 +201,7 @@ class UpdateNviCandidateStatusHandlerTest extends LocalDynamoTest {
         assertThat(actualApprovalStatus.reason(), is(equalTo(rejectionReason)));
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name="shouldRemoveReasonWhenUpdatingStatusFromRejected to {0}")
     @EnumSource(value = ApprovalStatus.class, names = {"PENDING", "APPROVED"})
     void shouldRemoveReasonWhenUpdatingStatusFromRejected(ApprovalStatus newStatus) throws IOException {
         var institutionId = randomUri();


### PR DESCRIPTION
Add names to parameterized tests so that the GitHub test results bot can differentiate between new and old tests (no name => automatically generated name for each test run => bot thinks the test was replaced).