### PR TITLE
refactor: Rename handler to force recreation of resource

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -995,7 +995,7 @@ Resources:
         Variables:
           DLQ_QUEUE_URL: !Ref IndexDLQ
 
-  ReEvaluateNviCandidatesHandler:
+  BatchReEvaluateNviCandidatesHandler:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: event-handlers


### PR DESCRIPTION
This is done purely to trick CFN into recreating the resource, as the stack is stuck in an invalid state.