### PR TITLE
Np 48263 FetchReportStatusByPublicationIdHandler - Global status APPROVED and REJECTED

### DIFF
--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/ReportStatusDto.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/ReportStatusDto.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.rest.fetch;
 
 import java.net.URI;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
 
 public record ReportStatusDto(URI publicationId, StatusWithDescriptionDto reportStatus, String period) {
 
@@ -22,6 +23,10 @@ public record ReportStatusDto(URI publicationId, StatusWithDescriptionDto report
             return StatusDto.REPORTED;
         } else if (candidate.isPendingReview()) {
             return StatusDto.PENDING_REVIEW;
+        } else if (GlobalApprovalStatus.REJECTED.equals(candidate.getGlobalApprovalStatus())) {
+            return StatusDto.REJECTED;
+        } else if (GlobalApprovalStatus.APPROVED.equals(candidate.getGlobalApprovalStatus())) {
+            return StatusDto.APPROVED;
         } else if (candidate.isUnderReview()) {
             return StatusDto.UNDER_REVIEW;
         } else if (candidate.isNotReportedInClosedPeriod()) {
@@ -35,6 +40,8 @@ public record ReportStatusDto(URI publicationId, StatusWithDescriptionDto report
 
         PENDING_REVIEW("Pending review. Awaiting approval from all institutions"),
         UNDER_REVIEW("Under review. At least one institution has approved/rejected"),
+        APPROVED("Approved by all involved institutions in open period"),
+        REJECTED("Rejected by all involved institutions in open period"),
         REPORTED("Reported in closed period"),
         NOT_REPORTED("Not reported in closed period"),
         NOT_CANDIDATE("Not a candidate");

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/ReportStatusDto.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/ReportStatusDto.java
@@ -23,9 +23,11 @@ public record ReportStatusDto(URI publicationId, StatusWithDescriptionDto report
             return StatusDto.REPORTED;
         } else if (candidate.isPendingReview()) {
             return StatusDto.PENDING_REVIEW;
-        } else if (GlobalApprovalStatus.REJECTED.equals(candidate.getGlobalApprovalStatus())) {
+        } else if (GlobalApprovalStatus.REJECTED.equals(candidate.getGlobalApprovalStatus())
+                   && candidate.getPeriod().isOpen()) {
             return StatusDto.REJECTED;
-        } else if (GlobalApprovalStatus.APPROVED.equals(candidate.getGlobalApprovalStatus())) {
+        } else if (GlobalApprovalStatus.APPROVED.equals(candidate.getGlobalApprovalStatus())
+                   && candidate.getPeriod().isOpen()) {
             return StatusDto.APPROVED;
         } else if (candidate.isUnderReview()) {
             return StatusDto.UNDER_REVIEW;

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
@@ -94,11 +94,12 @@ class FetchReportStatusByPublicationIdHandlerTest extends LocalDynamoTest {
     @EnumSource(value = ApprovalStatus.class, names = {"APPROVED", "REJECTED"})
     void shouldReturnUnderReviewWhenPublicationIsCandidateWithAtLeastOneNonPendingApprovalInOpenPeriod(
         ApprovalStatus approvalStatus) throws IOException {
-        var institutionId = randomUri();
-        var upsertCandidateRequest = createUpsertCandidateRequest(new URI[]{institutionId, randomUri()}).build();
+        var institution1 = randomUri();
+        var involvedInstitutions = new URI[]{institution1, randomUri()};
+        var upsertCandidateRequest = createUpsertCandidateRequest(involvedInstitutions).build();
         var candidate = upsert(upsertCandidateRequest);
         candidate.updateApproval(
-            new UpdateStatusRequest(institutionId, approvalStatus, randomString(), randomString()));
+            new UpdateStatusRequest(institution1, approvalStatus, randomString(), randomString()));
         periodRepository = periodRepositoryReturningOpenedPeriod(CURRENT_YEAR);
         var handler = new FetchReportStatusByPublicationIdHandler(candidateRepository, periodRepository);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
@@ -95,7 +95,7 @@ class FetchReportStatusByPublicationIdHandlerTest extends LocalDynamoTest {
     void shouldReturnUnderReviewWhenPublicationIsCandidateWithAtLeastOneNonPendingApprovalInOpenPeriod(
         ApprovalStatus approvalStatus) throws IOException {
         var institutionId = randomUri();
-        var upsertCandidateRequest = createUpsertCandidateRequest(institutionId, randomUri());
+        var upsertCandidateRequest = createUpsertCandidateRequest(new URI[]{institutionId, randomUri()}).build();
         var candidate = upsert(upsertCandidateRequest);
         candidate.updateApproval(
             new UpdateStatusRequest(institutionId, approvalStatus, randomString(), randomString()));
@@ -116,11 +116,14 @@ class FetchReportStatusByPublicationIdHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnApprovedWhenPublicationIsCandidateWithAllApprovalsApproved() throws IOException {
-        var institutionId = randomUri();
-        var upsertCandidateRequest = createUpsertCandidateRequest(institutionId).build();
+        var institution1 = randomUri();
+        var institution2 = randomUri();
+        var upsertCandidateRequest = createUpsertCandidateRequest(institution1, institution2);
         var candidate = upsert(upsertCandidateRequest);
         candidate.updateApproval(
-            new UpdateStatusRequest(institutionId, ApprovalStatus.APPROVED, randomString(), randomString()));
+            new UpdateStatusRequest(institution1, ApprovalStatus.APPROVED, randomString(), randomString()));
+        candidate.updateApproval(
+            new UpdateStatusRequest(institution2, ApprovalStatus.APPROVED, randomString(), randomString()));
         periodRepository = periodRepositoryReturningOpenedPeriod(CURRENT_YEAR);
         var handler = new FetchReportStatusByPublicationIdHandler(candidateRepository, periodRepository);
 
@@ -138,11 +141,14 @@ class FetchReportStatusByPublicationIdHandlerTest extends LocalDynamoTest {
 
     @Test
     void shouldReturnRejectedWhenPublicationIsCandidateWithAllApprovalsRejected() throws IOException {
-        var institutionId = randomUri();
-        var upsertCandidateRequest = createUpsertCandidateRequest(institutionId).build();
+        var institution1 = randomUri();
+        var institution2 = randomUri();
+        var upsertCandidateRequest = createUpsertCandidateRequest(institution1, institution2);
         var candidate = upsert(upsertCandidateRequest);
         candidate.updateApproval(
-            new UpdateStatusRequest(institutionId, ApprovalStatus.REJECTED, randomString(), randomString()));
+            new UpdateStatusRequest(institution1, ApprovalStatus.REJECTED, randomString(), randomString()));
+        candidate.updateApproval(
+            new UpdateStatusRequest(institution2, ApprovalStatus.REJECTED, randomString(), randomString()));
         periodRepository = periodRepositoryReturningOpenedPeriod(CURRENT_YEAR);
         var handler = new FetchReportStatusByPublicationIdHandler(candidateRepository, periodRepository);
 


### PR DESCRIPTION
FE noticed that it is also relevant to know whether all approvals are approved in an open period, so added two new statuses that can be returned by `FetchReportStatusByPublicationIdHandler`