### PR TITLE
perf: Replace sleep with force-refresh to improve test speed

### DIFF
--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -192,7 +192,7 @@ class OpenSearchClientTest {
 
   @ParameterizedTest(name = "shouldOrderResult {0}")
   @ValueSource(strings = {"asc", "desc"})
-  void shouldOrderResult(String sortOrder) throws  IOException {
+  void shouldOrderResult(String sortOrder) throws IOException {
     var createdFirst = documentWithCreatedDate(Instant.now());
     var createdSecond = documentWithCreatedDate(Instant.now().plus(1, ChronoUnit.MINUTES));
     addDocumentsToIndex(createdFirst, createdSecond);
@@ -215,8 +215,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldDeleteIndexAndThrowExceptionWhenSearchingInNonExistentIndex()
-      throws IOException {
+  void shouldDeleteIndexAndThrowExceptionWhenSearchingInNonExistentIndex() throws IOException {
     var document = singleNviCandidateIndexDocument().build();
     addDocumentsToIndex(document);
     openSearchClient.deleteIndex();
@@ -245,8 +244,7 @@ class OpenSearchClientTest {
 
   @ParameterizedTest(name = "shouldReturnAggregationsWithExpectedCount {0}")
   @MethodSource("aggregationNameAndExpectedCountProvider")
-  void shouldReturnAggregationsWithExpectedCount(Entry<String, Integer> entry)
-      throws IOException {
+  void shouldReturnAggregationsWithExpectedCount(Entry<String, Integer> entry) throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_NEW_JSON),
         documentFromString("document_new_collaboration.json"),
@@ -352,8 +350,7 @@ class OpenSearchClientTest {
 
   @ParameterizedTest(name = "shouldReturnSearchResultsUsingFilter {0}")
   @MethodSource("filterNameProvider")
-  void shouldReturnSearchResultsUsingFilter(Entry<String, Integer> entry)
-      throws IOException {
+  void shouldReturnSearchResultsUsingFilter(Entry<String, Integer> entry) throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_NEW_JSON),
         documentFromString("document_new_collaboration.json"),
@@ -378,8 +375,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldNotIncludeDisputesForOtherOrganizationsInDisputeFilter()
-      throws IOException {
+  void shouldNotIncludeDisputesForOtherOrganizationsInDisputeFilter() throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_ORGANIZATION_AGGREGATION_DISPUTE_JSON),
         documentFromString("document_dispute_not_sikt.json"));
@@ -430,8 +426,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnHitsOnSearchTermsPartOfPublicationTitle()
-      throws IOException {
+  void shouldReturnHitsOnSearchTermsPartOfPublicationTitle() throws IOException {
     var firstTitle = "Start of sentence. Lorem ipsum dolor sit amet, consectetur adipiscing elit";
     var secondTitle = "Another hit. First word lorem ipsum dolor sit amet, something else";
     var thirdTitleShouldNotGetHit = "Some other title";
@@ -485,8 +480,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnOneHitWhenSearchTermExactlyPublicationIdentifier()
-      throws IOException {
+  void shouldReturnOneHitWhenSearchTermExactlyPublicationIdentifier() throws IOException {
     var expectedHit = singleNviCandidateIndexDocument().build();
     var searchTerm = expectedHit.publicationDetails().identifier();
     var someTitleIncludingPartsOfSearchTerm = "Some title including " + searchTerm.split("-")[0];
@@ -548,8 +542,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnSingleDocumentWhenFilteringByAssignee()
-      throws IOException {
+  void shouldReturnSingleDocumentWhenFilteringByAssignee() throws IOException {
     var customer = randomUri();
     var assignee =
         randomString().concat(" ").concat(randomString()).concat(" ").concat(randomString());
@@ -600,8 +593,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnSingleDocumentWhenFilteringByCategory()
-      throws IOException {
+  void shouldReturnSingleDocumentWhenFilteringByCategory() throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_NEW_JSON),
         documentFromString("document_pending_category_degree_bachelor.json"));
@@ -641,8 +633,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnOrganizationAggregationWithSubAggregations()
-      throws IOException {
+  void shouldReturnOrganizationAggregationWithSubAggregations() throws IOException {
     addDocumentsToIndex(documentFromString("document_organization_aggregation_pending.json"));
     addDocumentsToIndex(documentFromString("document_organization_aggregation_new.json"));
     addDocumentsToIndex(documentFromString(DOCUMENT_ORGANIZATION_AGGREGATION_DISPUTE_JSON));

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -109,7 +109,6 @@ import org.opensearch.testcontainers.OpensearchContainer;
 @SuppressWarnings({"PMD.AvoidUsingHardCodedIP", "PMD.GodClass", "PMD.CouplingBetweenObjects"})
 class OpenSearchClientTest {
 
-  public static final int DELAY_ON_INDEX = 2000;
   public static final String YEAR = "2023";
   public static final String CATEGORY = "AcademicArticle";
   public static final String UNEXISTING_FILTER = "unexisting-filter";

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -192,7 +192,7 @@ class OpenSearchClientTest {
 
   @ParameterizedTest(name = "shouldOrderResult {0}")
   @ValueSource(strings = {"asc", "desc"})
-  void shouldOrderResult(String sortOrder) throws InterruptedException, IOException {
+  void shouldOrderResult(String sortOrder) throws  IOException {
     var createdFirst = documentWithCreatedDate(Instant.now());
     var createdSecond = documentWithCreatedDate(Instant.now().plus(1, ChronoUnit.MINUTES));
     addDocumentsToIndex(createdFirst, createdSecond);
@@ -216,7 +216,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldDeleteIndexAndThrowExceptionWhenSearchingInNonExistentIndex()
-      throws IOException, InterruptedException {
+      throws IOException {
     var document = singleNviCandidateIndexDocument().build();
     addDocumentsToIndex(document);
     openSearchClient.deleteIndex();
@@ -231,7 +231,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldRemoveDocumentFromIndex() throws InterruptedException, IOException {
+  void shouldRemoveDocumentFromIndex() throws IOException {
     var document = singleNviCandidateIndexDocument().build();
     addDocumentsToIndex(document);
     openSearchClient.removeDocumentFromIndex(document.identifier());
@@ -246,7 +246,7 @@ class OpenSearchClientTest {
   @ParameterizedTest(name = "shouldReturnAggregationsWithExpectedCount {0}")
   @MethodSource("aggregationNameAndExpectedCountProvider")
   void shouldReturnAggregationsWithExpectedCount(Entry<String, Integer> entry)
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_NEW_JSON),
         documentFromString("document_new_collaboration.json"),
@@ -275,7 +275,7 @@ class OpenSearchClientTest {
         Arrays.stream(SearchAggregation.values())
             .filter(aggregation -> !ORGANIZATION_APPROVAL_STATUS_AGGREGATION.equals(aggregation))
             .toList();
-    assertEquals(expectedAggregations.size(), aggregations.keySet().size());
+    assertEquals(expectedAggregations.size(), aggregations.size());
   }
 
   @Test
@@ -285,13 +285,13 @@ class OpenSearchClientTest {
         CandidateSearchParameters.builder().withAggregationType(requestedAggregation).build();
     var searchResponse = openSearchClient.search(searchParameters);
     var aggregations = searchResponse.aggregations();
-    assertEquals(1, aggregations.keySet().size());
+    assertEquals(1, aggregations.size());
     assertEquals(requestedAggregation, aggregations.keySet().iterator().next());
   }
 
   @Test
   void shouldReturnSearchResultsWithContributorAffiliatedWithSubUnitOfSearchedInstitution()
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_WITH_CONTRIBUTOR_FROM_NTNU_SUBUNIT_JSON),
         documentFromString("document_with_contributor_from_sikt.json"));
@@ -305,7 +305,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldReturnSearchResultsWithContributorOfSearchedInstitutionWhenSearchingSubUnit()
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(documentFromString(DOCUMENT_WITH_CONTRIBUTOR_FROM_NTNU_SUBUNIT_JSON));
 
     var searchParameters =
@@ -318,7 +318,7 @@ class OpenSearchClientTest {
   @Test
   void
       shouldReturnSearchResultsWithContributorOfSearchedInstitutionWhenSearchingTopLevelInstitution()
-          throws IOException, InterruptedException {
+          throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_WITH_CONTRIBUTOR_FROM_NTNU_SUBUNIT_JSON),
         documentFromString("document_with_contributor_from_ntnu_toplevel.json"),
@@ -334,7 +334,7 @@ class OpenSearchClientTest {
   @Test
   void
       shouldReturnSearchResultsWithContributorOfSearchedInstitutionWhenSearchingTopLevelInstitutionExcludingSubUnit()
-          throws IOException, InterruptedException {
+          throws IOException {
     var subUnitDoc = documentFromString(DOCUMENT_WITH_CONTRIBUTOR_FROM_NTNU_SUBUNIT_JSON);
     var topLevelDoc = documentFromString("document_with_contributor_from_ntnu_toplevel.json");
 
@@ -353,7 +353,7 @@ class OpenSearchClientTest {
   @ParameterizedTest(name = "shouldReturnSearchResultsUsingFilter {0}")
   @MethodSource("filterNameProvider")
   void shouldReturnSearchResultsUsingFilter(Entry<String, Integer> entry)
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_NEW_JSON),
         documentFromString("document_new_collaboration.json"),
@@ -379,7 +379,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldNotIncludeDisputesForOtherOrganizationsInDisputeFilter()
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_ORGANIZATION_AGGREGATION_DISPUTE_JSON),
         documentFromString("document_dispute_not_sikt.json"));
@@ -397,7 +397,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnHitOnSearchTermPublicationIdentifier() throws IOException, InterruptedException {
+  void shouldReturnHitOnSearchTermPublicationIdentifier() throws IOException {
     var indexDocuments = generateNumberOfCandidates(5);
     addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
     var searchTerm = indexDocuments.get(2).publicationDetails().identifier();
@@ -408,7 +408,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnHitOnSearchTermCandidateIdentifier() throws IOException, InterruptedException {
+  void shouldReturnHitOnSearchTermCandidateIdentifier() throws IOException {
     var indexDocuments = generateNumberOfCandidates(5);
     addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
     var searchTerm = indexDocuments.get(2).identifier().toString();
@@ -419,7 +419,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnHitOnSearchTermPublicationTitle() throws IOException, InterruptedException {
+  void shouldReturnHitOnSearchTermPublicationTitle() throws IOException {
     var indexDocuments = generateNumberOfCandidates(5);
     addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
     var searchTerm = indexDocuments.get(2).publicationDetails().title();
@@ -431,7 +431,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldReturnHitsOnSearchTermsPartOfPublicationTitle()
-      throws IOException, InterruptedException {
+      throws IOException {
     var firstTitle = "Start of sentence. Lorem ipsum dolor sit amet, consectetur adipiscing elit";
     var secondTitle = "Another hit. First word lorem ipsum dolor sit amet, something else";
     var thirdTitleShouldNotGetHit = "Some other title";
@@ -453,7 +453,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnHitOnSearchTermContributorName() throws IOException, InterruptedException {
+  void shouldReturnHitOnSearchTermContributorName() throws IOException {
     var indexDocuments = generateNumberOfCandidates(5);
     addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
     var expectedHit = indexDocuments.get(2);
@@ -465,7 +465,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnHitOnSearchTermPublicationAbstract() throws IOException, InterruptedException {
+  void shouldReturnHitOnSearchTermPublicationAbstract() throws IOException {
     var indexDocuments = generateNumberOfCandidates(5);
     addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
     var searchTerm = indexDocuments.get(2).publicationDetails().abstractText();
@@ -476,7 +476,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnAllWhenSearchTermNotProvided() throws InterruptedException, IOException {
+  void shouldReturnAllWhenSearchTermNotProvided() throws IOException {
     var indexDocuments = generateNumberOfCandidates(5);
     addDocumentsToIndex(indexDocuments.toArray(new NviCandidateIndexDocument[0]));
     var searchParameters = defaultSearchParameters().build();
@@ -486,7 +486,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldReturnOneHitWhenSearchTermExactlyPublicationIdentifier()
-      throws IOException, InterruptedException {
+      throws IOException {
     var expectedHit = singleNviCandidateIndexDocument().build();
     var searchTerm = expectedHit.publicationDetails().identifier();
     var someTitleIncludingPartsOfSearchTerm = "Some title including " + searchTerm.split("-")[0];
@@ -500,7 +500,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnSingleDocumentWhenFilteringByYear() throws InterruptedException, IOException {
+  void shouldReturnSingleDocumentWhenFilteringByYear() throws IOException {
     var customer = randomUri();
     var year = randomString();
     var document =
@@ -523,7 +523,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldReturnSingleDocumentWhenFilteringByTitle() throws InterruptedException, IOException {
+  void shouldReturnSingleDocumentWhenFilteringByTitle() throws IOException {
     var customer = randomUri();
     var title =
         randomString().concat(" ").concat(randomString()).concat(" ").concat(randomString());
@@ -549,7 +549,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldReturnSingleDocumentWhenFilteringByAssignee()
-      throws InterruptedException, IOException {
+      throws IOException {
     var customer = randomUri();
     var assignee =
         randomString().concat(" ").concat(randomString()).concat(" ").concat(randomString());
@@ -576,7 +576,7 @@ class OpenSearchClientTest {
   @ParameterizedTest(name = "shouldReturnSearchResultsUsingFilterAndSearchTermCombined {0}")
   @MethodSource("filterNameProvider")
   void shouldReturnSearchResultsUsingFilterAndSearchTermCombined(Entry<String, Integer> entry)
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_NEW_JSON),
         documentFromString("document_new_collaboration.json"),
@@ -601,7 +601,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldReturnSingleDocumentWhenFilteringByCategory()
-      throws InterruptedException, IOException {
+      throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_NEW_JSON),
         documentFromString("document_pending_category_degree_bachelor.json"));
@@ -629,7 +629,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldReturnAllSearchResultsWhenSearchingWithoutCustomerAndAffiliations()
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(
         documentFromString(DOCUMENT_WITH_CONTRIBUTOR_FROM_NTNU_SUBUNIT_JSON),
         documentFromString("document_with_contributor_from_sikt.json"));
@@ -642,7 +642,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldReturnOrganizationAggregationWithSubAggregations()
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(documentFromString("document_organization_aggregation_pending.json"));
     addDocumentsToIndex(documentFromString("document_organization_aggregation_new.json"));
     addDocumentsToIndex(documentFromString(DOCUMENT_ORGANIZATION_AGGREGATION_DISPUTE_JSON));
@@ -664,7 +664,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldNotIncludeRejectedPointsInOrganizationAggregationWithSubAggregations()
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(documentFromString("document_organization_aggregation_pending.json"));
     addDocumentsToIndex(documentFromString("document_organization_aggregation_new.json"));
     addDocumentsToIndex(documentFromString("document_organization_aggregation_rejected.json"));
@@ -686,7 +686,7 @@ class OpenSearchClientTest {
 
   @Test
   void shouldReturnOrganizationAggregationWithSubAggregationsForUpToOneThousandInvolvedOrgs()
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(nviCandidateWithOneThousandInvolvedOrgs());
     var aggregation = ORGANIZATION_APPROVAL_STATUS_AGGREGATION.getAggregationName();
     var searchParameters = defaultSearchParameters().withAggregationType(aggregation).build();
@@ -706,7 +706,7 @@ class OpenSearchClientTest {
 
   @Test
   void organizationAggregationShouldNotContainAggregationsForOtherTopLevelOrgs()
-      throws IOException, InterruptedException {
+      throws IOException {
     addDocumentsToIndex(documentFromString("document_organization_aggregation_collaboration.json"));
     var aggregation = ORGANIZATION_APPROVAL_STATUS_AGGREGATION.getAggregationName();
     var searchParameters =
@@ -731,7 +731,7 @@ class OpenSearchClientTest {
   }
 
   @Test
-  void shouldExcludeFields() throws IOException, InterruptedException {
+  void shouldExcludeFields() throws IOException {
     var document = documentWithContributors();
     addDocumentsToIndex(document);
     var searchParameters =
@@ -870,13 +870,9 @@ class OpenSearchClientTest {
   }
 
   private static void addDocumentToIndex() {
-    try {
-      addDocumentsToIndex(
-          singleNviCandidateIndexDocumentWithCustomer(
-              ORGANIZATION, randomString(), randomString(), YEAR, randomString()));
-    } catch (InterruptedException exception) {
-      throw new RuntimeException(exception);
-    }
+    addDocumentsToIndex(
+        singleNviCandidateIndexDocumentWithCustomer(
+            ORGANIZATION, randomString(), randomString(), YEAR, randomString()));
   }
 
   @NotNull
@@ -1017,8 +1013,7 @@ class OpenSearchClientTest {
         .withContributors(List.of(randomNviContributor(randomUri())));
   }
 
-  private static void addDocumentsToIndex(NviCandidateIndexDocument... documents)
-      throws InterruptedException {
+  private static void addDocumentsToIndex(NviCandidateIndexDocument... documents) {
     Arrays.stream(documents).forEach(openSearchClient::addDocumentToIndex);
     refreshIndex();
   }


### PR DESCRIPTION
Replace Thread.sleep in OpenSearch container tests with a forced refresh operation on indices to improve test speed.
Local testing indicates that this improves the execution time of this test suite from 2 minutes 37 seconds to 7 seconds.