### PR TITLE
fix: Remove incorrect validation on NviPeriod upsert

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/CreatePeriodRequest.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/CreatePeriodRequest.java
@@ -3,7 +3,6 @@ package no.sikt.nva.nvi.common.service.model;
 import static no.sikt.nva.nvi.common.utils.Validator.doesNotHaveNullValues;
 import static no.sikt.nva.nvi.common.utils.Validator.hasValidLength;
 import static no.sikt.nva.nvi.common.utils.Validator.isBefore;
-import static no.sikt.nva.nvi.common.utils.Validator.isNotBeforeCurrentTime;
 import java.time.Instant;
 
 public record CreatePeriodRequest(Integer publishingYear, Instant startDate, Instant reportingDate,
@@ -21,8 +20,6 @@ public record CreatePeriodRequest(Integer publishingYear, Instant startDate, Ins
         doesNotHaveNullValues(this);
         hasValidLength(publishingYear(), EXPECTED_LENGTH);
         isBefore(startDate(), reportingDate());
-        isNotBeforeCurrentTime(startDate());
-        isNotBeforeCurrentTime(reportingDate());
     }
 
     public static final class Builder {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/UpdatePeriodRequest.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/UpdatePeriodRequest.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.common.service.model;
 
 import static no.sikt.nva.nvi.common.utils.Validator.doesNotHaveNullValues;
 import static no.sikt.nva.nvi.common.utils.Validator.isBefore;
-import static no.sikt.nva.nvi.common.utils.Validator.isNotBeforeCurrentTime;
 import java.time.Instant;
 
 public record UpdatePeriodRequest(Integer publishingYear, Instant startDate, Instant reportingDate, Username modifiedBy)
@@ -16,8 +15,6 @@ public record UpdatePeriodRequest(Integer publishingYear, Instant startDate, Ins
     public void validate() {
         doesNotHaveNullValues(this);
         isBefore(startDate(), reportingDate());
-        isNotBeforeCurrentTime(startDate());
-        isNotBeforeCurrentTime(reportingDate());
     }
 
     public static final class Builder {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/Validator.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/Validator.java
@@ -23,12 +23,6 @@ public final class Validator {
         }
     }
 
-    public static void isNotBeforeCurrentTime(Instant date) {
-        if (date.isBefore(Instant.now())) {
-            throw new IllegalArgumentException("Provided date is back in time!");
-        }
-    }
-
     public static void doesNotHaveNullValues(UpsertPeriodRequest upsertPeriodRequest) {
         if (isNull(upsertPeriodRequest.publishingYear())) {
             throw new IllegalArgumentException("Publishing year can not be null!");

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
@@ -73,10 +73,15 @@ class CandidateApprovalTest extends CandidateTestSetup {
                          Arguments.of(ApprovalStatus.REJECTED, ApprovalStatus.APPROVED));
     }
 
-    public static Stream<PeriodRepository> periodRepositoryProvider() {
-        var year = ZonedDateTime.now().getYear();
-        return Stream.of(periodRepositoryReturningClosedPeriod(year), periodRepositoryReturningNotOpenedPeriod(year),
-                         mock(PeriodRepository.class));
+    public static Stream<Arguments> periodRepositoryProvider() {
+        var year = ZonedDateTime
+                       .now()
+                       .getYear();
+        return Stream.of(Arguments.of(Named.of("Repository returning closed period",
+                                               periodRepositoryReturningClosedPeriod(year))),
+                         Arguments.of(Named.of("Repository returning period not opened yet",
+                                               periodRepositoryReturningNotOpenedPeriod(year))),
+                         Arguments.of(Named.of("Mocked repository", mock(PeriodRepository.class))));
     }
 
     @Test
@@ -242,7 +247,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
         assertThrows(IllegalArgumentException.class, () -> candidateBO.updateApproval(() -> institutionId));
     }
 
-    @ParameterizedTest(name="Should not allow to update approval when candidate is not within period {0}")
+    @ParameterizedTest
     @MethodSource("periodRepositoryProvider")
     void shouldNotAllowToUpdateApprovalWhenCandidateIsNotWithinPeriod(PeriodRepository periodRepository) {
         var candidate = randomApplicableCandidate(candidateRepository, periodRepository);

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/NviPeriodTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/NviPeriodTest.java
@@ -36,10 +36,16 @@ class NviPeriodTest extends LocalDynamoTest {
         var expectedId = constructExpectedId(request);
         var actual = NviPeriod.create(request, periodRepository);
         assertEquals(expectedId, actual.getId());
-        assertEquals(request.publishingYear(), actual.getPublishingYear());
-        assertEquals(request.startDate(), actual.getStartDate());
-        assertEquals(request.reportingDate(), actual.getReportingDate());
-        assertEquals(request.createdBy(), actual.getCreatedBy());
+        assertThatRequestMatchesYear(request, actual);
+    }
+
+    @Test
+    void shouldCreateNviPeriodForCurrentYear() {
+        var request = createRequest(YEAR - 1);
+        var expectedId = constructExpectedId(request);
+        var actual = NviPeriod.create(request, periodRepository);
+        assertEquals(expectedId, actual.getId());
+        assertThatRequestMatchesYear(request, actual);
     }
 
     @Test
@@ -90,12 +96,6 @@ class NviPeriodTest extends LocalDynamoTest {
     @Test
     void shouldReturnIllegalArgumentExceptionWhenPublishingYearHasInvalidLength() {
         var createRequest = createRequest(22);
-        assertThrows(IllegalArgumentException.class, () -> NviPeriod.create(createRequest, periodRepository));
-    }
-
-    @Test
-    void shouldReturnIllegalArgumentExceptionWhenWhenStartDateHasAlreadyBeenReached() {
-        var createRequest = createRequest(YEAR, Instant.now(), nowPlusDays(1));
         assertThrows(IllegalArgumentException.class, () -> NviPeriod.create(createRequest, periodRepository));
     }
 
@@ -163,5 +163,12 @@ class NviPeriodTest extends LocalDynamoTest {
                    .addChild("period")
                    .addChild(String.valueOf(createPeriodRequest.publishingYear()))
                    .getUri();
+    }
+
+    private static void assertThatRequestMatchesYear(CreatePeriodRequest request, NviPeriod actual) {
+        assertEquals(request.publishingYear(), actual.getPublishingYear());
+        assertEquals(request.startDate(), actual.getStartDate());
+        assertEquals(request.reportingDate(), actual.getReportingDate());
+        assertEquals(request.createdBy(), actual.getCreatedBy());
     }
 }


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48396

This allows creating/updating NVI periods with date in the past.
This validation should be expanded and improved in future (see [NP-48230](https://sikt.atlassian.net/browse/NP-48230)), but for now we can allow creating NVI periods start/ending in the past.

[NP-48230]: https://sikt.atlassian.net/browse/NP-48230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