### PR TITLE
[np-48561] refactor: Extend base class in all REST handler tests

### DIFF
--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
@@ -54,6 +54,7 @@ import org.apache.hc.core5.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
+// TODO: Move allowedOperation tests here
 /** Base test class for handlers that return a CandidateDto. */
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTest {

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
@@ -54,7 +54,6 @@ import org.apache.hc.core5.http.ContentType;
 import org.junit.jupiter.api.BeforeEach;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
-// TODO: Move allowedOperation tests here
 /** Base test class for handlers that return a CandidateDto. */
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTest {

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -1,9 +1,8 @@
 package no.sikt.nva.nvi.rest.create;
 
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertNonCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
-import static no.sikt.nva.nvi.test.UpsertRequestBuilder.randomUpsertRequestBuilder;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -12,65 +11,47 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.Mockito.mock;
 
-import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URI;
-import java.time.Year;
 import java.util.Map;
 import java.util.UUID;
-import no.sikt.nva.nvi.common.db.CandidateRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.service.dto.ApprovalDto;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.model.Candidate;
-import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
-import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
+import no.sikt.nva.nvi.rest.BaseCandidateRestHandlerTest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
-import no.sikt.nva.nvi.test.LocalDynamoTest;
-import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.GatewayResponse;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
-class CreateNoteHandlerTest extends LocalDynamoTest {
+// TODO: Migrate to abstract test class
+class CreateNoteHandlerTest extends BaseCandidateRestHandlerTest {
 
-  public static final int YEAR = Year.now().getValue();
-  private Context context;
-  private ByteArrayOutputStream output;
-  private CreateNoteHandler handler;
-  private CandidateRepository candidateRepository;
-  private PeriodRepository periodRepository;
-  private ViewingScopeValidator viewingScopeValidatorReturningFalse;
+  @Override
+  protected ApiGatewayHandler<NviNoteRequest, CandidateDto> createHandler() {
+    return new CreateNoteHandler(candidateRepository, periodRepository, mockViewingScopeValidator);
+  }
 
   @BeforeEach
   void setUp() {
-    output = new ByteArrayOutputStream();
-    context = mock(Context.class);
-    localDynamo = initializeTestDatabase();
-    candidateRepository = new CandidateRepository(localDynamo);
-    periodRepository = TestUtils.periodRepositoryReturningOpenedPeriod(YEAR);
-    viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(true);
-    handler =
-        new CreateNoteHandler(
-            candidateRepository, periodRepository, viewingScopeValidatorReturningFalse);
+    resourcePathParameter = "candidateIdentifier";
   }
 
   @Test
   void shouldReturnUnauthorizedWhenMissingAccessRights() throws IOException {
     handler.handleRequest(
-        requestWithoutAccessRights(UUID.randomUUID(), randomNote()), output, context);
+        requestWithoutAccessRights(UUID.randomUUID(), randomNote()), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -78,14 +59,14 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
 
   @Test
   void shouldReturnUnauthorizedWhenCandidateIsNotInUsersViewingScope() throws IOException {
-    var candidate = upsert(randomUpsertRequestBuilder().build());
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var request =
         createRequest(candidate.getIdentifier(), new NviNoteRequest("The note"), randomString());
-    viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(false);
+    var viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(false);
     handler =
         new CreateNoteHandler(
             candidateRepository, periodRepository, viewingScopeValidatorReturningFalse);
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
   }
@@ -97,7 +78,7 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
             Map.of("someInvalidInputField", randomString()));
     var request = createRequest(UUID.randomUUID(), invalidRequestBody, randomString());
 
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_BAD_REQUEST)));
@@ -105,12 +86,12 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
 
   @Test
   void shouldAddNoteToCandidateWhenNoteIsValid() throws IOException {
-    var candidate = upsert(randomUpsertRequestBuilder().build());
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var theNote = "The note";
     var userName = randomString();
 
     var request = createRequest(candidate.getIdentifier(), new NviNoteRequest(theNote), userName);
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var gatewayResponse = GatewayResponse.fromOutputStream(output, CandidateDto.class);
     var actualNote = gatewayResponse.getBodyObject(CandidateDto.class).notes().getFirst();
 
@@ -120,16 +101,16 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
 
   @Test
   void shouldReturnConflictWhenCreatingNoteAndReportingPeriodIsClosed() throws IOException {
-    var candidate = upsert(randomUpsertRequestBuilder().build());
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var request =
         createRequest(
             candidate.getIdentifier(), new NviNoteRequest(randomString()), randomString());
     var handler =
         new CreateNoteHandler(
             candidateRepository,
-            periodRepositoryReturningClosedPeriod(YEAR),
-            viewingScopeValidatorReturningFalse);
-    handler.handleRequest(request, output, context);
+            periodRepositoryReturningClosedPeriod(CURRENT_YEAR),
+            mockViewingScopeValidator);
+    handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(Matchers.equalTo(HttpURLConnection.HTTP_CONFLICT)));
@@ -137,7 +118,7 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
 
   @Test
   void shouldReturn405NotAllowedWhenAddingNoteToNonCandidate() throws IOException {
-    var candidateBO = upsert(randomUpsertRequestBuilder().build());
+    var candidateBO = setupValidCandidate(topLevelOrganizationId);
     var nonCandidate =
         Candidate.updateNonCandidate(
                 createUpsertNonCandidateRequest(candidateBO.getPublicationId()),
@@ -145,7 +126,7 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
             .orElseThrow();
     var request =
         createRequest(nonCandidate.getIdentifier(), randomNote().toJsonString(), randomString());
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(Matchers.equalTo(HttpURLConnection.HTTP_BAD_METHOD)));
@@ -153,34 +134,34 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
 
   @Test
   void shouldSetUserAsAssigneeWhenUsersInstitutionApprovalIsUnassigned() throws IOException {
-    var institutionId = randomUri();
-    var candidate = upsert(createUpsertCandidateRequest(institutionId).build());
-    assertNull(candidate.getApprovals().get(institutionId).getAssigneeUsername());
+    var candidate = setupValidCandidate(topLevelOrganizationId);
+    assertNull(candidate.getApprovals().get(topLevelOrganizationId).getAssigneeUsername());
     var userName = randomString();
-    var request = createRequest(candidate.getIdentifier(), randomNote(), userName, institutionId);
-    handler.handleRequest(request, output, context);
+    var request =
+        createRequest(candidate.getIdentifier(), randomNote(), userName, topLevelOrganizationId);
+    handler.handleRequest(request, output, CONTEXT);
     var response =
         GatewayResponse.fromOutputStream(output, CandidateDto.class)
             .getBodyObject(CandidateDto.class);
-    var actualAssignee = getActualAssignee(response, institutionId);
+    var actualAssignee = getActualAssignee(response, topLevelOrganizationId);
     assertEquals(userName, actualAssignee);
   }
 
   @Test
   void shouldNotSetUserAsAssigneeWhenUsersInstitutionApprovalHasAssignee() throws IOException {
-    var institutionId = randomUri();
-    var candidate = upsert(createUpsertCandidateRequest(institutionId).build());
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var existingApprovalAssignee = randomString();
     candidate.updateApprovalAssignee(
-        new UpdateAssigneeRequest(institutionId, existingApprovalAssignee));
-    assertNotNull(candidate.getApprovals().get(institutionId).getAssigneeUsername());
+        new UpdateAssigneeRequest(topLevelOrganizationId, existingApprovalAssignee));
+    assertNotNull(candidate.getApprovals().get(topLevelOrganizationId).getAssigneeUsername());
     var request =
-        createRequest(candidate.getIdentifier(), randomNote(), randomString(), institutionId);
-    handler.handleRequest(request, output, context);
+        createRequest(
+            candidate.getIdentifier(), randomNote(), randomString(), topLevelOrganizationId);
+    handler.handleRequest(request, output, CONTEXT);
     var response =
         GatewayResponse.fromOutputStream(output, CandidateDto.class)
             .getBodyObject(CandidateDto.class);
-    var actualAssignee = getActualAssignee(response, institutionId);
+    var actualAssignee = getActualAssignee(response, topLevelOrganizationId);
     assertEquals(existingApprovalAssignee, actualAssignee);
   }
 
@@ -207,7 +188,7 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
     return new HandlerRequestBuilder<NviNoteRequest>(JsonUtils.dtoObjectMapper)
         .withBody(body)
         .withTopLevelCristinOrgId(topLevelOrganizationId)
-        .withPathParameters(Map.of("candidateIdentifier", identifier.toString()))
+        .withPathParameters(Map.of(resourcePathParameter, identifier.toString()))
         .withAccessRights(topLevelOrganizationId, AccessRight.MANAGE_NVI_CANDIDATES)
         .withUserName(userName)
         .build();
@@ -219,16 +200,10 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
     return new HandlerRequestBuilder<String>(JsonUtils.dtoObjectMapper)
         .withBody(body)
         .withTopLevelCristinOrgId(topLevelOrganizationId)
-        .withPathParameters(Map.of("candidateIdentifier", identifier.toString()))
+        .withPathParameters(Map.of(resourcePathParameter, identifier.toString()))
         .withAccessRights(topLevelOrganizationId, AccessRight.MANAGE_NVI_CANDIDATES)
         .withUserName(userName)
         .build();
-  }
-
-  private Candidate upsert(UpsertCandidateRequest request) {
-    Candidate.upsert(request, candidateRepository, periodRepository);
-    return Candidate.fetchByPublicationId(
-        request::publicationId, candidateRepository, periodRepository);
   }
 
   private NviNoteRequest randomNote() {
@@ -238,7 +213,7 @@ class CreateNoteHandlerTest extends LocalDynamoTest {
   private InputStream requestWithoutAccessRights(UUID candidateIdentifier, NviNoteRequest request)
       throws JsonProcessingException {
     return new HandlerRequestBuilder<NviNoteRequest>(JsonUtils.dtoObjectMapper)
-        .withPathParameters(Map.of("candidateIdentifier", candidateIdentifier.toString()))
+        .withPathParameters(Map.of(resourcePathParameter, candidateIdentifier.toString()))
         .withBody(request)
         .build();
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
-// TODO: Migrate to abstract test class
 class CreateNoteHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Override

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.nvi.rest.create;
 
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertNonCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -22,7 +21,6 @@ import java.util.UUID;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.service.dto.ApprovalDto;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
-import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.rest.BaseCandidateRestHandlerTest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
 import no.unit.nva.commons.json.JsonUtils;
@@ -117,12 +115,7 @@ class CreateNoteHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturn405NotAllowedWhenAddingNoteToNonCandidate() throws IOException {
-    var candidateBO = setupValidCandidate(topLevelOrganizationId);
-    var nonCandidate =
-        Candidate.updateNonCandidate(
-                createUpsertNonCandidateRequest(candidateBO.getPublicationId()),
-                candidateRepository)
-            .orElseThrow();
+    var nonCandidate = setupNonApplicableCandidate(topLevelOrganizationId);
     var request =
         createRequest(nonCandidate.getIdentifier(), randomNote().toJsonString(), randomString());
     handler.handleRequest(request, output, CONTEXT);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -39,6 +39,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
+// TODO: Migrate to abstract test class
 class RemoveNoteHandlerTest extends LocalDynamoTest {
 
   public static final int YEAR = Calendar.getInstance().getWeeksInWeekYear();

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -2,8 +2,8 @@ package no.sikt.nva.nvi.rest.remove;
 
 import static no.sikt.nva.nvi.rest.fetch.FetchNviCandidateHandler.CANDIDATE_IDENTIFIER;
 import static no.sikt.nva.nvi.rest.remove.RemoveNoteHandler.PARAM_NOTE_IDENTIFIER;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
-import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomUsername;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -12,43 +12,28 @@ import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
 
-import com.amazonaws.services.lambda.runtime.Context;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.util.Calendar;
 import java.util.Map;
 import java.util.UUID;
-import no.sikt.nva.nvi.common.db.CandidateRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.model.Username;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.rest.BaseCandidateRestHandlerTest;
 import no.sikt.nva.nvi.rest.create.NviNoteRequest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
-import no.sikt.nva.nvi.test.LocalDynamoTest;
-import no.sikt.nva.nvi.test.TestUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.GatewayResponse;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
-// TODO: Migrate to abstract test class
-class RemoveNoteHandlerTest extends LocalDynamoTest {
-
-  public static final int YEAR = Calendar.getInstance().getWeeksInWeekYear();
-  private Context context;
-  private ByteArrayOutputStream output;
-  private RemoveNoteHandler handler;
-  private PeriodRepository periodRepository;
-  private CandidateRepository candidateRepository;
-
+class RemoveNoteHandlerTest extends BaseCandidateRestHandlerTest {
   private static HandlerRequestBuilder<NviNoteRequest> createRequestWithoutAccessRights(
       String candidateId, String noteId, String userName) {
     return new HandlerRequestBuilder<NviNoteRequest>(dtoObjectMapper)
@@ -57,16 +42,14 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
         .withUserName(userName);
   }
 
+  @Override
+  protected ApiGatewayHandler<Void, CandidateDto> createHandler() {
+    return new RemoveNoteHandler(candidateRepository, periodRepository, mockViewingScopeValidator);
+  }
+
   @BeforeEach
   void setUp() {
-    output = new ByteArrayOutputStream();
-    context = mock(Context.class);
-    localDynamo = initializeTestDatabase();
-    candidateRepository = new CandidateRepository(localDynamo);
-    periodRepository = periodRepositoryReturningOpenedPeriod(YEAR);
-    handler =
-        new RemoveNoteHandler(
-            candidateRepository, periodRepository, new FakeViewingScopeValidator(true));
+    resourcePathParameter = "candidateIdentifier";
   }
 
   @Test
@@ -74,7 +57,7 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
     handler.handleRequest(
         createRequestWithoutAccessRights(randomString(), randomString(), randomString()).build(),
         output,
-        context);
+        CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -82,40 +65,40 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
 
   @Test
   void shouldReturnUnauthorizedWhenCandidateIsNotInUsersViewingScope() throws IOException {
-    var candidate = createCandidate();
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var user = randomUsername();
     var candidateWithNote = createNote(candidate, user);
-    var noteId = candidateWithNote.toDto().notes().get(0).identifier();
+    var noteId = candidateWithNote.toDto().notes().getFirst().identifier();
     var request = createRequest(candidate.getIdentifier(), noteId, user.value()).build();
     var viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(false);
     handler =
         new RemoveNoteHandler(
             candidateRepository, periodRepository, viewingScopeValidatorReturningFalse);
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
   }
 
   @Test
   void shouldReturnUnauthorizedWhenNotTheUserThatCreatedTheNote() throws IOException {
-    var candidate = createCandidate();
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var user = randomUsername();
     var candidateWithNote = createNote(candidate, user);
-    var noteId = candidateWithNote.toDto().notes().get(0).identifier();
+    var noteId = candidateWithNote.toDto().notes().getFirst().identifier();
     var request = createRequest(candidate.getIdentifier(), noteId, randomString()).build();
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
   }
 
   @Test
   void shouldBeAbleToRemoveNoteWhenTheUserThatCreatedIt() throws IOException {
-    var candidate = createCandidate();
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var user = randomUsername();
     var candidateWithNote = createNote(candidate, user);
-    var noteId = candidateWithNote.toDto().notes().get(0).identifier();
+    var noteId = candidateWithNote.toDto().notes().getFirst().identifier();
     var request = createRequest(candidate.getIdentifier(), noteId, user.value()).build();
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var gatewayResponse = GatewayResponse.fromOutputStream(output, CandidateDto.class);
     var body = gatewayResponse.getBodyObject(CandidateDto.class);
     assertThat(body.notes(), hasSize(0));
@@ -124,25 +107,25 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
   @Test
   void shouldReturnNotFoundWhenNoteDoesntExist() throws IOException {
     var request = createRequest(UUID.randomUUID(), UUID.randomUUID(), randomString()).build();
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_NOT_FOUND)));
   }
 
   @Test
   void shouldReturnConflictWhenRemovingNoteAndReportingPeriodIsClosed() throws IOException {
-    var candidate = createCandidate();
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var user = randomString();
     candidate.createNote(
         new CreateNoteRequest(randomString(), user, randomUri()), candidateRepository);
-    var noteId = candidate.toDto().notes().get(0).identifier();
+    var noteId = candidate.toDto().notes().getFirst().identifier();
     var request = createRequest(candidate.getIdentifier(), noteId, user).build();
     handler =
         new RemoveNoteHandler(
             candidateRepository,
-            periodRepositoryReturningClosedPeriod(YEAR),
+            periodRepositoryReturningClosedPeriod(CURRENT_YEAR),
             new FakeViewingScopeValidator(true));
-    handler.handleRequest(request, output, context);
+    handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(Matchers.equalTo(HttpURLConnection.HTTP_CONFLICT)));
@@ -151,10 +134,6 @@ class RemoveNoteHandlerTest extends LocalDynamoTest {
   private Candidate createNote(Candidate candidate, Username user) {
     return candidate.createNote(
         new CreateNoteRequest(randomString(), user.value(), randomUri()), candidateRepository);
-  }
-
-  private Candidate createCandidate() {
-    return TestUtils.randomApplicableCandidate(candidateRepository, periodRepository);
   }
 
   private HandlerRequestBuilder<NviNoteRequest> createRequest(

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -168,20 +168,6 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CONFLICT)));
   }
 
-  @ParameterizedTest(name = "Should not allow status {0} if organization has unverified creators")
-  @EnumSource(
-      value = ApprovalStatus.class,
-      names = {STATUS_APPROVED, STATUS_REJECTED})
-  void shouldReturnConflictWhenUpdatingStatusAndInstitutionHasUnverifiedCreators(
-      ApprovalStatus newStatus) throws IOException {
-    var candidate = setupCandidateWithUnverifiedCreator();
-    var request = createRequest(candidate.getIdentifier(), topLevelOrganizationId, newStatus);
-    handler.handleRequest(request, output, CONTEXT);
-    var response = GatewayResponse.fromOutputStream(output, Problem.class);
-
-    assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CONFLICT)));
-  }
-
   @ParameterizedTest(
       name = "Should not allow status {0} if sub-organization has unverified creators")
   @EnumSource(

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.rest.upsert;
 
 import static java.util.UUID.randomUUID;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningNotOpenedPeriod;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -97,7 +96,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnUnauthorizedWhenCandidateIsNotInUsersViewingScope() throws IOException {
-    var candidate = upsert(createUpsertCandidateRequest(topLevelOrganizationId).build());
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var request =
         createRequest(candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.APPROVED);
     handler =
@@ -139,7 +138,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
   @Test
   void shouldBeForbiddenToChangeStatusOfOtherInstitution() throws IOException {
     var otherInstitutionId = randomUri();
-    var candidate = upsert(createUpsertCandidateRequest(topLevelOrganizationId).build());
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var requestBody =
         new NviStatusRequest(
             candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.PENDING, null);
@@ -160,7 +159,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
             periodRepository,
             mockViewingScopeValidator,
             mockOrganizationRetriever);
-    var candidate = upsert(createUpsertCandidateRequest(topLevelOrganizationId).build());
+    var candidate = setupValidCandidate(topLevelOrganizationId);
     var request =
         createRequest(candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.APPROVED);
     handler.handleRequest(request, output, CONTEXT);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -51,6 +51,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
+// TODO: Migrate to abstract test class
 class UpsertAssigneeHandlerTest extends LocalDynamoTest {
 
   private static final int YEAR = Calendar.getInstance().getWeekYear();

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -1,12 +1,11 @@
 package no.sikt.nva.nvi.rest.upsert;
 
 import static java.util.UUID.randomUUID;
-import static no.sikt.nva.nvi.rest.upsert.UpsertAssigneeHandler.CANDIDATE_IDENTIFIER;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningNotOpenedPeriod;
-import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -17,33 +16,28 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.amazonaws.services.lambda.runtime.Context;
 import com.fasterxml.jackson.core.JsonProcessingException;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.nio.file.Path;
-import java.util.Calendar;
 import java.util.Map;
 import java.util.Optional;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
-import no.sikt.nva.nvi.common.db.CandidateRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.rest.BaseCandidateRestHandlerTest;
 import no.sikt.nva.nvi.rest.model.UpsertAssigneeRequest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
-import no.sikt.nva.nvi.test.LocalDynamoTest;
 import no.sikt.nva.nvi.test.TestUtils;
-import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
+import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.GatewayResponse;
 import nva.commons.core.ioutils.IoUtils;
 import org.hamcrest.CoreMatchers;
@@ -51,38 +45,27 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
-// TODO: Migrate to abstract test class
-class UpsertAssigneeHandlerTest extends LocalDynamoTest {
+class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
 
-  private static final int YEAR = Calendar.getInstance().getWeekYear();
   private static final String USER_RESPONSE_BODY_WITHOUT_ACCESS_RIGHT_JSON =
       "userResponseBodyWithoutAccessRight" + ".json";
   private static final String USER_RESPONSE_BODY_WITH_ACCESS_RIGHT_JSON =
       "userResponseBodyWithAccessRight.json";
-  private Context context;
-  private ByteArrayOutputStream output;
-  private UpsertAssigneeHandler handler;
-  private CandidateRepository candidateRepository;
-  private PeriodRepository periodRepository;
-  private AuthorizedBackendUriRetriever uriRetriever;
-  private FakeViewingScopeValidator viewingScopeValidator;
+
+  @Override
+  protected ApiGatewayHandler<UpsertAssigneeRequest, CandidateDto> createHandler() {
+    return new UpsertAssigneeHandler(
+        candidateRepository, periodRepository, mockUriRetriever, mockViewingScopeValidator);
+  }
 
   @BeforeEach
-  void init() {
-    output = new ByteArrayOutputStream();
-    context = mock(Context.class);
-    candidateRepository = new CandidateRepository(initializeTestDatabase());
-    periodRepository = periodRepositoryReturningOpenedPeriod(YEAR);
-    uriRetriever = mock(AuthorizedBackendUriRetriever.class);
-    viewingScopeValidator = new FakeViewingScopeValidator(true);
-    handler =
-        new UpsertAssigneeHandler(
-            candidateRepository, periodRepository, uriRetriever, viewingScopeValidator);
+  void setUp() {
+    resourcePathParameter = "candidateIdentifier";
   }
 
   @Test
   void shouldReturnUnauthorizedWhenMissingAccessRights() throws IOException {
-    handler.handleRequest(createRequestWithoutAccessRights(), output, context);
+    handler.handleRequest(createRequestWithoutAccessRights(), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -90,7 +73,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
 
   @Test
   void shouldReturnUnauthorizedWhenAssigneeIsNotFromTheSameInstitution() throws IOException {
-    handler.handleRequest(createRequestWithDifferentInstitution(), output, context);
+    handler.handleRequest(createRequestWithDifferentInstitution(), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -101,7 +84,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
     mockUserApiResponse(USER_RESPONSE_BODY_WITHOUT_ACCESS_RIGHT_JSON);
     var candidate = createCandidate();
     var assignee = randomString();
-    handler.handleRequest(createRequest(candidate, assignee), output, context);
+    handler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -112,11 +95,14 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
     mockUserApiResponse(USER_RESPONSE_BODY_WITHOUT_ACCESS_RIGHT_JSON);
     var candidate = createCandidate();
     var assignee = randomString();
-    viewingScopeValidator = new FakeViewingScopeValidator(false);
+    var viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(false);
     handler =
         new UpsertAssigneeHandler(
-            candidateRepository, periodRepository, uriRetriever, viewingScopeValidator);
-    handler.handleRequest(createRequest(candidate, assignee), output, context);
+            candidateRepository,
+            periodRepository,
+            mockUriRetriever,
+            viewingScopeValidatorReturningFalse);
+    handler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
     assertThat(
         response.getStatusCode(), is(CoreMatchers.equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -125,7 +111,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
   @Test
   void shouldReturnNotFoundWhenCandidateDoesNotExist() throws IOException {
     mockUserApiResponse(USER_RESPONSE_BODY_WITH_ACCESS_RIGHT_JSON);
-    handler.handleRequest(createRequestWithNonExistingCandidate(), output, context);
+    handler.handleRequest(createRequestWithNonExistingCandidate(), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_NOT_FOUND)));
@@ -136,14 +122,14 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
     mockUserApiResponse(USER_RESPONSE_BODY_WITH_ACCESS_RIGHT_JSON);
     var candidate = createCandidate();
     var assignee = randomString();
-    var periodRepositoryForClosedPeriod = periodRepositoryReturningClosedPeriod(YEAR);
+    var periodRepositoryForClosedPeriod = periodRepositoryReturningClosedPeriod(CURRENT_YEAR);
     var customHandler =
         new UpsertAssigneeHandler(
             candidateRepository,
             periodRepositoryForClosedPeriod,
-            uriRetriever,
-            viewingScopeValidator);
-    customHandler.handleRequest(createRequest(candidate, assignee), output, context);
+            mockUriRetriever,
+            mockViewingScopeValidator);
+    customHandler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CONFLICT)));
@@ -155,14 +141,15 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
     mockUserApiResponse(USER_RESPONSE_BODY_WITH_ACCESS_RIGHT_JSON);
     var candidate = createCandidate();
     var assignee = randomString();
-    var periodRepositoryForNotYetOpenPeriod = periodRepositoryReturningNotOpenedPeriod(YEAR);
+    var periodRepositoryForNotYetOpenPeriod =
+        periodRepositoryReturningNotOpenedPeriod(CURRENT_YEAR);
     var customHandler =
         new UpsertAssigneeHandler(
             candidateRepository,
             periodRepositoryForNotYetOpenPeriod,
-            uriRetriever,
-            viewingScopeValidator);
-    customHandler.handleRequest(createRequest(candidate, assignee), output, context);
+            mockUriRetriever,
+            mockViewingScopeValidator);
+    customHandler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_CONFLICT)));
@@ -173,7 +160,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
     mockUserApiResponse(USER_RESPONSE_BODY_WITH_ACCESS_RIGHT_JSON);
     var candidate = createCandidate();
     var assignee = randomString();
-    handler.handleRequest(createRequest(candidate, assignee), output, context);
+    handler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
 
     assertThat(
@@ -186,7 +173,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
   void shouldRemoveAssigneeWhenAssigneeIsPresent() throws IOException {
     mockUserApiResponse(USER_RESPONSE_BODY_WITH_ACCESS_RIGHT_JSON);
     var candidate = createCandidate();
-    handler.handleRequest(createRequest(candidate, null), output, context);
+    handler.handleRequest(createRequest(candidate, null), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
 
     assertThat(
@@ -200,7 +187,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
     mockUserApiResponse(USER_RESPONSE_BODY_WITH_ACCESS_RIGHT_JSON);
     var newAssignee = randomString();
     var candidate = candidateWithFinalizedApproval(newAssignee);
-    handler.handleRequest(createRequest(candidate, newAssignee), output, context);
+    handler.handleRequest(createRequest(candidate, newAssignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, CandidateDto.class);
 
     assertThat(
@@ -231,7 +218,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
   }
 
   private void mockUserApiResponse(String responseFile) {
-    when(uriRetriever.getRawContent(any(), any()))
+    when(mockUriRetriever.getRawContent(any(), any()))
         .thenReturn(Optional.ofNullable(IoUtils.stringFromResources(Path.of(responseFile))));
   }
 
@@ -245,7 +232,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
         .withAccessRights(requestBody.institutionId(), AccessRight.MANAGE_NVI_CANDIDATES)
         .withUserName(randomString())
         .withBody(requestBody)
-        .withPathParameters(Map.of(CANDIDATE_IDENTIFIER, candidate.getIdentifier().toString()))
+        .withPathParameters(Map.of(resourcePathParameter, candidate.getIdentifier().toString()))
         .build();
   }
 
@@ -258,7 +245,7 @@ class UpsertAssigneeHandlerTest extends LocalDynamoTest {
         .withAccessRights(organizationId, AccessRight.MANAGE_NVI_CANDIDATES)
         .withUserName(randomString())
         .withBody(requestBody)
-        .withPathParameters(Map.of(CANDIDATE_IDENTIFIER, randomUUID().toString()))
+        .withPathParameters(Map.of(resourcePathParameter, randomUUID().toString()))
         .build();
   }
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -2,8 +2,6 @@ package no.sikt.nva.nvi.rest.upsert;
 
 import static java.util.UUID.randomUUID;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
-import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
-import static no.sikt.nva.nvi.test.TestUtils.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningNotOpenedPeriod;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -13,7 +11,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -23,7 +20,6 @@ import java.net.HttpURLConnection;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.Optional;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
@@ -33,7 +29,6 @@ import no.sikt.nva.nvi.rest.BaseCandidateRestHandlerTest;
 import no.sikt.nva.nvi.rest.model.UpsertAssigneeRequest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
 import no.sikt.nva.nvi.test.TestUtils;
-import no.unit.nva.auth.uriretriever.UriRetriever;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
@@ -200,19 +195,12 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
   }
 
   private Candidate candidateWithFinalizedApproval(String newAssignee) {
-    var institutionId = randomUri();
-    var mockUriRetriever = mock(UriRetriever.class);
-    var mockOrganizationRetriever = new OrganizationRetriever(mockUriRetriever);
-    mockOrganizationResponseForAffiliation(institutionId, null, mockUriRetriever);
-    var request = createUpsertCandidateRequest(institutionId).build();
-    Candidate.upsert(request, candidateRepository, periodRepository);
-    var candidate =
-        Candidate.fetchByPublicationId(
-            request::publicationId, candidateRepository, periodRepository);
-    candidate.updateApprovalAssignee(new UpdateAssigneeRequest(institutionId, newAssignee));
+    var candidate = setupValidCandidate(topLevelOrganizationId);
+    candidate.updateApprovalAssignee(
+        new UpdateAssigneeRequest(topLevelOrganizationId, newAssignee));
     candidate.updateApprovalStatus(
         new UpdateStatusRequest(
-            institutionId, ApprovalStatus.APPROVED, randomString(), randomString()),
+            topLevelOrganizationId, ApprovalStatus.APPROVED, randomString(), randomString()),
         mockOrganizationRetriever);
     return candidate;
   }


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48561

This refactors the REST handler tests to all extend the same base class, in a separate PR from the actual business logic changes.