### PR TITLE
fix: Replace objectMapper

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDto.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDto.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.events.evaluator.dto;
 
+import static java.util.Collections.emptyList;
+import static java.util.Objects.nonNull;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -31,6 +33,16 @@ public record ContributorDto(
       @JsonProperty("identity") ExpandedIdentityDto expandedIdentity,
       @JsonProperty("role") ExpandedRoleDto role,
       @JsonProperty("affiliations") List<ExpandedAffiliationDto> expandedAffiliations) {
+
+    public ExpandedContributorDto(
+        ExpandedIdentityDto expandedIdentity,
+        ExpandedRoleDto role,
+        List<ExpandedAffiliationDto> expandedAffiliations) {
+      this.expandedIdentity = expandedIdentity;
+      this.role = role;
+      this.expandedAffiliations =
+          nonNull(expandedAffiliations) ? expandedAffiliations : emptyList();
+    }
 
     public ContributorDto toDto() {
       var name = expandedIdentity().name();

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDto.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDto.java
@@ -4,6 +4,7 @@ import static java.util.Collections.emptyList;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -52,12 +53,16 @@ public record ContributorDto(
       var affiliations =
           expandedAffiliations().stream().map(ExpandedAffiliationDto::toDto).toList();
 
-      return new ContributorDto(name, id, verificationStatus, roleType, affiliations);
+      // FIXME: This is a temporary fix to handle the fact that the name field can be an array.
+      // We should handle this properly in the whole chain, but for now we just take the first
+      // element and discard other names.
+      return new ContributorDto(name.getFirst(), id, verificationStatus, roleType, affiliations);
     }
   }
 
   public record ExpandedIdentityDto(
-      @JsonProperty("name") String name,
+      @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("name")
+          List<String> name,
       @JsonProperty("id") URI id,
       @JsonProperty("verificationStatus") String verificationStatus) {}
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDto.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDto.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.events.evaluator.dto;
 
 import static java.util.Collections.emptyList;
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 
@@ -46,17 +47,14 @@ public record ContributorDto(
     }
 
     public ContributorDto toDto() {
-      var name = expandedIdentity().name();
+      var name = expandedIdentity().defaultName();
       var id = expandedIdentity().id();
       var verificationStatus = expandedIdentity().verificationStatus();
       var roleType = role().type();
       var affiliations =
           expandedAffiliations().stream().map(ExpandedAffiliationDto::toDto).toList();
 
-      // FIXME: This is a temporary fix to handle the fact that the name field can be an array.
-      // We should handle this properly in the whole chain, but for now we just take the first
-      // element and discard other names.
-      return new ContributorDto(name.getFirst(), id, verificationStatus, roleType, affiliations);
+      return new ContributorDto(name, id, verificationStatus, roleType, affiliations);
     }
   }
 
@@ -64,7 +62,18 @@ public record ContributorDto(
       @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY) @JsonProperty("name")
           List<String> name,
       @JsonProperty("id") URI id,
-      @JsonProperty("verificationStatus") String verificationStatus) {}
+      @JsonProperty("verificationStatus") String verificationStatus) {
+
+    // FIXME: This is a temporary fix to handle the fact that the name field can be an array.
+    // We should handle this properly in the whole chain, but for now we just take the first
+    // element and discard other names.
+    public String defaultName() {
+      if (isNull(name) || name.isEmpty()) {
+        return null;
+      }
+      return name.getFirst();
+    }
+  }
 
   public record ExpandedRoleDto(@JsonProperty("type") String type) {}
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDtoTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDtoTest.java
@@ -20,7 +20,6 @@ class ContributorDtoTest {
               "verificationStatus": "NotVerified",
               "additionalIdentifiers": []
           },
