### PR TITLE
fix: Parse null as empty list

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/InstitutionPoints.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/InstitutionPoints.java
@@ -1,11 +1,13 @@
 package no.sikt.nva.nvi.common.service.model;
 
+import static java.util.Collections.emptyList;
 import static java.util.Objects.nonNull;
 
 import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbInstitutionPoints.DbCreatorAffiliationPoints;
 import no.sikt.nva.nvi.common.utils.DecimalUtils;
@@ -17,12 +19,14 @@ public record InstitutionPoints(
     List<CreatorAffiliationPoints> creatorAffiliationPoints) {
 
   public static InstitutionPoints from(DbInstitutionPoints dbInstitutionPoints) {
+    var creatorAffiliationPoints =
+        Optional.ofNullable(dbInstitutionPoints.creatorAffiliationPoints())
+            .map(list -> list.stream().map(CreatorAffiliationPoints::from).toList())
+            .orElse(emptyList());
     return new InstitutionPoints(
         dbInstitutionPoints.institutionId(),
         dbInstitutionPoints.points(),
-        dbInstitutionPoints.creatorAffiliationPoints().stream()
-            .map(CreatorAffiliationPoints::from)
-            .toList());
+        creatorAffiliationPoints);
   }
 
   @Override

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/InstitutionPointsTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/InstitutionPointsTest.java
@@ -1,7 +1,7 @@
 package no.sikt.nva.nvi.common.service.model;
 
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigDecimal;
 import java.util.List;

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/InstitutionPointsTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/InstitutionPointsTest.java
@@ -1,0 +1,22 @@
+package no.sikt.nva.nvi.common.service.model;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.List;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+import org.junit.jupiter.api.Test;
+
+class InstitutionPointsTest {
+
+  @Test
+  void shouldParseEntityWithNoCreatorPoints() {
+    var institutionId = randomUri();
+    var dbPoints =
+        List.of(new CandidateDao.DbInstitutionPoints(institutionId, BigDecimal.ZERO, null));
+    var expectedPoints = new InstitutionPoints(institutionId, BigDecimal.ZERO, List.of());
+    var actualPoints = InstitutionPoints.from(dbPoints.getFirst());
+    assertEquals(expectedPoints, actualPoints);
+  }
+}


### PR DESCRIPTION
This adds validation logic to handle cases where the list of points for a creator with no points is stored in DynamoDB as `null` instead of an empty list.