### PR TITLE
[np-48561] refactor: Use identity service in UpsertAssigneeHandler

### DIFF
--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/model/User.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/model/User.java
@@ -1,9 +1,0 @@
-package no.sikt.nva.nvi.rest.model;
-
-import java.util.List;
-import nva.commons.apigateway.AccessRight;
-
-public record User(List<Role> roles) {
-
-  public record Role(List<AccessRight> accessRights) {}
-}

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandler.java
@@ -1,13 +1,11 @@
 package no.sikt.nva.nvi.rest.upsert;
 
+import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
-import java.net.URI;
-import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.DynamoRepository;
@@ -20,20 +18,16 @@ import no.sikt.nva.nvi.common.utils.RequestUtil;
 import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
 import no.sikt.nva.nvi.rest.ViewingScopeHandler;
 import no.sikt.nva.nvi.rest.model.UpsertAssigneeRequest;
-import no.sikt.nva.nvi.rest.model.User;
-import no.sikt.nva.nvi.rest.model.User.Role;
-import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
-import no.unit.nva.auth.uriretriever.RawContentRetriever;
+import no.unit.nva.clients.GetUserResponse;
 import no.unit.nva.clients.IdentityServiceClient;
-import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
+import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
-import nva.commons.core.paths.UriWrapper;
 
 public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeRequest, CandidateDto>
     implements ViewingScopeHandler {
@@ -44,11 +38,6 @@ public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeReque
       ENVIRONMENT.readEnv("BACKEND_CLIENT_AUTH_URL");
   public static final String BACKEND_CLIENT_SECRET_NAME =
       ENVIRONMENT.readEnv("BACKEND_CLIENT_SECRET_NAME");
-  public static final String API_HOST = ENVIRONMENT.readEnv("API_HOST");
-  public static final String USERS_ROLES_PATH_PARAM = "users-roles";
-  public static final String USERS_PATH_PARAM = "users";
-  public static final String CONTENT_TYPE = "application/json";
-  private final RawContentRetriever uriRetriever;
   private final CandidateRepository candidateRepository;
   private final PeriodRepository periodRepository;
   private final IdentityServiceClient identityServiceClient;
@@ -59,7 +48,6 @@ public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeReque
     this(
         new CandidateRepository(DynamoRepository.defaultDynamoClient()),
         new PeriodRepository(DynamoRepository.defaultDynamoClient()),
-        new AuthorizedBackendUriRetriever(BACKEND_CLIENT_AUTH_URL, BACKEND_CLIENT_SECRET_NAME),
         IdentityServiceClient.prepare(),
         ViewingScopeHandler.defaultViewingScopeValidator());
   }
@@ -67,13 +55,11 @@ public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeReque
   public UpsertAssigneeHandler(
       CandidateRepository candidateRepository,
       PeriodRepository periodRepository,
-      RawContentRetriever uriRetriever,
       IdentityServiceClient identityServiceClient,
       ViewingScopeValidator viewingScopeValidator) {
     super(UpsertAssigneeRequest.class);
     this.candidateRepository = candidateRepository;
     this.periodRepository = periodRepository;
-    this.uriRetriever = uriRetriever;
     this.identityServiceClient = identityServiceClient;
     this.viewingScopeValidator = viewingScopeValidator;
   }
@@ -118,10 +104,6 @@ public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeReque
     }
   }
 
-  private static User toUser(String body) {
-    return attempt(() -> JsonUtils.dtoObjectMapper.readValue(body, User.class)).orElseThrow();
-  }
-
   private void validateCustomerAndAccessRight(UpsertAssigneeRequest input, RequestInfo requestInfo)
       throws UnauthorizedException {
     RequestUtil.hasAccessRight(requestInfo, AccessRight.MANAGE_NVI_CANDIDATES);
@@ -132,33 +114,17 @@ public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeReque
   }
 
   private void assigneeHasAccessRight(String assignee) throws UnauthorizedException {
-    var user = fetchUser(assignee);
-    if (!hasManageNviCandidateAccessRight(user)) {
+    try {
+      var user = identityServiceClient.getUser(assignee);
+      if (isNull(user) || !isIsNviCurator(user)) {
+        throw new UnauthorizedException();
+      }
+    } catch (NotFoundException e) {
       throw new UnauthorizedException();
     }
   }
 
-  private boolean hasManageNviCandidateAccessRight(User user) {
-    return user.roles().stream()
-        .map(Role::accessRights)
-        .flatMap(List::stream)
-        .anyMatch(
-            accessRights -> accessRights.name().equals(AccessRight.MANAGE_NVI_CANDIDATES.name()));
-  }
-
-  private User fetchUser(String assignee) {
-    return attempt(() -> constructFetchUserUri(assignee))
-        .map(uri -> uriRetriever.getRawContent(uri, CONTENT_TYPE))
-        .map(Optional::orElseThrow)
-        .map(UpsertAssigneeHandler::toUser)
-        .orElseThrow();
-  }
-
-  private URI constructFetchUserUri(String assignee) {
-    return UriWrapper.fromHost(API_HOST)
-        .addChild(USERS_ROLES_PATH_PARAM)
-        .addChild(USERS_PATH_PARAM)
-        .addChild(assignee)
-        .getUri();
+  private static boolean isIsNviCurator(GetUserResponse user) {
+    return user.accessRights().contains(AccessRight.MANAGE_NVI_CANDIDATES.name());
   }
 }

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandler.java
@@ -24,6 +24,7 @@ import no.sikt.nva.nvi.rest.model.User;
 import no.sikt.nva.nvi.rest.model.User.Role;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
 import no.unit.nva.auth.uriretriever.RawContentRetriever;
+import no.unit.nva.clients.IdentityServiceClient;
 import no.unit.nva.commons.json.JsonUtils;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.ApiGatewayHandler;
@@ -50,6 +51,7 @@ public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeReque
   private final RawContentRetriever uriRetriever;
   private final CandidateRepository candidateRepository;
   private final PeriodRepository periodRepository;
+  private final IdentityServiceClient identityServiceClient;
   private final ViewingScopeValidator viewingScopeValidator;
 
   @JacocoGenerated
@@ -58,6 +60,7 @@ public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeReque
         new CandidateRepository(DynamoRepository.defaultDynamoClient()),
         new PeriodRepository(DynamoRepository.defaultDynamoClient()),
         new AuthorizedBackendUriRetriever(BACKEND_CLIENT_AUTH_URL, BACKEND_CLIENT_SECRET_NAME),
+        IdentityServiceClient.prepare(),
         ViewingScopeHandler.defaultViewingScopeValidator());
   }
 
