### PR TITLE
[np-48420] refactor: remove unused customerId

### DIFF
--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionReportHandlerTest.java
@@ -140,13 +140,9 @@ class FetchInstitutionReportHandlerTest {
   @Test
   void shouldReturnUnauthorizedWhenUserDoesNotHaveSufficientAccessRight() throws IOException {
     var institutionId = randomUri();
-    var customerId = randomUri();
     var request =
         createRequest(
-                institutionId,
-                AccessRight.MANAGE_DOI,
-                customerId,
-                Map.of(YEAR, String.valueOf(CURRENT_YEAR)))
+                institutionId, AccessRight.MANAGE_DOI, Map.of(YEAR, String.valueOf(CURRENT_YEAR)))
             .build();
     handler.handleRequest(request, output, CONTEXT);
     var response = fromOutputStream(output, Problem.class);
@@ -256,9 +252,7 @@ class FetchInstitutionReportHandlerTest {
     var topLevelCristinOrg = randomCristinOrgUri();
     var year = "2021";
     var request =
-        createRequest(
-                topLevelCristinOrg, MANAGE_NVI_CANDIDATES, topLevelCristinOrg, Map.of(YEAR, year))
-            .build();
+        createRequest(topLevelCristinOrg, MANAGE_NVI_CANDIDATES, Map.of(YEAR, year)).build();
     when(openSearchClient.search(any()))
         .thenReturn(aggregationResponse(1))
         .thenReturn(
@@ -282,9 +276,7 @@ class FetchInstitutionReportHandlerTest {
     var topLevelCristinOrg = randomCristinOrgUri();
     var year = "2021";
     var request =
-        createRequest(
-                topLevelCristinOrg, MANAGE_NVI_CANDIDATES, topLevelCristinOrg, Map.of(YEAR, year))
-            .build();
+        createRequest(topLevelCristinOrg, MANAGE_NVI_CANDIDATES, Map.of(YEAR, year)).build();
     when(openSearchClient.search(any()))
         .thenReturn(aggregationResponse(1))
         .thenReturn(
@@ -562,7 +554,7 @@ class FetchInstitutionReportHandlerTest {
 
   private static InputStream requestWithInvalidYearParam() throws JsonProcessingException {
     var invalidYear = "someInvalidYear";
-    return createRequest(randomUri(), MANAGE_NVI_CANDIDATES, randomUri(), Map.of())
+    return createRequest(randomUri(), MANAGE_NVI_CANDIDATES, Map.of())
         .withPathParameters(Map.of(YEAR, invalidYear))
         .build();
   }
@@ -570,22 +562,15 @@ class FetchInstitutionReportHandlerTest {
   private static InputStream requestWithMediaType(String mediaType, URI topLevelCristinOrg)
       throws JsonProcessingException {
     return createRequest(
-            topLevelCristinOrg,
-            MANAGE_NVI_CANDIDATES,
-            randomUri(),
-            Map.of(YEAR, String.valueOf(CURRENT_YEAR)))
+            topLevelCristinOrg, MANAGE_NVI_CANDIDATES, Map.of(YEAR, String.valueOf(CURRENT_YEAR)))
         .withHeaders(Map.of(ACCEPT, mediaType))
         .build();
   }
 
   private static HandlerRequestBuilder<InputStream> createRequest(
-      URI topLevelCristinOrg,
-      AccessRight accessRight,
-      URI customerId,
-      Map<String, String> pathParameters) {
+      URI topLevelCristinOrg, AccessRight accessRight, Map<String, String> pathParameters) {
     return new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
-        .withCurrentCustomer(customerId)
-        .withAccessRights(customerId, accessRight)
+        .withAccessRights(topLevelCristinOrg, accessRight)
         .withTopLevelCristinOrgId(topLevelCristinOrg)
         .withUserName(randomString())
         .withPathParameters(pathParameters);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionStatusAggregationHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionStatusAggregationHandlerTest.java
@@ -86,11 +86,9 @@ class FetchInstitutionStatusAggregationHandlerTest {
 
   private static HandlerRequestBuilder<InputStream> createRequest(
       URI userTopLevelCristinInstitution, URI institutionId, int year, AccessRight accessRight) {
-    var customerId = randomUri();
     return new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
-        .withCurrentCustomer(customerId)
         .withTopLevelCristinOrgId(userTopLevelCristinInstitution)
-        .withAccessRights(customerId, accessRight)
+        .withAccessRights(userTopLevelCristinInstitution, accessRight)
         .withUserName(randomString())
         .withPathParameters(
             Map.of(
@@ -102,9 +100,7 @@ class FetchInstitutionStatusAggregationHandlerTest {
 
   private static HandlerRequestBuilder<InputStream> createRequestWithoutAccessRight(
       URI userTopLevelCristinInstitution, URI institutionId, int year) {
-    var customerId = randomUri();
     return new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
-        .withCurrentCustomer(customerId)
         .withTopLevelCristinOrgId(userTopLevelCristinInstitution)
         .withUserName(randomString())
         .withPathParameters(

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -572,7 +572,6 @@ class SearchNviCandidatesHandlerTest {
     return new HandlerRequestBuilder<Void>(JsonUtils.dtoObjectMapper)
         .withTopLevelCristinOrgId(topLevelCristinOrgId)
         .withUserName(randomString())
-        .withCurrentCustomer(topLevelCristinOrgId)
         .withAccessRights(topLevelCristinOrgId, AccessRight.MANAGE_NVI)
         .build();
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/UpdateNviCandidateStatusValidator.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/validator/UpdateNviCandidateStatusValidator.java
@@ -37,8 +37,9 @@ public final class UpdateNviCandidateStatusValidator {
   }
 
   private static boolean hasUnverifiedCreator(
-      Candidate candidate, URI customerId, OrganizationRetriever organizationRetriever) {
-    var customerOrganization = organizationRetriever.fetchOrganization(customerId).getTopLevelOrg();
+      Candidate candidate, URI institutionId, OrganizationRetriever organizationRetriever) {
+    var customerOrganization =
+        organizationRetriever.fetchOrganization(institutionId).getTopLevelOrg();
     var unverifiedCreators = candidate.getPublicationDetails().getUnverifiedCreators();
     return unverifiedCreators.stream()
         .flatMap(contributor -> getTopLevelAffiliations(contributor, organizationRetriever))

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/RequestUtilTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/RequestUtilTest.java
@@ -57,11 +57,9 @@ class RequestUtilTest {
   private static InputStream createRequest(
       URI userTopLevelCristinInstitution, AccessRight accessRight, String userName)
       throws JsonProcessingException {
-    var customerId = randomUri();
     return new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
-        .withCurrentCustomer(customerId)
         .withTopLevelCristinOrgId(userTopLevelCristinInstitution)
-        .withAccessRights(customerId, accessRight)
+        .withAccessRights(userTopLevelCristinInstitution, accessRight)
         .withUserName(userName)
         .build();
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
@@ -65,7 +65,6 @@ public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTest {
   protected static final Context CONTEXT = mock(Context.class);
   protected final DynamoDbClient localDynamo = initializeTestDatabase();
   protected String resourcePathParameter;
-  protected URI currentCustomerId;
   protected URI topLevelCristinOrgId;
   protected URI subUnitCristinOrgId;
   protected ByteArrayOutputStream output;
@@ -75,17 +74,16 @@ public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTest {
 
   protected InputStream createRequestWithAdminAccess(String resourceIdentifier)
       throws JsonProcessingException {
-    return createRequest(resourceIdentifier, topLevelCristinOrgId, currentCustomerId, MANAGE_NVI);
+    return createRequest(resourceIdentifier, topLevelCristinOrgId, MANAGE_NVI);
   }
 
   protected InputStream createRequest(
-      String resourceIdentifier, URI cristinInstitutionId, URI customerId, AccessRight accessRight)
+      String resourceIdentifier, URI cristinInstitutionId, AccessRight accessRight)
       throws JsonProcessingException {
     return new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
         .withHeaders(Map.of(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType()))
-        .withCurrentCustomer(customerId)
         .withTopLevelCristinOrgId(cristinInstitutionId)
-        .withAccessRights(customerId, accessRight)
+        .withAccessRights(cristinInstitutionId, accessRight)
         .withUserName(randomString())
         .withPathParameters(Map.of(resourcePathParameter, resourceIdentifier))
         .build();
@@ -95,7 +93,6 @@ public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTest {
   protected void commonSetup() {
     subUnitCristinOrgId = randomUri();
     topLevelCristinOrgId = randomUri();
-    currentCustomerId = topLevelCristinOrgId;
 
     output = new ByteArrayOutputStream();
     candidateRepository = new CandidateRepository(localDynamo);
@@ -109,7 +106,6 @@ public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTest {
       throws JsonProcessingException {
     return new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
         .withHeaders(Map.of(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType()))
-        .withCurrentCustomer(currentCustomerId)
         .withTopLevelCristinOrgId(topLevelCristinOrgId)
         .withUserName(randomString())
         .withPathParameters(Map.of(resourcePathParameter, resourceIdentifier))
@@ -118,8 +114,7 @@ public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTest {
 
   protected InputStream createRequestWithCuratorAccess(String resourceIdentifier)
       throws JsonProcessingException {
-    return createRequest(
-        resourceIdentifier, topLevelCristinOrgId, currentCustomerId, MANAGE_NVI_CANDIDATES);
+    return createRequest(resourceIdentifier, topLevelCristinOrgId, MANAGE_NVI_CANDIDATES);
   }
 
   protected Candidate setupValidCandidate(URI institutionId) {
@@ -262,7 +257,7 @@ public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTest {
 
   protected UpdateStatusRequest createStatusRequest(ApprovalStatus status) {
     return UpdateStatusRequest.builder()
-        .withInstitutionId(currentCustomerId)
+        .withInstitutionId(topLevelCristinOrgId)
         .withApprovalStatus(status)
         .withUsername(randomString())
         .withReason(ApprovalStatus.REJECTED.equals(status) ? randomString() : null)

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/CreateNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/CreateNviPeriodHandlerTest.java
@@ -87,11 +87,9 @@ class CreateNviPeriodHandlerTest extends LocalDynamoTest {
   }
 
   private InputStream createRequest(UpsertNviPeriodRequest period) throws JsonProcessingException {
-    var customerId = randomUri();
     return new HandlerRequestBuilder<UpsertNviPeriodRequest>(JsonUtils.dtoObjectMapper)
         .withBody(period)
-        .withCurrentCustomer(customerId)
-        .withAccessRights(customerId, AccessRight.MANAGE_NVI)
+        .withAccessRights(randomUri(), AccessRight.MANAGE_NVI)
         .withUserName(randomString())
         .build();
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/UpdateNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/UpdateNviPeriodHandlerTest.java
@@ -88,11 +88,9 @@ class UpdateNviPeriodHandlerTest extends LocalDynamoTest {
   }
 
   private InputStream toInputStream(UpsertNviPeriodRequest request) throws JsonProcessingException {
-    var customerId = randomUri();
     return new HandlerRequestBuilder<UpsertNviPeriodRequest>(JsonUtils.dtoObjectMapper)
         .withBody(request)
-        .withCurrentCustomer(customerId)
-        .withAccessRights(customerId, AccessRight.MANAGE_NVI)
+        .withAccessRights(randomUri(), AccessRight.MANAGE_NVI)
         .withUserName(randomString())
         .build();
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -204,26 +204,23 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
   private InputStream createRequest(
       UUID identifier, NviNoteRequest body, String userName, URI institutionId)
       throws JsonProcessingException {
-    var customerId = randomUri();
     return new HandlerRequestBuilder<NviNoteRequest>(JsonUtils.dtoObjectMapper)
         .withBody(body)
-        .withCurrentCustomer(customerId)
         .withTopLevelCristinOrgId(institutionId)
         .withPathParameters(Map.of("candidateIdentifier", identifier.toString()))
-        .withAccessRights(customerId, AccessRight.MANAGE_NVI_CANDIDATES)
+        .withAccessRights(institutionId, AccessRight.MANAGE_NVI_CANDIDATES)
         .withUserName(userName)
         .build();
   }
 
   private InputStream createRequest(UUID identifier, String body, String userName)
       throws JsonProcessingException {
-    var customerId = randomUri();
+    var topLevelCristinOrgId = randomUri();
     return new HandlerRequestBuilder<String>(JsonUtils.dtoObjectMapper)
         .withBody(body)
-        .withCurrentCustomer(customerId)
-        .withTopLevelCristinOrgId(randomUri())
+        .withTopLevelCristinOrgId(topLevelCristinOrgId)
         .withPathParameters(Map.of("candidateIdentifier", identifier.toString()))
-        .withAccessRights(customerId, AccessRight.MANAGE_NVI_CANDIDATES)
+        .withAccessRights(topLevelCristinOrgId, AccessRight.MANAGE_NVI_CANDIDATES)
         .withUserName(userName)
         .build();
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
@@ -47,7 +47,7 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
 
   @Test
   void shouldReturnNotFoundWhenCandidateExistsButNotApplicable() throws IOException {
-    var nonApplicableCandidate = setupNonApplicableCandidate(currentCustomerId);
+    var nonApplicableCandidate = setupNonApplicableCandidate(topLevelCristinOrgId);
     var request = createRequestWithCuratorAccess(nonApplicableCandidate.getIdentifier().toString());
     handler.handleRequest(request, output, CONTEXT);
     var gatewayResponse = getGatewayResponse();
@@ -57,7 +57,7 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
 
   @Test
   void shouldReturnValidCandidateWhenCandidateExists() throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request = createRequestWithCuratorAccess(candidate.getPublicationId().toString());
 
     handler.handleRequest(request, output, CONTEXT);
@@ -84,7 +84,7 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
   @Test
   void shouldReturnCandidateDtoWithApprovalStatusNewWhenApprovalStatusIsPendingAndUnassigned()
       throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request = createRequestWithCuratorAccess(candidate.getPublicationId().toString());
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
@@ -96,7 +96,7 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
 
   @Test
   void shouldReturnUnauthorizedWhenCandidateIsNotInUsersViewingScope() throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request = createRequestWithCuratorAccess(candidate.getPublicationId().toString());
     handler =
         new FetchNviCandidateByPublicationIdHandler(

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandlerTest.java
@@ -44,7 +44,7 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnNotFoundWhenCandidateExistsButNotApplicable() throws IOException {
-    var nonApplicableCandidate = setupNonApplicableCandidate(currentCustomerId);
+    var nonApplicableCandidate = setupNonApplicableCandidate(topLevelCristinOrgId);
     var request = createRequestWithCuratorAccess(nonApplicableCandidate.getIdentifier().toString());
     handler.handleRequest(request, output, CONTEXT);
     var gatewayResponse = getGatewayResponse();
@@ -54,7 +54,7 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnUnauthorizedWhenCandidateIsNotInUsersViewingScope() throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request = createRequestWithCuratorAccess(candidate.getIdentifier().toString());
     var viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(false);
     handler =
@@ -67,7 +67,7 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnUnauthorizedWhenUserDoesNotHaveSufficientAccessRight() throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request = createRequestWithoutAccessRight(candidate.getIdentifier().toString());
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -77,7 +77,7 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnValidCandidateWhenCandidateExists() throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request = createRequestWithCuratorAccess(candidate.getIdentifier().toString());
 
     handler.handleRequest(request, output, CONTEXT);
@@ -91,7 +91,7 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
   @Test
   void shouldReturnCandidateDtoWithApprovalStatusNewWhenApprovalStatusIsPendingAndUnassigned()
       throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request = createRequestWithCuratorAccess(candidate.getIdentifier().toString());
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
@@ -103,7 +103,7 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnValidCandidateWhenUserIsNviAdmin() throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request = createRequestWithAdminAccess(candidate.getIdentifier().toString());
 
     handler.handleRequest(request, output, CONTEXT);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandlerTest.java
@@ -73,10 +73,8 @@ class FetchNviPeriodsHandlerTest extends LocalDynamoTest {
 
   private InputStream createRequestWithAccessRight(AccessRight accessRight)
       throws JsonProcessingException {
-    var customerId = randomUri();
     return new HandlerRequestBuilder<UpsertNviPeriodRequest>(JsonUtils.dtoObjectMapper)
-        .withCurrentCustomer(customerId)
-        .withAccessRights(customerId, accessRight)
+        .withAccessRights(randomUri(), accessRight)
         .withUserName(randomString())
         .build();
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -18,7 +18,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.URI;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.UUID;
@@ -50,11 +49,10 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
   private CandidateRepository candidateRepository;
 
   private static HandlerRequestBuilder<NviNoteRequest> createRequestWithoutAccessRights(
-      URI customerId, String candidateId, String noteId, String userName) {
+      String candidateId, String noteId, String userName) {
     return new HandlerRequestBuilder<NviNoteRequest>(dtoObjectMapper)
         .withPathParameters(
             Map.of(CANDIDATE_IDENTIFIER, candidateId, PARAM_NOTE_IDENTIFIER, noteId))
-        .withCurrentCustomer(customerId)
         .withUserName(userName);
   }
 
@@ -73,9 +71,7 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
   @Test
   void shouldReturnUnauthorizedWhenMissingAccessRights() throws IOException {
     handler.handleRequest(
-        createRequestWithoutAccessRights(
-                randomUri(), randomString(), randomString(), randomString())
-            .build(),
+        createRequestWithoutAccessRights(randomString(), randomString(), randomString()).build(),
         output,
         context);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -162,9 +158,8 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
 
   private HandlerRequestBuilder<NviNoteRequest> createRequest(
       UUID candidateIdentifier, UUID noteIdentifier, String userName) {
-    var customerId = randomUri();
     return createRequestWithoutAccessRights(
-            customerId, candidateIdentifier.toString(), noteIdentifier.toString(), userName)
-        .withAccessRights(customerId, AccessRight.MANAGE_NVI_CANDIDATES);
+            candidateIdentifier.toString(), noteIdentifier.toString(), userName)
+        .withAccessRights(randomUri(), AccessRight.MANAGE_NVI_CANDIDATES);
   }
 }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -220,9 +220,9 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
             periodRepository,
             mockViewingScopeValidator,
             mockOrganizationRetriever);
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var request =
-        createRequest(candidate.getIdentifier(), currentCustomerId, ApprovalStatus.APPROVED);
+        createRequest(candidate.getIdentifier(), topLevelCristinOrgId, ApprovalStatus.APPROVED);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
@@ -231,8 +231,8 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnBadRequestIfRejectionDoesNotContainReason() throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
-    var request = createRequestWithoutReason(candidate.getIdentifier(), currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
+    var request = createRequestWithoutReason(candidate.getIdentifier(), topLevelCristinOrgId);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
@@ -251,9 +251,9 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
   @MethodSource("approvalStatusProvider")
   void shouldUpdateApprovalStatus(ApprovalStatus oldStatus, ApprovalStatus newStatus)
       throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     candidate.updateApprovalStatus(createStatusRequest(oldStatus), mockOrganizationRetriever);
-    var request = createRequest(candidate.getIdentifier(), currentCustomerId, newStatus);
+    var request = createRequest(candidate.getIdentifier(), topLevelCristinOrgId, newStatus);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
     var candidateResponse = response.getBodyObject(CandidateDto.class);
@@ -277,10 +277,10 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
       names = {STATUS_REJECTED, STATUS_APPROVED})
   void shouldResetFinalizedValuesWhenUpdatingStatusToPending(ApprovalStatus oldStatus)
       throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     candidate.updateApprovalStatus(createStatusRequest(oldStatus), mockOrganizationRetriever);
     var newStatus = ApprovalStatus.PENDING;
-    var request = createRequest(candidate.getIdentifier(), currentCustomerId, newStatus);
+    var request = createRequest(candidate.getIdentifier(), topLevelCristinOrgId, newStatus);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
     var candidateResponse = response.getBodyObject(CandidateDto.class);
@@ -295,14 +295,17 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
       value = ApprovalStatus.class,
       names = {STATUS_PENDING, STATUS_APPROVED})
   void shouldUpdateApprovalStatusToRejectedWithReason(ApprovalStatus oldStatus) throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     candidate.updateApprovalStatus(createStatusRequest(oldStatus), mockOrganizationRetriever);
     var rejectionReason = randomString();
     var requestBody =
         new NviStatusRequest(
-            candidate.getIdentifier(), currentCustomerId, ApprovalStatus.REJECTED, rejectionReason);
+            candidate.getIdentifier(),
+            topLevelCristinOrgId,
+            ApprovalStatus.REJECTED,
+            rejectionReason);
     var request =
-        createRequest(candidate.getIdentifier(), currentCustomerId, requestBody, randomString());
+        createRequest(candidate.getIdentifier(), topLevelCristinOrgId, requestBody, randomString());
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
     var candidateResponse = response.getBodyObject(CandidateDto.class);
@@ -331,13 +334,13 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
       names = {STATUS_PENDING, STATUS_APPROVED})
   void shouldRemoveReasonWhenUpdatingStatusFromRejected(ApprovalStatus newStatus)
       throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     candidate.updateApprovalStatus(
         createStatusRequest(ApprovalStatus.REJECTED), mockOrganizationRetriever);
     var request =
         createRequest(
             candidate.getIdentifier(),
-            currentCustomerId,
+            topLevelCristinOrgId,
             ApprovalStatus.parse(newStatus.getValue()));
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
@@ -350,13 +353,13 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldUpdateAssigneeWhenFinalizingApprovalWithoutAssignee() throws IOException {
-    var candidate = setupValidCandidate(currentCustomerId);
+    var candidate = setupValidCandidate(topLevelCristinOrgId);
     var assignee = randomString();
     var requestBody =
         new NviStatusRequest(
-            candidate.getIdentifier(), currentCustomerId, ApprovalStatus.APPROVED, null);
+            candidate.getIdentifier(), topLevelCristinOrgId, ApprovalStatus.APPROVED, null);
     var request =
-        createRequest(candidate.getIdentifier(), currentCustomerId, requestBody, assignee);
+        createRequest(candidate.getIdentifier(), topLevelCristinOrgId, requestBody, assignee);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
     var candidateResponse = response.getBodyObject(CandidateDto.class);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -231,12 +231,10 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
       throws JsonProcessingException {
     var approvalToUpdate = candidate.toDto().approvals().getFirst();
     var requestBody = new UpsertAssigneeRequest(newAssignee, approvalToUpdate.institutionId());
-    var customerId = randomUri();
     return new HandlerRequestBuilder<UpsertAssigneeRequest>(JsonUtils.dtoObjectMapper)
         .withBody(randomAssigneeRequest())
-        .withCurrentCustomer(customerId)
         .withTopLevelCristinOrgId(requestBody.institutionId())
-        .withAccessRights(customerId, AccessRight.MANAGE_NVI_CANDIDATES)
+        .withAccessRights(requestBody.institutionId(), AccessRight.MANAGE_NVI_CANDIDATES)
         .withUserName(randomString())
         .withBody(requestBody)
         .withPathParameters(Map.of(CANDIDATE_IDENTIFIER, candidate.getIdentifier().toString()))
@@ -246,12 +244,10 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
   private InputStream createRequestWithNonExistingCandidate() throws JsonProcessingException {
     var approvalToUpdate = createCandidate().toDto().approvals().get(0);
     var requestBody = new UpsertAssigneeRequest(randomString(), approvalToUpdate.institutionId());
-    var customerId = randomUri();
     return new HandlerRequestBuilder<UpsertAssigneeRequest>(JsonUtils.dtoObjectMapper)
         .withBody(randomAssigneeRequest())
-        .withCurrentCustomer(customerId)
         .withTopLevelCristinOrgId(requestBody.institutionId())
-        .withAccessRights(customerId, AccessRight.MANAGE_NVI_CANDIDATES)
+        .withAccessRights(requestBody.institutionId(), AccessRight.MANAGE_NVI_CANDIDATES)
         .withUserName(randomString())
         .withBody(requestBody)
         .withPathParameters(Map.of(CANDIDATE_IDENTIFIER, randomUUID().toString()))


### PR DESCRIPTION
This removes the `currentCustomer` field from requests in tests, as it does not appear to be in use. Some references are merged with `topLevelCristinOrgId`, as that is the field we (sometimes) check.