### PR TITLE
fix: Remove unused identifier from NviStatusRequest

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -345,6 +345,7 @@ public final class Candidate {
         .withIdentifier(identifier)
         .withPublicationId(getPublicationId())
         .withApprovals(mapToApprovalDtos())
+        .withAllowedOperations(Collections.emptySet())
         .withNotes(mapToNoteDtos())
         .withPeriod(mapToPeriodStatusDto())
         .withTotalPoints(totalPoints)

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -103,7 +103,7 @@ class CandidateTest extends CandidateTestSetup {
     var upsertCandidateRequest =
         randomUpsertRequestBuilder().withUnverifiedCreators(List.of(unverifiedCreator)).build();
     var expectedUnverifiedCreatorCount = upsertCandidateRequest.unverifiedCreators().size();
-    var expectedVerifiedCreatorCount = upsertCandidateRequest.creators().keySet().size();
+    var expectedVerifiedCreatorCount = upsertCandidateRequest.creators().size();
 
     var fetchedCandidate = upsert(upsertCandidateRequest);
 
@@ -248,6 +248,7 @@ class CandidateTest extends CandidateTestSetup {
     var expectedDto =
         CandidateDto.builder()
             .withApprovals(mapToApprovalDtos(candidate))
+            .withAllowedOperations(Collections.emptySet())
             .withId(candidate.getId())
             .withPublicationId(candidate.getPublicationId())
             .withIdentifier(candidate.getIdentifier())

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/upsert/NviStatusRequest.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/upsert/NviStatusRequest.java
@@ -4,15 +4,13 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 import java.net.URI;
-import java.util.UUID;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 
-public record NviStatusRequest(
-    UUID candidateId, URI institutionId, ApprovalStatus status, String reason) {
+public record NviStatusRequest(URI institutionId, ApprovalStatus status, String reason) {
 
   public void validate() {
-    if (isNull(candidateId) || isNull(institutionId) || isNull(status)) {
+    if (isNull(institutionId) || isNull(status)) {
       throw new IllegalArgumentException("Missing required fields");
     }
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.rest.upsert;
 
-import static java.util.UUID.randomUUID;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
@@ -92,7 +91,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
   }
 
   private NviStatusRequest randomStatusRequest() {
-    return new NviStatusRequest(randomUUID(), randomUri(), ApprovalStatus.APPROVED, null);
+    return new NviStatusRequest(randomUri(), ApprovalStatus.APPROVED, null);
   }
 
   @Test
@@ -117,10 +116,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
       throws JsonProcessingException {
     var requestBody =
         new NviStatusRequest(
-            candidateIdentifier,
-            institutionId,
-            status,
-            ApprovalStatus.REJECTED.equals(status) ? randomString() : null);
+            institutionId, status, ApprovalStatus.REJECTED.equals(status) ? randomString() : null);
     return createRequest(candidateIdentifier, institutionId, requestBody);
   }
 
@@ -140,9 +136,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
   void shouldBeForbiddenToChangeStatusOfOtherInstitution() throws IOException {
     var otherInstitutionId = randomUri();
     var candidate = upsert(createUpsertCandidateRequest(topLevelOrganizationId).build());
-    var requestBody =
-        new NviStatusRequest(
-            candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.PENDING, null);
+    var requestBody = new NviStatusRequest(topLevelOrganizationId, ApprovalStatus.PENDING, null);
     var request = createRequest(candidate.getIdentifier(), otherInstitutionId, requestBody);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -230,8 +224,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
 
   private InputStream createRequestWithoutReason(UUID candidateIdentifier, URI institutionId)
       throws JsonProcessingException {
-    var requestBody =
-        new NviStatusRequest(candidateIdentifier, institutionId, ApprovalStatus.REJECTED, null);
+    var requestBody = new NviStatusRequest(institutionId, ApprovalStatus.REJECTED, null);
     return createRequest(candidateIdentifier, institutionId, requestBody);
   }
 
@@ -287,11 +280,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
     candidate.updateApprovalStatus(createStatusRequest(oldStatus), mockOrganizationRetriever);
     var rejectionReason = randomString();
     var requestBody =
-        new NviStatusRequest(
-            candidate.getIdentifier(),
-            topLevelOrganizationId,
-            ApprovalStatus.REJECTED,
-            rejectionReason);
+        new NviStatusRequest(topLevelOrganizationId, ApprovalStatus.REJECTED, rejectionReason);
     var request =
         createRequest(
             candidate.getIdentifier(), topLevelOrganizationId, requestBody, randomString());
@@ -343,9 +332,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
   void shouldUpdateAssigneeWhenFinalizingApprovalWithoutAssignee() throws IOException {
     var candidate = setupValidCandidate(topLevelOrganizationId);
     var assignee = randomString();
-    var requestBody =
-        new NviStatusRequest(
-            candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.APPROVED, null);
+    var requestBody = new NviStatusRequest(topLevelOrganizationId, ApprovalStatus.APPROVED, null);
     var request =
         createRequest(candidate.getIdentifier(), topLevelOrganizationId, requestBody, assignee);
     handler.handleRequest(request, output, CONTEXT);


### PR DESCRIPTION
Removes the `candidateId` from the request, as this is taken from path parameters and the update request applied directly to the `Candidate`. A previous PR added validation on this field, which causes errors as the field is not actually in use.

Also adds an empty `allowedOperations` field to the now-deprecated builder, to ensure the field is always present (as the OpenAPI spec promises).