### PR TITLE
build: Add support for textFixtures in nvi-commons

### DIFF
--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -40,6 +40,8 @@ dependencies {
 
     testImplementation libs.nva.testutils
     testImplementation libs.dynamodDbLocal
+
+    testImplementation(testFixtures(project(":nvi-commons")))
 }
 
 test {

--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
     implementation libs.bundles.jacksonjr
     implementation libs.bundles.logging
+
+    testImplementation(testFixtures(project(":nvi-commons")))
 }
 
 test {

--- a/nvi-commons/build.gradle
+++ b/nvi-commons/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testFixturesImplementation libs.bundles.testing
     testFixturesImplementation libs.nva.core
     testFixturesImplementation libs.nva.json
+    testFixturesImplementation libs.nva.commons.auth
 }
 
 test {

--- a/nvi-commons/build.gradle
+++ b/nvi-commons/build.gradle
@@ -1,5 +1,7 @@
 plugins {
     id 'nva.nvi.java-conventions'
+    id 'java-library'
+    id 'java-test-fixtures'
 }
 
 dependencies {
@@ -22,6 +24,10 @@ dependencies {
 
     testImplementation libs.dynamodDbLocal
     testImplementation project(':nvi-test')
+
+    testFixturesImplementation libs.bundles.testing
+    testFixturesImplementation libs.nva.core
+    testFixturesImplementation libs.nva.json
 }
 
 test {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/client/OrganizationRetrieverTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/client/OrganizationRetrieverTest.java
@@ -1,19 +1,16 @@
 package no.sikt.nva.nvi.common.client;
 
 import static no.sikt.nva.nvi.common.client.MockHttpResponseUtil.createResponse;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganization;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationWithPartOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import no.sikt.nva.nvi.common.client.model.Organization;
-import no.sikt.nva.nvi.common.client.model.Organization.Builder;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,22 +28,10 @@ class OrganizationRetrieverTest {
 
   @Test
   void shouldFetchOrganization() {
-    var expectedOrganization = randomOrganizationWithPartOf();
+    var expectedOrganization = randomOrganizationWithPartOf(randomOrganization().build());
     mockUriRetriever(expectedOrganization);
     var actualOrganization = organizationRetriever.fetchOrganization(expectedOrganization.id());
     assertEquals(expectedOrganization, actualOrganization);
-  }
-
-  private static Builder randomOrganization() {
-    return Organization.builder()
-        .withId(randomUri())
-        .withContext(randomString())
-        .withLabels(Map.of(randomString(), randomString()))
-        .withType(randomString());
-  }
-
-  private static Organization randomOrganizationWithPartOf() {
-    return randomOrganization().withPartOf(List.of(randomOrganization().build())).build();
   }
 
   private void mockUriRetriever(Organization expectedOrganization) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/model/OrganizationTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/model/OrganizationTest.java
@@ -1,13 +1,10 @@
 package no.sikt.nva.nvi.common.model;
 
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganization;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationWithPartOf;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import java.util.List;
-import java.util.Map;
 import no.sikt.nva.nvi.common.client.model.Organization;
-import no.sikt.nva.nvi.common.client.model.Organization.Builder;
 import org.junit.jupiter.api.Test;
 
 class OrganizationTest {
@@ -33,17 +30,5 @@ class OrganizationTest {
     var json = organization.toJsonString();
     var actualOrganization = Organization.from(json);
     assertEquals(organization, actualOrganization);
-  }
-
-  private static Builder randomOrganization() {
-    return Organization.builder()
-        .withId(randomUri())
-        .withContext(randomString())
-        .withLabels(Map.of(randomString(), randomString()))
-        .withType(randomString());
-  }
-
-  private static Organization randomOrganizationWithPartOf(Organization topLevelOrg) {
-    return randomOrganization().withPartOf(List.of(topLevelOrg)).build();
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
@@ -1,12 +1,24 @@
 package no.sikt.nva.nvi.common.model;
 
+import static java.util.Objects.nonNull;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.net.URI;
+import java.net.http.HttpResponse;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.client.model.Organization.Builder;
+import no.unit.nva.auth.uriretriever.UriRetriever;
 
 public class OrganizationFixtures {
 
@@ -20,5 +32,46 @@ public class OrganizationFixtures {
 
   public static Organization randomOrganizationWithPartOf(Organization topLevelOrg) {
     return randomOrganization().withPartOf(List.of(topLevelOrg)).build();
+  }
+
+  public static void mockOrganizationResponseForAffiliation(
+      URI topLevelInstitutionId, URI subUnitId, UriRetriever uriRetriever) {
+    var subUnits = new ArrayList<Organization>();
+    if (nonNull(subUnitId)) {
+      var topLevelOrganizationAsLeafNode =
+          Organization.builder().withId(topLevelInstitutionId).build();
+      var subUnitOrganization =
+          Organization.builder()
+              .withId(subUnitId)
+              .withPartOf(List.of(topLevelOrganizationAsLeafNode))
+              .build();
+      mockOrganizationResponse(subUnitOrganization, uriRetriever);
+      subUnits.add(subUnitOrganization);
+    }
+    var topLevelOrganization =
+        Organization.builder().withId(topLevelInstitutionId).withHasPart(subUnits).build();
+    mockOrganizationResponse(topLevelOrganization, uriRetriever);
+  }
+
+  private static void mockOrganizationResponse(
+      Organization organization, UriRetriever uriRetriever) {
+    var body = generateResponseBody(organization);
+    var response = Optional.of(createResponse(200, body));
+    when(uriRetriever.fetchResponse(eq(organization.id()), any())).thenReturn(response);
+  }
+
+  private static String generateResponseBody(Organization organization) {
+    try {
+      return dtoObjectMapper.writeValueAsString(organization);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static HttpResponse<String> createResponse(int status, String body) {
+    var response = (HttpResponse<String>) mock(HttpResponse.class);
+    when(response.statusCode()).thenReturn(status);
+    when(response.body()).thenReturn(body);
+    return response;
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
@@ -1,0 +1,24 @@
+package no.sikt.nva.nvi.common.model;
+
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+
+import java.util.List;
+import java.util.Map;
+import no.sikt.nva.nvi.common.client.model.Organization;
+import no.sikt.nva.nvi.common.client.model.Organization.Builder;
+
+public class OrganizationFixtures {
+
+  public static Builder randomOrganization() {
+    return Organization.builder()
+        .withId(randomUri())
+        .withContext(randomString())
+        .withLabels(Map.of(randomString(), randomString()))
+        .withType(randomString());
+  }
+
+  public static Organization randomOrganizationWithPartOf(Organization topLevelOrg) {
+    return randomOrganization().withPartOf(List.of(topLevelOrg)).build();
+  }
+}

--- a/nvi-rest/build.gradle
+++ b/nvi-rest/build.gradle
@@ -21,6 +21,8 @@ dependencies {
     testImplementation libs.dynamodDbLocal
     testImplementation libs.bundles.testing
     testImplementation project(':nvi-test')
+
+    testImplementation(testFixtures(project(":nvi-commons")))
 }
 
 test {

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
@@ -1,10 +1,10 @@
 package no.sikt.nva.nvi.rest;
 
 import static java.math.BigDecimal.ZERO;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.test.TestUtils.createUpsertNonCandidateRequest;
-import static no.sikt.nva.nvi.test.TestUtils.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.periodRepositoryReturningOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomUriWithSuffix;


### PR DESCRIPTION
This is a proof of concept and initial framework for using `textFixtures`, with the goal of moving shared test utility code to the `nvi-commons` module. This adds an example `OrganizationFixture` with copies of existing utility methods to show that imports work properly.