@@ -65,11 +68,13 @@ public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeReque
       CandidateRepository candidateRepository,
       PeriodRepository periodRepository,
       RawContentRetriever uriRetriever,
+      IdentityServiceClient identityServiceClient,
       ViewingScopeValidator viewingScopeValidator) {
     super(UpsertAssigneeRequest.class);
     this.candidateRepository = candidateRepository;
     this.periodRepository = periodRepository;
     this.uriRetriever = uriRetriever;
+    this.identityServiceClient = identityServiceClient;
     this.viewingScopeValidator = viewingScopeValidator;
   }
 

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandler.java
@@ -26,18 +26,12 @@ import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.apigateway.exceptions.NotFoundException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
-import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 
 public class UpsertAssigneeHandler extends ApiGatewayHandler<UpsertAssigneeRequest, CandidateDto>
     implements ViewingScopeHandler {
 
   public static final String CANDIDATE_IDENTIFIER = "candidateIdentifier";
-  public static final Environment ENVIRONMENT = new Environment();
-  public static final String BACKEND_CLIENT_AUTH_URL =
-      ENVIRONMENT.readEnv("BACKEND_CLIENT_AUTH_URL");
-  public static final String BACKEND_CLIENT_SECRET_NAME =
-      ENVIRONMENT.readEnv("BACKEND_CLIENT_SECRET_NAME");
   private final CandidateRepository candidateRepository;
   private final PeriodRepository periodRepository;
   private final IdentityServiceClient identityServiceClient;

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -29,6 +30,7 @@ import no.sikt.nva.nvi.rest.BaseCandidateRestHandlerTest;
 import no.sikt.nva.nvi.rest.model.UpsertAssigneeRequest;
 import no.sikt.nva.nvi.test.FakeViewingScopeValidator;
 import no.sikt.nva.nvi.test.TestUtils;
+import no.unit.nva.clients.IdentityServiceClient;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
@@ -46,16 +48,22 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
       "userResponseBodyWithoutAccessRight" + ".json";
   private static final String USER_RESPONSE_BODY_WITH_ACCESS_RIGHT_JSON =
       "userResponseBodyWithAccessRight.json";
+  private IdentityServiceClient mockIdentityServiceClient;
 
   @Override
   protected ApiGatewayHandler<UpsertAssigneeRequest, CandidateDto> createHandler() {
     return new UpsertAssigneeHandler(
-        candidateRepository, periodRepository, mockUriRetriever, mockViewingScopeValidator);
+        candidateRepository,
+        periodRepository,
+        mockUriRetriever,
+        mockIdentityServiceClient,
+        mockViewingScopeValidator);
   }
 
   @BeforeEach
   void setUp() {
     resourcePathParameter = "candidateIdentifier";
+    mockIdentityServiceClient = mock(IdentityServiceClient.class);
   }
 
   @Test
@@ -96,6 +104,7 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
             candidateRepository,
             periodRepository,
             mockUriRetriever,
+            mockIdentityServiceClient,
             viewingScopeValidatorReturningFalse);
     handler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -123,6 +132,7 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
             candidateRepository,
             periodRepositoryForClosedPeriod,
             mockUriRetriever,
+            mockIdentityServiceClient,
             mockViewingScopeValidator);
     customHandler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -143,6 +153,7 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
             candidateRepository,
             periodRepositoryForNotYetOpenPeriod,
             mockUriRetriever,
+            mockIdentityServiceClient,
             mockViewingScopeValidator);
     customHandler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48561

This PR refactors access control in `UpsertAssigneeHandler` to use `identityServiceClient` instead of manually performing the same call. It is done in conjunction with this ticket to simplify testing of other necessary changes in the handler.

The authorization check in this handler is slightly more complex because we check the access level of the user being assigned and not just the user making the request.