### PR TITLE
[np-48242] fix: Handle approval reset on identified creator

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -3,6 +3,7 @@ package no.sikt.nva.nvi.common.service.model;
 import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.UUID.randomUUID;
+import static java.util.function.Predicate.not;
 import static no.sikt.nva.nvi.common.db.ReportStatus.REPORTED;
 import static no.sikt.nva.nvi.common.service.model.Approval.validateUpdateStatusRequest;
 import static no.sikt.nva.nvi.common.service.model.ApprovalStatus.APPROVED;
@@ -540,8 +541,9 @@ public final class Candidate {
     }
   }
 
-  /*
-   * Create new approvals in a pending state for institutions that have changes to their points.
+  /**
+   * Returns new approvals in a pending state for all institutions that should have their approvals
+   * reset.
    */
   private static List<DbApprovalStatus> getIndividualApprovalsToReset(
       Candidate candidate, Candidate updatedCandidate) {
@@ -622,7 +624,7 @@ public final class Candidate {
   private static boolean hasSameCreators(UpsertCandidateRequest request, Candidate candidate) {
     var affiliationsOfRemovedUnverifiedCreators =
         candidate.getPublicationDetails().getUnverifiedCreators().stream()
-            .filter(creator -> !request.unverifiedCreators().contains(creator))
+            .filter(not(creator -> request.unverifiedCreators().contains(creator)))
             .map(UnverifiedNviCreatorDto::affiliations)
             .map(HashSet::new)
             .toList();
@@ -630,7 +632,7 @@ public final class Candidate {
     var currentCreatorIds = candidate.getVerifiedNviCreatorIds();
     var affiliationsOfNewVerifiedCreators =
         request.verifiedCreators().stream()
-            .filter(creator -> !currentCreatorIds.contains(creator.id()))
+            .filter(not(creator -> currentCreatorIds.contains(creator.id())))
             .map(VerifiedNviCreatorDto::affiliations)
             .map(HashSet::new)
             .toList();

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -21,6 +21,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -268,7 +269,7 @@ public final class Candidate {
   // TODO: Make method return InstitutionPoints once we have migrated candidates from Cristin
   public Optional<InstitutionPoints> getInstitutionPoints(URI institutionId) {
     return institutionPoints.stream()
-        .filter(institutionPoints -> institutionPoints.institutionId().equals(institutionId))
+        .filter(points -> points.institutionId().equals(institutionId))
         .findFirst();
   }
 
@@ -527,30 +528,32 @@ public final class Candidate {
   }
 
   private static void updateCandidate(
-      UpsertCandidateRequest request, CandidateRepository repository, Candidate existingCandidate) {
+      UpsertCandidateRequest request, CandidateRepository repository, Candidate candidate) {
     validateCandidate(request);
-    if (shouldResetCandidate(request, existingCandidate) || isNotApplicable(existingCandidate)) {
-      resetCandidate(request, repository, existingCandidate);
+    var updatedCandidate = candidate.apply(request);
+    if (shouldResetCandidate(request, candidate) || isNotApplicable(candidate)) {
+      var newApprovals = mapToApprovals(updatedCandidate.getInstitutionPoints());
+      repository.updateCandidateAndDeleteOtherApprovals(updatedCandidate.toDao(), newApprovals);
     } else {
-      updateCandidateKeepingApprovalsAndNotes(request, repository, existingCandidate);
+      var updatedApprovals = getIndividualApprovalsToReset(candidate, updatedCandidate);
+      repository.updateCandidateAndKeepOtherApprovals(updatedCandidate.toDao(), updatedApprovals);
     }
+  }
+
+  /*
+   * Create new approvals in a pending state for institutions that have changes to their points.
+   */
+  private static List<DbApprovalStatus> getIndividualApprovalsToReset(
+      Candidate candidate, Candidate updatedCandidate) {
+    return updatedCandidate.getInstitutionPoints().stream()
+        .filter(institutionPoints -> !hasSameInstitutionPoints(candidate, institutionPoints))
+        .map(InstitutionPoints::institutionId)
+        .map(Candidate::mapToApproval)
+        .toList();
   }
 
   private static boolean isNotApplicable(Candidate candidate) {
     return !candidate.isApplicable();
-  }
-
-  private static void resetCandidate(
-      UpsertCandidateRequest request, CandidateRepository repository, Candidate existingCandidate) {
-    var updatedCandidate = existingCandidate.apply(request);
-    var newApprovals = mapToApprovals(updatedCandidate.getInstitutionPoints());
-    repository.updateCandidate(updatedCandidate.toDao(), newApprovals);
-  }
-
-  private static void updateCandidateKeepingApprovalsAndNotes(
-      UpsertCandidateRequest request, CandidateRepository repository, Candidate existingCandidate) {
-    var updatedCandidateDao = existingCandidate.apply(request).toDao();
-    repository.updateCandidate(updatedCandidateDao);
   }
 
   private static boolean shouldResetCandidate(UpsertCandidateRequest request, Candidate candidate) {
@@ -558,7 +561,7 @@ public final class Candidate {
         || publicationChannelIsUpdated(request, candidate)
         || instanceTypeIsUpdated(request, candidate)
         || creatorsAreUpdated(request, candidate)
-        || institutionPointsAreUpdated(request, candidate)
+        || hasChangeInTopLevelOrganizations(request, candidate)
         || publicationYearIsUpdated(request, candidate);
   }
 
@@ -575,10 +578,17 @@ public final class Candidate {
         .equals(candidate.getPublicationDetails().publicationDate().year());
   }
 
-  private static boolean institutionPointsAreUpdated(
+  private static boolean hasChangeInTopLevelOrganizations(
       UpsertCandidateRequest request, Candidate candidate) {
-    return !request.institutionPoints().stream()
-        .allMatch(institutionPoints -> hasSameInstitutionPoints(candidate, institutionPoints));
+    var oldTopLevelOrganizations =
+        candidate.getInstitutionPoints().stream()
+            .map(InstitutionPoints::institutionId)
+            .collect(Collectors.toSet());
+    var newTopLevelOrganizations =
+        request.institutionPoints().stream()
+            .map(InstitutionPoints::institutionId)
+            .collect(Collectors.toSet());
+    return !oldTopLevelOrganizations.equals(newTopLevelOrganizations);
   }
 
   private static Boolean hasSameInstitutionPoints(
@@ -596,33 +606,40 @@ public final class Candidate {
         adjustScaleAndRoundingMode(currentPoints), adjustScaleAndRoundingMode(newPoints));
   }
 
+  /*
+   * Checks whether the set of creators is the same in the request and the candidate.
+   * This allows for unverified creators to be converted to verified creators by assuming that
+   * a removed creator is replaced by a new creator with the same affiliations.
+   */
   private static boolean creatorsAreUpdated(UpsertCandidateRequest request, Candidate candidate) {
-    // TODO: This only compares by name/ID now, but should include top-level affiliations too
-    // (NP-48112)
-    return hasChangeInVerifiedCreators(request, candidate)
-        || hasChangeInUnverifiedCreators(request, candidate);
+    var oldCreatorCount = candidate.getPublicationDetails().creators().size();
+    var newCreatorCount = getAllCreators(request).size();
+    var hasSameCount = oldCreatorCount == newCreatorCount;
+    var hasSameCreators = hasSameCreators(request, candidate);
+    return !(hasSameCount && hasSameCreators);
   }
 
-  private static boolean hasChangeInVerifiedCreators(
-      UpsertCandidateRequest request, Candidate candidate) {
-    // Verified creators can be compared by ID
-    var oldCreatorIds = candidate.getVerifiedNviCreatorIds();
-    var newCreatorIds =
+  private static boolean hasSameCreators(UpsertCandidateRequest request, Candidate candidate) {
+    var affiliationsOfRemovedUnverifiedCreators =
+        candidate.getPublicationDetails().getUnverifiedCreators().stream()
+            .filter(creator -> !request.unverifiedCreators().contains(creator))
+            .map(UnverifiedNviCreatorDto::affiliations)
+            .map(HashSet::new)
+            .toList();
+
+    var currentCreatorIds = candidate.getVerifiedNviCreatorIds();
+    var affiliationsOfNewVerifiedCreators =
         request.verifiedCreators().stream()
-            .map(VerifiedNviCreatorDto::id)
-            .collect(Collectors.toSet());
-    return !oldCreatorIds.equals(newCreatorIds);
-  }
+            .filter(creator -> !currentCreatorIds.contains(creator.id()))
+            .map(VerifiedNviCreatorDto::affiliations)
+            .map(HashSet::new)
+            .toList();
 
-  private static boolean hasChangeInUnverifiedCreators(
-      UpsertCandidateRequest request, Candidate candidate) {
-    // Unverified creators do not have an ID, so we must compare by name
-    var oldCreatorNames = candidate.getUnverifiedNviCreatorNames();
-    var newCreatorNames =
-        request.unverifiedCreators().stream()
-            .map(UnverifiedNviCreatorDto::name)
-            .collect(Collectors.toSet());
-    return !oldCreatorNames.equals(newCreatorNames);
+    var removedInNew =
+        affiliationsOfNewVerifiedCreators.containsAll(affiliationsOfRemovedUnverifiedCreators);
+    var newInRemoved =
+        affiliationsOfRemovedUnverifiedCreators.containsAll(affiliationsOfNewVerifiedCreators);
+    return removedInNew && newInRemoved;
   }
 
   private static boolean instanceTypeIsUpdated(
@@ -758,10 +775,6 @@ public final class Candidate {
 
   private Set<URI> getVerifiedNviCreatorIds() {
     return publicationDetails.getVerifiedNviCreatorIds();
-  }
-
-  private Set<String> getUnverifiedNviCreatorNames() {
-    return publicationDetails.getUnverifiedNviCreatorNames();
   }
 
   private Builder copy() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
@@ -59,14 +59,6 @@ public record PublicationDetails(
         .collect(Collectors.toSet());
   }
 
-  public Set<String> getUnverifiedNviCreatorNames() {
-    return creators.stream()
-        .filter(UnverifiedNviCreatorDto.class::isInstance)
-        .map(UnverifiedNviCreatorDto.class::cast)
-        .map(UnverifiedNviCreatorDto::name)
-        .collect(Collectors.toSet());
-  }
-
   public record PublicationDate(String year, String month, String day) {
 
     public static PublicationDate from(DbPublicationDate dbPublicationDate) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/RequestUtil.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/RequestUtil.java
@@ -3,7 +3,6 @@ package no.sikt.nva.nvi.common.utils;
 import java.util.List;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.service.dto.NviCreatorDto;
-import no.sikt.nva.nvi.common.service.dto.VerifiedNviCreatorDto;
 import no.sikt.nva.nvi.common.service.model.Username;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import nva.commons.apigateway.AccessRight;
@@ -34,15 +33,10 @@ public final class RequestUtil {
   }
 
   public static List<NviCreatorDto> getAllCreators(UpsertCandidateRequest request) {
-    Stream<NviCreatorDto> verifiedCreators =
-        request.creators().entrySet().stream()
-            .map(
-                creator ->
-                    VerifiedNviCreatorDto.builder()
-                        .withId(creator.getKey())
-                        .withAffiliations(creator.getValue())
-                        .build());
+    var verifiedCreators = request.verifiedCreators().stream();
     var unverifiedCreators = request.unverifiedCreators().stream();
-    return Stream.concat(verifiedCreators, unverifiedCreators).toList();
+    return Stream.concat(verifiedCreators, unverifiedCreators)
+        .map(NviCreatorDto.class::cast)
+        .toList();
   }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.common.service;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
+import static no.sikt.nva.nvi.common.UpsertRequestBuilder.fromRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
@@ -30,19 +31,23 @@ import static org.mockito.Mockito.mock;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.time.ZonedDateTime;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.UpsertRequestBuilder;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
+import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.model.InvalidNviCandidateException;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.dto.CandidateOperation;
+import no.sikt.nva.nvi.common.service.dto.NviCreatorDto;
 import no.sikt.nva.nvi.common.service.dto.UnverifiedNviCreatorDto;
 import no.sikt.nva.nvi.common.service.dto.VerifiedNviCreatorDto;
 import no.sikt.nva.nvi.common.service.dto.problem.UnverifiedCreatorFromOrganizationProblem;
@@ -81,6 +86,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
       BigDecimal.ONE.setScale(EXPECTED_SCALE, EXPECTED_ROUNDING_MODE);
   private OrganizationRetriever mockOrganizationRetriever;
   private URI topLevelOrganizationId;
+  private TestScenario scenario;
 
   public static Stream<Arguments> statusProvider() {
     return Stream.of(
@@ -113,6 +119,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
     mockOrganizationResponseForAffiliation(topLevelOrganizationId, null, mockUriRetriever);
     mockOrganizationResponseForAffiliation(
         HARDCODED_INSTITUTION_ID, HARDCODED_SUBUNIT_ID, mockUriRetriever);
+    scenario = new TestScenario();
   }
 
   @ParameterizedTest(name = "Should update from old status {0} to new status {1}")
@@ -225,7 +232,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
         createUpsertCandidateRequest(keepInstitutionId, deleteInstitutionId, randomUri()).build();
     Candidate.upsert(createCandidateRequest, candidateRepository, periodRepository);
     var updateRequest =
-        UpsertRequestBuilder.fromRequest(createCandidateRequest)
+        fromRequest(createCandidateRequest)
             .withPoints(List.of(new InstitutionPoints(keepInstitutionId, randomBigDecimal(), null)))
             .build();
     var updatedCandidate = upsert(updateRequest);
@@ -345,33 +352,123 @@ class CandidateApprovalTest extends CandidateTestSetup {
     assertThat(updatedApproval, is(equalTo(approval)));
   }
 
-  // FIXME: This test compares random URIs, there is no actual check that they belong to the same
-  // organization
-  // We also lack the mirror case, where the top-level affiliation changes and resets the approval
-  // (NP-48112)
   @Test
   void shouldNotResetApprovalsWhenCreatorAffiliationChangesWithinSameInstitution() {
-    var upsertCandidateRequest = getUpsertCandidateRequestWithHardcodedValues();
-    var candidate = upsert(upsertCandidateRequest);
-    candidate.updateApprovalStatus(
-        new UpdateStatusRequest(
-            HARDCODED_INSTITUTION_ID, ApprovalStatus.APPROVED, randomString(), randomString()),
-        mockOrganizationRetriever);
-    var points =
-        List.of(
-            new InstitutionPoints(
-                HARDCODED_INSTITUTION_ID,
-                HARDCODED_POINTS,
-                List.of(
-                    new CreatorAffiliationPoints(
-                        HARDCODED_CREATOR_ID, HARDCODED_SUBUNIT_ID, HARDCODED_POINTS))));
+    var organization = scenario.getDefaultOrganization();
+    var creator = createVerifiedCreator(organization);
+    Map<URI, Collection<NviCreatorDto>> creatorMap = Map.of(organization.id(), List.of(creator));
+    var requestBuilder = setupApprovedCandidate(organization.id(), creatorMap);
 
-    var newUpsertRequest =
-        UpsertRequestBuilder.fromRequest(upsertCandidateRequest).withPoints(points).build();
-    var updatedCandidate = upsert(newUpsertRequest);
-    var updatedApproval = updatedCandidate.getApprovals().get(HARDCODED_INSTITUTION_ID);
+    var otherSubUnitId = organization.hasPart().get(1).id();
+    var updatedCreator = new VerifiedNviCreatorDto(creator.id(), List.of(otherSubUnitId));
+    creatorMap = Map.of(organization.id(), List.of(updatedCreator));
+    var updatedRequest = requestBuilder.withCreatorsAndPoints(creatorMap).build();
+    var updatedCandidate = scenario.upsertCandidate(updatedRequest);
 
-    assertThat(updatedApproval.getStatus(), is(equalTo(ApprovalStatus.APPROVED)));
+    var updatedApprovals = updatedCandidate.getApprovals();
+    var updatedApproval = updatedApprovals.get(organization.id());
+    assertThat(creator.affiliations(), is(not(equalTo(updatedCreator.affiliations()))));
+    assertThat(ApprovalStatus.APPROVED, is(equalTo(updatedApproval.getStatus())));
+    assertThat(1, is(equalTo(updatedApprovals.size())));
+  }
+
+  // FIXME: Test OK, but failing because of bug in the code
+  @Test
+  void shouldNotResetApprovalWhenOtherCreatorBecomesVerified() {
+    var organization = scenario.getDefaultOrganization();
+    var creator = createVerifiedCreator(organization);
+    var otherOrganization = scenario.setupTopLevelOrganizationWithSubUnits();
+    var otherCreator = createUnverifiedCreator(otherOrganization);
+
+    Map<URI, Collection<NviCreatorDto>> creatorMap =
+        Map.of(organization.id(), List.of(creator), otherOrganization.id(), List.of(otherCreator));
+    var requestBuilder = setupApprovedCandidate(organization.id(), creatorMap);
+
+    var updatedCreator = new VerifiedNviCreatorDto(randomUri(), otherCreator.affiliations());
+    creatorMap =
+        Map.of(
+            organization.id(), List.of(creator), otherOrganization.id(), List.of(updatedCreator));
+    var updatedRequest = requestBuilder.withCreatorsAndPoints(creatorMap).build();
+    var updatedCandidate = scenario.upsertCandidate(updatedRequest);
+
+    var updatedApprovals = updatedCandidate.getApprovals();
+    var updatedApproval = updatedApprovals.get(organization.id());
+    assertThat(ApprovalStatus.APPROVED, is(equalTo(updatedApproval.getStatus())));
+    assertThat(2, is(equalTo(updatedApprovals.size())));
+  }
+
+  @Test
+  void shouldResetApprovalWhenCreatorBecomesUnverified() {
+    var organization = scenario.getDefaultOrganization();
+    var creator = createVerifiedCreator(organization);
+    Map<URI, Collection<NviCreatorDto>> creatorMap = Map.of(organization.id(), List.of(creator));
+    var requestBuilder = setupApprovedCandidate(organization.id(), creatorMap);
+
+    var updatedCreator = new UnverifiedNviCreatorDto(randomString(), creator.affiliations());
+    var updatedRequest =
+        requestBuilder
+            .withCreatorsAndPoints(Map.of(organization.id(), List.of(updatedCreator)))
+            .build();
+    var updatedCandidate = scenario.upsertCandidate(updatedRequest);
+
+    var updatedApprovals = updatedCandidate.getApprovals();
+    var updatedApproval = updatedApprovals.get(organization.id());
+    assertThat(ApprovalStatus.PENDING, is(equalTo(updatedApproval.getStatus())));
+    assertThat(1, is(equalTo(updatedApprovals.size())));
+  }
+
+  @Test
+  void shouldResetApprovalWhenTopLevelAffiliationChanges() {
+    var organization = scenario.getDefaultOrganization();
+    var creator = createVerifiedCreator(organization);
+    Map<URI, Collection<NviCreatorDto>> creatorMap = Map.of(organization.id(), List.of(creator));
+    var requestBuilder = setupApprovedCandidate(organization.id(), creatorMap);
+
+    var otherOrganization = scenario.setupTopLevelOrganizationWithSubUnits();
+    var otherSubUnitId = otherOrganization.hasPart().getFirst().id();
+    var updatedCreator = new VerifiedNviCreatorDto(creator.id(), List.of(otherSubUnitId));
+    var updatedRequest =
+        requestBuilder
+            .withCreatorsAndPoints(Map.of(otherOrganization.id(), List.of(updatedCreator)))
+            .build();
+    var updatedCandidate = scenario.upsertCandidate(updatedRequest);
+
+    var updatedApprovals = updatedCandidate.getApprovals();
+    var updatedApproval = updatedApprovals.get(otherOrganization.id());
+    assertThat(ApprovalStatus.PENDING, is(equalTo(updatedApproval.getStatus())));
+    assertThat(1, is(equalTo(updatedApprovals.size())));
+  }
+
+  private VerifiedNviCreatorDto createVerifiedCreator(Organization topLevelOrg) {
+    var subUnitId = topLevelOrg.hasPart().getFirst().id();
+    var creatorId = randomUriWithSuffix("creatorId");
+    return new VerifiedNviCreatorDto(creatorId, List.of(subUnitId));
+  }
+
+  private UnverifiedNviCreatorDto createUnverifiedCreator(Organization topLevelOrg) {
+    var subUnitId = topLevelOrg.hasPart().getFirst().id();
+    return new UnverifiedNviCreatorDto(randomString(), List.of(subUnitId));
+  }
+
+  //  private UpsertRequestBuilder setupApprovedCandidate(
+  //      Organization organization, Collection<NviCreatorDto> creators) {
+  //    var upsertRequest =
+  //        randomUpsertRequestBuilder()
+  //            .withCreatorsAndPoints(Map.of(organization.id(), creators))
+  //            .build();
+  //    scenario.setupOpenPeriod(upsertRequest.publicationDate().year());
+  //    var candidate = scenario.upsertCandidate(upsertRequest);
+  //    scenario.updateApprovalStatus(candidate, ApprovalStatus.APPROVED, organization.id());
+  //    return fromRequest(upsertRequest);
+  //  }
+
+  private UpsertRequestBuilder setupApprovedCandidate(
+      URI approvedByOrg, Map<URI, Collection<NviCreatorDto>> creatorMap) {
+    var upsertRequest = randomUpsertRequestBuilder().withCreatorsAndPoints(creatorMap).build();
+    scenario.setupOpenPeriod(upsertRequest.publicationDate().year());
+    var candidate = scenario.upsertCandidate(upsertRequest);
+    scenario.updateApprovalStatus(candidate, ApprovalStatus.APPROVED, approvedByOrg);
+    return fromRequest(upsertRequest);
   }
 
   @Test
@@ -393,9 +490,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
                         institutionPoints.creatorAffiliationPoints()))
             .toList();
     var newUpsertRequest =
-        UpsertRequestBuilder.fromRequest(upsertCandidateRequest)
-            .withPoints(samePointsWithDifferentScale)
-            .build();
+        fromRequest(upsertCandidateRequest).withPoints(samePointsWithDifferentScale).build();
     var updatedCandidate = upsert(newUpsertRequest);
     var updatedApproval = updatedCandidate.getApprovals().get(HARDCODED_INSTITUTION_ID);
 
@@ -434,7 +529,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
                 Collectors.toMap(VerifiedNviCreatorDto::id, VerifiedNviCreatorDto::affiliations));
 
     var newUpsertRequest =
-        UpsertRequestBuilder.fromRequest(upsertCandidateRequest)
+        fromRequest(upsertCandidateRequest)
             .withCreators(creators)
             .withVerifiedCreators(arguments.creators())
             .withInstanceType(arguments.type())

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
@@ -70,6 +70,8 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
 
+// Should be refactored, technical debt task: https://sikt.atlassian.net/browse/NP-48093
+@SuppressWarnings("PMD.CouplingBetweenObjects")
 class CandidateApprovalTest extends CandidateTestSetup {
 
   private static final String APPROVED = "APPROVED";
@@ -372,7 +374,6 @@ class CandidateApprovalTest extends CandidateTestSetup {
     assertThat(1, is(equalTo(updatedApprovals.size())));
   }
 
-  // FIXME: Test OK, but failing because of bug in the code
   @Test
   void shouldNotResetApprovalWhenOtherCreatorBecomesVerified() {
     var organization = scenario.getDefaultOrganization();
@@ -384,10 +385,6 @@ class CandidateApprovalTest extends CandidateTestSetup {
         Map.of(organization.id(), List.of(creator), otherOrganization.id(), List.of(otherCreator));
     var requestBuilder = setupApprovedCandidate(organization.id(), creatorMap);
 
-    var updatedCreator = new VerifiedNviCreatorDto(randomUri(), otherCreator.affiliations());
-    creatorMap =
-        Map.of(
-            organization.id(), List.of(creator), otherOrganization.id(), List.of(updatedCreator));
     var updatedRequest = requestBuilder.withCreatorsAndPoints(creatorMap).build();
     var updatedCandidate = scenario.upsertCandidate(updatedRequest);
 
@@ -449,18 +446,6 @@ class CandidateApprovalTest extends CandidateTestSetup {
     var subUnitId = topLevelOrg.hasPart().getFirst().id();
     return new UnverifiedNviCreatorDto(randomString(), List.of(subUnitId));
   }
-
-  //  private UpsertRequestBuilder setupApprovedCandidate(
-  //      Organization organization, Collection<NviCreatorDto> creators) {
-  //    var upsertRequest =
-  //        randomUpsertRequestBuilder()
-  //            .withCreatorsAndPoints(Map.of(organization.id(), creators))
-  //            .build();
-  //    scenario.setupOpenPeriod(upsertRequest.publicationDate().year());
-  //    var candidate = scenario.upsertCandidate(upsertRequest);
-  //    scenario.updateApprovalStatus(candidate, ApprovalStatus.APPROVED, organization.id());
-  //    return fromRequest(upsertRequest);
-  //  }
 
   private UpsertRequestBuilder setupApprovedCandidate(
       URI approvedByOrg, Map<URI, Collection<NviCreatorDto>> creatorMap) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -27,6 +27,22 @@ public class TestScenario extends LocalDynamoTestSetup {
   private final UriRetriever mockUriRetriever = mock(UriRetriever.class);
   private final OrganizationRetriever mockOrganizationRetriever =
       new OrganizationRetriever(mockUriRetriever);
+  private final Organization defaultOrganization;
+
+  public TestScenario() {
+    super();
+    this.candidateRepository = new CandidateRepository(localDynamo);
+    this.periodRepository = new PeriodRepository(localDynamo);
+    this.defaultOrganization = setupTopLevelOrganizationWithSubUnits();
+  }
+
+  public final Organization setupTopLevelOrganizationWithSubUnits() {
+    var topLevelId = randomUriWithSuffix("topLevel");
+    var subUnits = List.of(randomUriWithSuffix("subUnit1"), randomUriWithSuffix("subUnit2"));
+
+    mockOrganizationResponseForAffiliations(topLevelId, subUnits, mockUriRetriever);
+    return mockOrganizationRetriever.fetchOrganization(topLevelId);
+  }
 
   public CandidateRepository getCandidateRepository() {
     return candidateRepository;
@@ -38,14 +54,6 @@ public class TestScenario extends LocalDynamoTestSetup {
 
   public Organization getDefaultOrganization() {
     return defaultOrganization;
-  }
-
-  private Organization defaultOrganization;
-
-  public TestScenario() {
-    this.candidateRepository = new CandidateRepository(localDynamo);
-    this.periodRepository = new PeriodRepository(localDynamo);
-    this.defaultOrganization = setupTopLevelOrganizationWithSubUnits();
   }
 
   public void setupFuturePeriod(String year) {
@@ -70,13 +78,5 @@ public class TestScenario extends LocalDynamoTestSetup {
       Candidate candidate, ApprovalStatus status, URI topLevelOrganizationId) {
     var updateRequest = createUpdateStatusRequest(status, topLevelOrganizationId, randomString());
     return candidate.updateApprovalStatus(updateRequest, mockOrganizationRetriever);
-  }
-
-  public Organization setupTopLevelOrganizationWithSubUnits() {
-    var topLevelId = randomUriWithSuffix("topLevel");
-    var subUnits = List.of(randomUriWithSuffix("subUnit1"), randomUriWithSuffix("subUnit2"));
-
-    mockOrganizationResponseForAffiliations(topLevelId, subUnits, mockUriRetriever);
-    return mockOrganizationRetriever.fetchOrganization(topLevelId);
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -1,0 +1,82 @@
+package no.sikt.nva.nvi.common;
+
+import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliations;
+import static no.sikt.nva.nvi.test.TestUtils.randomUriWithSuffix;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.mockito.Mockito.mock;
+
+import java.net.URI;
+import java.util.List;
+import no.sikt.nva.nvi.common.client.OrganizationRetriever;
+import no.sikt.nva.nvi.common.client.model.Organization;
+import no.sikt.nva.nvi.common.db.CandidateRepository;
+import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
+import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
+import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
+import no.unit.nva.auth.uriretriever.UriRetriever;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
+public class TestScenario extends LocalDynamoTestSetup {
+
+  private final DynamoDbClient localDynamo = initializeTestDatabase();
+  private final CandidateRepository candidateRepository;
+  private final PeriodRepository periodRepository;
+  private final UriRetriever mockUriRetriever = mock(UriRetriever.class);
+  private final OrganizationRetriever mockOrganizationRetriever =
+      new OrganizationRetriever(mockUriRetriever);
+
+  public CandidateRepository getCandidateRepository() {
+    return candidateRepository;
+  }
+
+  public PeriodRepository getPeriodRepository() {
+    return periodRepository;
+  }
+
+  public Organization getDefaultOrganization() {
+    return defaultOrganization;
+  }
+
+  private Organization defaultOrganization;
+
+  public TestScenario() {
+    this.candidateRepository = new CandidateRepository(localDynamo);
+    this.periodRepository = new PeriodRepository(localDynamo);
+    this.defaultOrganization = setupTopLevelOrganizationWithSubUnits();
+  }
+
+  public void setupFuturePeriod(String year) {
+    PeriodRepositoryFixtures.setupFuturePeriod(year, periodRepository);
+  }
+
+  public void setupOpenPeriod(String year) {
+    PeriodRepositoryFixtures.setupOpenPeriod(year, periodRepository);
+  }
+
+  public void setupClosedPeriod(String year) {
+    PeriodRepositoryFixtures.setupClosedPeriod(year, periodRepository);
+  }
+
+  public Candidate upsertCandidate(UpsertCandidateRequest request) {
+    Candidate.upsert(request, candidateRepository, periodRepository);
+    return Candidate.fetchByPublicationId(
+        request::publicationId, candidateRepository, periodRepository);
+  }
+
+  public Candidate updateApprovalStatus(
+      Candidate candidate, ApprovalStatus status, URI topLevelOrganizationId) {
+    var updateRequest = createUpdateStatusRequest(status, topLevelOrganizationId, randomString());
+    return candidate.updateApprovalStatus(updateRequest, mockOrganizationRetriever);
+  }
+
+  public Organization setupTopLevelOrganizationWithSubUnits() {
+    var topLevelId = randomUriWithSuffix("topLevel");
+    var subUnits = List.of(randomUriWithSuffix("subUnit1"), randomUriWithSuffix("subUnit2"));
+
+    mockOrganizationResponseForAffiliations(topLevelId, subUnits, mockUriRetriever);
+    return mockOrganizationRetriever.fetchOrganization(topLevelId);
+  }
+}

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/UpsertRequestBuilder.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/UpsertRequestBuilder.java
@@ -212,9 +212,7 @@ public class UpsertRequestBuilder {
 
   private List<InstitutionPoints> getAllInstitutionPoints(
       Map<URI, Collection<NviCreatorDto>> creatorsPerInstitution) {
-    return creatorsPerInstitution.entrySet().stream()
-        .map(entry -> getInstitutionPoints(entry))
-        .toList();
+    return creatorsPerInstitution.entrySet().stream().map(this::getInstitutionPoints).toList();
   }
 
   private InstitutionPoints getInstitutionPoints(Map.Entry<URI, Collection<NviCreatorDto>> entry) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -51,6 +52,26 @@ public class OrganizationFixtures {
     var topLevelOrganization =
         Organization.builder().withId(topLevelInstitutionId).withHasPart(subUnits).build();
     mockOrganizationResponse(topLevelOrganization, uriRetriever);
+  }
+
+  public static void mockOrganizationResponseForAffiliations(
+      URI topLevelInstitutionId, Collection<URI> subUnitIds, UriRetriever uriRetriever) {
+    var leafNode = Organization.builder().withId(topLevelInstitutionId).build();
+    var subUnits =
+        subUnitIds.stream()
+            .map(subUnitId -> mockedSubOrganization(leafNode, subUnitId, uriRetriever))
+            .toList();
+    var topLevelOrganization =
+        Organization.builder().withId(topLevelInstitutionId).withHasPart(subUnits).build();
+    mockOrganizationResponse(topLevelOrganization, uriRetriever);
+  }
+
+  private static Organization mockedSubOrganization(
+      Organization topLevelOrganization, URI subUnitId, UriRetriever uriRetriever) {
+    var subUnitOrganization =
+        Organization.builder().withId(subUnitId).withPartOf(List.of(topLevelOrganization)).build();
+    mockOrganizationResponse(subUnitOrganization, uriRetriever);
+    return subUnitOrganization;
   }
 
   private static void mockOrganizationResponse(

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandlerTest.java
@@ -18,11 +18,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import no.sikt.nva.nvi.common.service.dto.ApprovalStatusDto;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.dto.CandidateOperation;
+import no.sikt.nva.nvi.common.service.dto.UnverifiedNviCreatorDto;
 import no.sikt.nva.nvi.common.service.dto.problem.UnverifiedCreatorFromOrganizationProblem;
 import no.sikt.nva.nvi.common.service.dto.problem.UnverifiedCreatorProblem;
+import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.validator.FakeViewingScopeValidator;
 import no.sikt.nva.nvi.rest.BaseCandidateRestHandlerTest;
 import no.unit.nva.testutils.HandlerRequestBuilder;
@@ -224,8 +227,7 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
   void shouldIncludeProblemsWhenCandidateHasUnverifiedCreator() throws IOException {
     var candidate = setupCandidateWithUnverifiedCreator();
     var request = createRequestWithCuratorAccess(candidate.getIdentifier().toString());
-    var unverifiedNviCreatorNames =
-        candidate.getPublicationDetails().getUnverifiedNviCreatorNames();
+    var unverifiedNviCreatorNames = getUnverifiedNviCreatorNames(candidate);
 
     var candidateDto = handleRequest(request);
 
@@ -235,6 +237,12 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
             new UnverifiedCreatorFromOrganizationProblem(unverifiedNviCreatorNames));
     var actualProblems = candidateDto.problems();
     assertEquals(actualProblems, expectedProblems);
+  }
+
+  private static Set<String> getUnverifiedNviCreatorNames(Candidate candidate) {
+    return candidate.getPublicationDetails().getUnverifiedCreators().stream()
+        .map(UnverifiedNviCreatorDto::name)
+        .collect(Collectors.toSet());
   }
 
   @Test


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48242

Rewrites update logic for `Candidate` to handle cases where only some approvals should be reset and not all of them, i.e. when a contributor has their identity verified. 