-          "affiliations": [],
           "role": {
               "type": "Creator"
           },

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDtoTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/dto/ContributorDtoTest.java
@@ -6,11 +6,34 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class ContributorDtoTest {
 
-  private static final String UNAFFILIATED_UNVERIFIED_CONTRIBUTOR =
+  private static final String CONTRIBUTOR_WITH_EMPTY_AFFILIATIONS =
+      """
+      {
+          "type": "Contributor",
+          "identity": {
+              "type": "Identity",
+              "name": "I.N. Kognito",
+              "verificationStatus": "NotVerified",
+              "additionalIdentifiers": []
+          },
+          "affiliations": [],
+          "role": {
+              "type": "Creator"
+          },
+          "sequence": 1,
+          "correspondingAuthor": false
+      }
+      """;
+
+  private static final String CONTRIBUTOR_WITH_MISSING_AFFILIATIONS =
       """
       {
           "type": "Contributor",
@@ -28,9 +51,36 @@ class ContributorDtoTest {
       }
       """;
 
-  @Test
-  void fromJsonNode() throws JsonProcessingException {
-    var contributorNode = parseJsonString(UNAFFILIATED_UNVERIFIED_CONTRIBUTOR);
+  private static final String CONTRIBUTOR_WITH_MULTIPLE_NAMES =
+      """
+      {
+          "type": "Contributor",
+          "identity": {
+              "type": "Identity",
+              "name": ["I.N. Kognito", "Ignacio N. Kognito"],
+              "verificationStatus": "NotVerified",
+              "additionalIdentifiers": []
+          },
+          "role": {
+              "type": "Creator"
+          },
+          "sequence": 1,
+          "correspondingAuthor": false
+      }
+      """;
+
+  private static Stream<Arguments> validContributorJsonProvider() {
+    return Stream.of(
+        Arguments.of(Named.of("WithEmptyListOfAffiliations", CONTRIBUTOR_WITH_EMPTY_AFFILIATIONS)),
+        Arguments.of(
+            Named.of("WithMissingListOfAffiliations", CONTRIBUTOR_WITH_MISSING_AFFILIATIONS)),
+        Arguments.of(Named.of("WithArrayOfNames", CONTRIBUTOR_WITH_MULTIPLE_NAMES)));
+  }
+
+  @ParameterizedTest
+  @MethodSource("validContributorJsonProvider")
+  void fromJsonNode(String jsonContributor) throws JsonProcessingException {
+    var contributorNode = parseJsonString(jsonContributor);
     var expectedContributor =
         new ContributorDto("I.N. Kognito", null, "NotVerified", "Creator", emptyList());
     var actualContributor = ContributorDto.fromJsonNode(contributorNode);

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -52,7 +52,8 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
       "Failed to fetch candidate with identifier: {}";
   private static final String FAILED_TO_GENERATE_INDEX_DOCUMENT_MESSAGE =
       "Failed to generate index document for candidate with identifier: {}";
-  private static final String BLANK_ERROR_MESSAGE_PASSED_TO_ERROR_HANDLER = "An unexpected error occurred with a blank message passed to error handler.";
+  private static final String BLANK_ERROR_MESSAGE_PASSED_TO_ERROR_HANDLER =
+      "An unexpected error occurred with a blank message passed to error handler.";
   private final StorageReader<URI> storageReader;
   private final StorageWriter<IndexDocumentWithConsumptionAttributes> storageWriter;
   private final CandidateRepository candidateRepository;
@@ -242,7 +243,7 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
   }
 
   private void handleFailure(
-    Failure<?> failure, String message, String messageArgument, UUID candidateIdentifier) {
+      Failure<?> failure, String message, String messageArgument, UUID candidateIdentifier) {
     validateErrorMessage(messageArgument);
     logFailure(message, messageArgument, failure.getException());
     sqsClient.sendMessage(failure.getException().getMessage(), dlqUrl, candidateIdentifier);

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -4,6 +4,7 @@ import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
 import static no.sikt.nva.nvi.common.utils.ExceptionUtils.getStackTrace;
 import static no.sikt.nva.nvi.index.aws.S3StorageWriter.GZIP_ENDING;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.StringUtils.isBlank;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -51,6 +52,7 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
       "Failed to fetch candidate with identifier: {}";
   private static final String FAILED_TO_GENERATE_INDEX_DOCUMENT_MESSAGE =
       "Failed to generate index document for candidate with identifier: {}";
+  private static final String BLANK_ERROR_MESSAGE_PASSED_TO_ERROR_HANDLER = "An unexpected error occurred with a blank message passed to error handler.";
   private final StorageReader<URI> storageReader;
   private final StorageWriter<IndexDocumentWithConsumptionAttributes> storageWriter;
   private final CandidateRepository candidateRepository;
@@ -226,13 +228,22 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
     return IndexDocumentWithConsumptionAttributes.from(candidate, persistedResource, uriRetriever);
   }
 
+  private void validateErrorMessage(String message) {
+    if (isBlank(message)) {
+      LOGGER.error(BLANK_ERROR_MESSAGE_PASSED_TO_ERROR_HANDLER, message);
+      sqsClient.sendMessage(BLANK_ERROR_MESSAGE_PASSED_TO_ERROR_HANDLER, dlqUrl);
+    }
+  }
+
   private void handleFailure(Failure<?> failure, String messageArgument) {
+    validateErrorMessage(messageArgument);
     logFailure(FAILED_TO_PARSE_EVENT_MESSAGE, messageArgument, failure.getException());
     sqsClient.sendMessage(failure.getException().getMessage(), dlqUrl);
   }
 
   private void handleFailure(
-      Failure<?> failure, String message, String messageArgument, UUID candidateIdentifier) {
+    Failure<?> failure, String message, String messageArgument, UUID candidateIdentifier) {
+    validateErrorMessage(messageArgument);
     logFailure(message, messageArgument, failure.getException());
     sqsClient.sendMessage(failure.getException().getMessage(), dlqUrl, candidateIdentifier);
   }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -3,7 +3,7 @@ package no.sikt.nva.nvi.index;
 import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
 import static no.sikt.nva.nvi.common.utils.ExceptionUtils.getStackTrace;
 import static no.sikt.nva.nvi.index.aws.S3StorageWriter.GZIP_ENDING;
-import static no.unit.nva.commons.json.JsonUtils.dynamoObjectMapper;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -158,7 +158,7 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
   }
 
   private DynamodbStreamRecord mapToDynamoDbRecord(String body) {
-    return attempt(() -> dynamoObjectMapper.readValue(body, DynamodbStreamRecord.class))
+    return attempt(() -> dtoObjectMapper.readValue(body, DynamodbStreamRecord.class))
         .orElse(
             failure -> {
               handleFailure(failure, body);

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/IndexDocumentHandler.java
@@ -231,7 +231,7 @@ public class IndexDocumentHandler implements RequestHandler<SQSEvent, Void> {
 
   private void validateErrorMessage(String message) {
     if (isBlank(message)) {
-      LOGGER.error(BLANK_ERROR_MESSAGE_PASSED_TO_ERROR_HANDLER, message);
+      LOGGER.error(BLANK_ERROR_MESSAGE_PASSED_TO_ERROR_HANDLER);
       sqsClient.sendMessage(BLANK_ERROR_MESSAGE_PASSED_TO_ERROR_HANDLER, dlqUrl);
     }
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/Dao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/Dao.java
@@ -1,6 +1,6 @@
 package no.sikt.nva.nvi.common.db;
 
-import static no.unit.nva.commons.json.JsonUtils.dynamoObjectMapper;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -45,7 +45,7 @@ public abstract class Dao implements DynamoEntryWithRangeKey {
   @DynamoDbIgnore
   public Map<String, AttributeValue> toDynamoFormat() {
     return EnhancedDocument.fromJson(
-            attempt(() -> dynamoObjectMapper.writeValueAsString(this)).orElseThrow())
+            attempt(() -> dtoObjectMapper.writeValueAsString(this)).orElseThrow())
         .toMap();
   }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/DynamoEntryWithRangeKey.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/DynamoEntryWithRangeKey.java
@@ -1,6 +1,6 @@
 package no.sikt.nva.nvi.common.db;
 
-import static no.unit.nva.commons.json.JsonUtils.dynamoObjectMapper;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -18,7 +18,7 @@ public interface DynamoEntryWithRangeKey extends Typed {
   static Dao parseAttributeValuesMap(Map<String, AttributeValue> value, Class<Dao> daoClass) {
     return attempt(
             () ->
-                dynamoObjectMapper.readValue(
+                dtoObjectMapper.readValue(
                     EnhancedDocument.fromAttributeValueMap(value).toJson(), daoClass))
         .orElseThrow();
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/DbCreatorTypeListConverter.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/DbCreatorTypeListConverter.java
@@ -1,6 +1,6 @@
 package no.sikt.nva.nvi.common.db.model;
 
-import static no.unit.nva.commons.json.JsonUtils.dynamoObjectMapper;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 
 import java.util.List;
@@ -48,7 +48,7 @@ public class DbCreatorTypeListConverter implements AttributeConverter<List<DbCre
   private DbCreatorType toCreator(Map<String, AttributeValue> attributeValueMap) {
     return attempt(
             () ->
-                dynamoObjectMapper.readValue(
+                dtoObjectMapper.readValue(
                     EnhancedDocument.fromAttributeValueMap(attributeValueMap).toJson(),
                     DbCreatorType.class))
         .orElseThrow();
@@ -58,7 +58,7 @@ public class DbCreatorTypeListConverter implements AttributeConverter<List<DbCre
     return AttributeValue.builder()
         .m(
             EnhancedDocument.fromJson(
-                    attempt(() -> dynamoObjectMapper.writeValueAsString(creator)).orElseThrow())
+                    attempt(() -> dtoObjectMapper.writeValueAsString(creator)).orElseThrow())
                 .toMap())
         .build();
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/DynamoDbUtils.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/DynamoDbUtils.java
@@ -2,7 +2,7 @@ package no.sikt.nva.nvi.common.utils;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.nonNull;
-import static no.unit.nva.commons.json.JsonUtils.dynamoObjectMapper;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
@@ -35,7 +35,7 @@ public final class DynamoDbUtils {
 
   public static DynamodbStreamRecord toDynamodbStreamRecord(String body)
       throws JsonProcessingException {
-    return dynamoObjectMapper.readValue(body, DynamodbStreamRecord.class);
+    return dtoObjectMapper.readValue(body, DynamodbStreamRecord.class);
   }
 
   private static String extractIdentifier(DynamodbStreamRecord record) {
@@ -76,7 +76,7 @@ public final class DynamoDbUtils {
       return AttributeValue.builder().l(emptyList()).build();
     }
     var json = writeAsString(value);
-    return dynamoObjectMapper.readValue(json, AttributeValue.serializableBuilderClass()).build();
+    return dtoObjectMapper.readValue(json, AttributeValue.serializableBuilderClass()).build();
   }
 
   private static AttributeValue mapEachAttributeValueToDynamoDbValue(
@@ -103,6 +103,6 @@ public final class DynamoDbUtils {
   private static String writeAsString(
       com.amazonaws.services.lambda.runtime.events.models.dynamodb.AttributeValue attributeValue)
       throws JsonProcessingException {
-    return dynamoObjectMapper.writeValueAsString(attributeValue);
+    return dtoObjectMapper.writeValueAsString(attributeValue);
   }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/DynamoDbUtilsTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/DynamoDbUtilsTest.java
@@ -1,7 +1,7 @@
 package no.sikt.nva.nvi.common.utils;
 
 import static no.sikt.nva.nvi.test.DynamoDbTestUtils.getAttributeValueMap;
-import static no.unit.nva.commons.json.JsonUtils.dynamoObjectMapper;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.amazonaws.services.lambda.runtime.events.DynamodbEvent.DynamodbStreamRecord;
@@ -15,51 +15,6 @@ class DynamoDbUtilsTest {
 
   public static final String SOME_FIELD_NAME = "fieldWithNullValue";
   public static final String IDENTIFIER = "identifier";
-
-  @Test
-  void shouldParseNullValuesWhenGettingImage() {
-    var streamRecordWithNullValue = setupStreamRecordWithFieldWithNullValue();
-    var attributeValueMap = DynamoDbUtils.getImage(streamRecordWithNullValue);
-    var expectedAttributeValue = AttributeValue.builder().nul(true).build();
-    assertEquals(expectedAttributeValue, attributeValueMap.get(SOME_FIELD_NAME));
-  }
-
-  @Test
-  void shouldParseImageToAttributeValueMap() {
-    var expectedAttributeValueMap = randomAttributeValueMap();
-    var streamRecord =
-        dynamodbRecordWithStreamRecord(
-            new StreamRecord().withNewImage(getAttributeValueMap(expectedAttributeValueMap)));
-    var actualAttributeValueMap = DynamoDbUtils.getImage(streamRecord);
-    assertEquals(expectedAttributeValueMap, actualAttributeValueMap);
-  }
-
-  @Test
-  void shouldExtractIdentifierFromNewImageWhenNewImageIsPresent() {
-    var expectedIdentifier = UUID.randomUUID();
-    var streamRecordWithNewImage =
-        dynamodbRecordWithStreamRecord(streamRecordWithOldAndNewImage(expectedIdentifier));
-    var actualIdentifier = DynamoDbUtils.extractIdFromRecord(streamRecordWithNewImage);
-    assertEquals(expectedIdentifier, actualIdentifier.orElse(null));
-  }
-
-  @Test
-  void shouldExtractIdentifierFromOldImageWhenNewImageIsNotPresent() {
-    var expectedIdentifier = UUID.randomUUID();
-    var streamRecordWithOldImage =
-        dynamodbRecordWithStreamRecord(streamRecordWithOnlyOldImage(expectedIdentifier));
-    var actualIdentifier = DynamoDbUtils.extractIdFromRecord(streamRecordWithOldImage);
-    assertEquals(expectedIdentifier, actualIdentifier.orElse(null));
-  }
-
-  @Test
-  void shouldSerializeWithoutLossOfData() throws Exception {
-    var originalStreamRecord =
-        dynamodbRecordWithStreamRecord(streamRecordWithOldAndNewImage(UUID.randomUUID()));
-    var streamRecordAsString = dynamoObjectMapper.writeValueAsString(originalStreamRecord);
-    var regeneratedStreamRecord = DynamoDbUtils.toDynamodbStreamRecord(streamRecordAsString);
-    assertEquals(originalStreamRecord, regeneratedStreamRecord);
-  }
 
   private static Map<String, AttributeValue> randomAttributeValueMap() {
     return Map.of(
@@ -105,5 +60,50 @@ class DynamoDbUtilsTest {
                     new com.amazonaws.services.lambda.runtime.events.models.dynamodb
                             .AttributeValue()
                         .withNULL(true))));
+  }
+
+  @Test
+  void shouldParseNullValuesWhenGettingImage() {
+    var streamRecordWithNullValue = setupStreamRecordWithFieldWithNullValue();
+    var attributeValueMap = DynamoDbUtils.getImage(streamRecordWithNullValue);
+    var expectedAttributeValue = AttributeValue.builder().nul(true).build();
+    assertEquals(expectedAttributeValue, attributeValueMap.get(SOME_FIELD_NAME));
+  }
+
+  @Test
+  void shouldParseImageToAttributeValueMap() {
+    var expectedAttributeValueMap = randomAttributeValueMap();
+    var streamRecord =
+        dynamodbRecordWithStreamRecord(
+            new StreamRecord().withNewImage(getAttributeValueMap(expectedAttributeValueMap)));
+    var actualAttributeValueMap = DynamoDbUtils.getImage(streamRecord);
+    assertEquals(expectedAttributeValueMap, actualAttributeValueMap);
+  }
+
+  @Test
+  void shouldExtractIdentifierFromNewImageWhenNewImageIsPresent() {
+    var expectedIdentifier = UUID.randomUUID();
+    var streamRecordWithNewImage =
+        dynamodbRecordWithStreamRecord(streamRecordWithOldAndNewImage(expectedIdentifier));
+    var actualIdentifier = DynamoDbUtils.extractIdFromRecord(streamRecordWithNewImage);
+    assertEquals(expectedIdentifier, actualIdentifier.orElse(null));
+  }
+
+  @Test
+  void shouldExtractIdentifierFromOldImageWhenNewImageIsNotPresent() {
+    var expectedIdentifier = UUID.randomUUID();
+    var streamRecordWithOldImage =
+        dynamodbRecordWithStreamRecord(streamRecordWithOnlyOldImage(expectedIdentifier));
+    var actualIdentifier = DynamoDbUtils.extractIdFromRecord(streamRecordWithOldImage);
+    assertEquals(expectedIdentifier, actualIdentifier.orElse(null));
+  }
+
+  @Test
+  void shouldSerializeWithoutLossOfData() throws Exception {
+    var originalStreamRecord =
+        dynamodbRecordWithStreamRecord(streamRecordWithOldAndNewImage(UUID.randomUUID()));
+    var streamRecordAsString = dtoObjectMapper.writeValueAsString(originalStreamRecord);
+    var regeneratedStreamRecord = DynamoDbUtils.toDynamodbStreamRecord(streamRecordAsString);
+    assertEquals(originalStreamRecord, regeneratedStreamRecord);
   }
 }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -5,6 +5,7 @@ import static no.sikt.nva.nvi.rest.remove.RemoveNoteHandler.PARAM_NOTE_IDENTIFIE
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomUsername;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -31,7 +32,6 @@ import no.sikt.nva.nvi.rest.create.NviNoteRequest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
 import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.sikt.nva.nvi.test.TestUtils;
-import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.GatewayResponse;
@@ -48,6 +48,15 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
   private RemoveNoteHandler handler;
   private PeriodRepository periodRepository;
   private CandidateRepository candidateRepository;
+
+  private static HandlerRequestBuilder<NviNoteRequest> createRequestWithoutAccessRights(
+      URI customerId, String candidateId, String noteId, String userName) {
+    return new HandlerRequestBuilder<NviNoteRequest>(dtoObjectMapper)
+        .withPathParameters(
+            Map.of(CANDIDATE_IDENTIFIER, candidateId, PARAM_NOTE_IDENTIFIER, noteId))
+        .withCurrentCustomer(customerId)
+        .withUserName(userName);
+  }
 
   @BeforeEach
   void setUp() {
@@ -140,15 +149,6 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(Matchers.equalTo(HttpURLConnection.HTTP_CONFLICT)));
-  }
-
-  private static HandlerRequestBuilder<NviNoteRequest> createRequestWithoutAccessRights(
-      URI customerId, String candidateId, String noteId, String userName) {
-    return new HandlerRequestBuilder<NviNoteRequest>(JsonUtils.dynamoObjectMapper)
-        .withPathParameters(
-            Map.of(CANDIDATE_IDENTIFIER, candidateId, PARAM_NOTE_IDENTIFIER, noteId))
-        .withCurrentCustomer(customerId)
-        .withUserName(userName);
   }
 
   private Candidate createNote(Candidate candidate, Username user) {


### PR DESCRIPTION
This is intended to fix an issue with parsing `CandidateDao` after changes to the data model, by replacing the object mapper used throughout the project. The `dynamoObjectMapper` used previously ignored empty fields (i.e. null values), which I believe caused issues with parsing certain values.