### PR TITLE
refactor: Improve use of test fixtures

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.events.batch;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -29,7 +30,6 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao;
 import no.sikt.nva.nvi.common.db.CandidateDao;
@@ -71,7 +71,7 @@ import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 
 // Should be refactored, technical debt task: https://sikt.atlassian.net/browse/NP-48093
 @SuppressWarnings("PMD.CouplingBetweenObjects")
-class EventBasedBatchScanHandlerTest extends LocalDynamoTestSetup {
+class EventBasedBatchScanHandlerTest {
 
   private static final int ONE_ENTRY_PER_EVENT = 1;
   private static final Map<String, String> START_FROM_BEGINNING = null;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -80,7 +80,7 @@ class EventBasedBatchScanHandlerTest {
   private static final int PAGE_SIZE = 4;
   private EventBasedBatchScanHandler handler;
   private ByteArrayOutputStream output;
-  private Context context;
+  private static final Context CONTEXT = mock(Context.class);
   private FakeEventBridgeClient eventBridgeClient;
   private NviCandidateRepositoryHelper candidateRepository;
   private NviPeriodRepositoryHelper periodRepository;
@@ -88,8 +88,7 @@ class EventBasedBatchScanHandlerTest {
   @BeforeEach
   public void init() {
     this.output = new ByteArrayOutputStream();
-    this.context = mock(Context.class);
-    when(context.getInvokedFunctionArn()).thenReturn(randomString());
+    when(CONTEXT.getInvokedFunctionArn()).thenReturn(randomString());
     this.eventBridgeClient = new FakeEventBridgeClient();
     var db = initializeTestDatabase();
     candidateRepository = new NviCandidateRepositoryHelper(db);
@@ -344,7 +343,7 @@ class EventBasedBatchScanHandlerTest {
   private void consumeEvents() {
     while (thereAreMoreEventsInEventBridge()) {
       var currentRequest = consumeLatestEmittedEvent();
-      handler.handleRequest(eventToInputStream(currentRequest), output, context);
+      handler.handleRequest(eventToInputStream(currentRequest), output, CONTEXT);
     }
   }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandlerTest.java
@@ -422,7 +422,8 @@ class EventBasedBatchScanHandlerTest {
         .boxed()
         .map(
             item ->
-                CandidateFixtures.randomApplicableCandidate(candidateRepository, periodRepository))
+                CandidateFixtures.setupRandomApplicableCandidate(
+                    candidateRepository, periodRepository))
         .map(
             a ->
                 a.createNote(

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.events.batch;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createNumberOfCandidatesForYear;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.getYearIndexStartMarker;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
@@ -25,7 +26,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.util.List;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -44,7 +44,7 @@ import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.eventbridge.model.PutEventsRequestEntry;
 import software.amazon.awssdk.services.sqs.model.SendMessageBatchRequestEntry;
 
-class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTestSetup {
+class ReEvaluateNviCandidatesHandlerTest {
 
   private static final int MAX_PAGE_SIZE = 1000;
   private static final int DEFAULT_PAGE_SIZE = 500;
@@ -62,8 +62,7 @@ class ReEvaluateNviCandidatesHandlerTest extends LocalDynamoTestSetup {
   void setUp() {
     outputStream = new ByteArrayOutputStream();
     sqsClient = new FakeSqsClient();
-    var localDynamoDbClient = initializeTestDatabase();
-    candidateRepository = new CandidateRepository(localDynamoDbClient);
+    candidateRepository = new CandidateRepository(initializeTestDatabase());
     var nviService = new BatchScanUtil(candidateRepository);
     this.eventBridgeClient = new FakeEventBridgeClient();
     handler =

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerWithLocalDynamoTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/RequeueDlqHandlerWithLocalDynamoTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.events.batch;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createCandidateDao;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidateWithYear;
 import static no.sikt.nva.nvi.events.batch.RequeueDlqTestUtils.generateMessages;
@@ -10,7 +11,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.amazonaws.services.lambda.runtime.Context;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
@@ -21,7 +21,7 @@ import software.amazon.awssdk.services.sqs.SqsClient;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest;
 import software.amazon.awssdk.services.sqs.model.ReceiveMessageResponse;
 
-class RequeueDlqHandlerWithLocalDynamoTest extends LocalDynamoTestSetup {
+class RequeueDlqHandlerWithLocalDynamoTest {
 
   public static final Context CONTEXT = mock(Context.class);
   public static final int YEAR = 2021;
@@ -35,8 +35,7 @@ class RequeueDlqHandlerWithLocalDynamoTest extends LocalDynamoTestSetup {
   void setUp() {
     sqsClient = setupSqsClient();
     client = new NviQueueClient(sqsClient);
-    var localDynamoDbClient = initializeTestDatabase();
-    candidateRepository = new CandidateRepository(localDynamoDbClient);
+    candidateRepository = new CandidateRepository(initializeTestDatabase());
     periodRepository = PeriodRepositoryFixtures.periodRepositoryReturningOpenedPeriod(YEAR);
   }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.events.cristin;
 
 import static java.util.UUID.randomUUID;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.events.cristin.CristinMapper.AFFILIATION_DELIMITER;
 import static no.sikt.nva.nvi.events.cristin.CristinMapper.API_HOST;
 import static no.sikt.nva.nvi.events.cristin.CristinMapper.PERSISTED_RESOURCES_BUCKET;
@@ -22,7 +23,6 @@ import java.net.URI;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.NviPeriodDao.DbNviPeriod;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
@@ -41,7 +41,7 @@ import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class CristinNviReportEventConsumerTest extends LocalDynamoTestSetup {
+class CristinNviReportEventConsumerTest {
 
   public static final LocalDate DATE_CONTROLLED = LocalDate.now();
   public static final String STATUS_CONTROLLED = "J";
@@ -55,7 +55,7 @@ class CristinNviReportEventConsumerTest extends LocalDynamoTestSetup {
 
   @BeforeEach
   void setup() {
-    localDynamo = initializeTestDatabase();
+    var localDynamo = initializeTestDatabase();
     candidateRepository = new CandidateRepository(localDynamo);
     periodRepository = new PeriodRepository(localDynamo);
     var s3Client = new FakeS3Client();

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -845,7 +845,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       // Then it should be evaluated as a Candidate
       var testScenario = getCandidateScenario();
       var year = HARDCODED_JSON_PUBLICATION_DATE.year();
-      setupOpenPeriod(year, periodRepository);
+      setupOpenPeriod(scenario, year);
 
       handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
@@ -860,7 +860,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       // When the publication is evaluated
       // Then it should be evaluated as a Candidate
       var year = HARDCODED_JSON_PUBLICATION_DATE.year();
-      setupClosedPeriod(year, periodRepository);
+      setupClosedPeriod(scenario, year);
       setupCandidateMatchingPublication(buildExpectedPublication());
       var testScenario = getCandidateScenario();
 
@@ -878,7 +878,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       // When the publication is updated to be no longer applicable
       // Then it should be re-evaluated as a NonCandidate
       var year = HARDCODED_JSON_PUBLICATION_DATE.year();
-      setupClosedPeriod(year, periodRepository);
+      setupClosedPeriod(scenario, year);
       setupCandidateMatchingPublication(buildExpectedPublication());
       publicationInstanceType = "ComicBook";
       var testScenario = getNonCandidateScenario();
@@ -898,7 +898,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       // When the publication is evaluated
       // Then it should be evaluated as a NonCandidate
       var year = HARDCODED_JSON_PUBLICATION_DATE.year();
-      setupClosedPeriod(year, periodRepository);
+      setupClosedPeriod(scenario, year);
       var testScenario = getNonCandidateScenario();
 
       handler.handleRequest(testScenario.event(), CONTEXT);

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -124,7 +124,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
   }
@@ -135,7 +135,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var fileUri = setupPublicationWithInvalidYear(invalidYear);
     var event = createEvent(new PersistedResourceMessage(fileUri));
     final var logAppender = LogUtils.getTestingAppender(EvaluatorService.class);
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var expectedLogMessage =
         String.format(
             "Skipping evaluation due to invalid year format %s.",
@@ -151,9 +151,9 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var resourceFileUri = setupCandidate(year);
     periodRepository = PeriodRepositoryFixtures.periodRepositoryReturningOpenedPeriod(year);
     setupEvaluatorService(periodRepository);
-    handler = new EvaluateNviCandidateHandler(evaluatorService, queueClient, env);
+    handler = new EvaluateNviCandidateHandler(evaluatorService, queueClient, ENVIRONMENT);
     var event = createEvent(new PersistedResourceMessage(resourceFileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(resourceFileUri)));
   }
@@ -167,7 +167,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
   }
@@ -184,7 +184,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
             UnixPath.of("evaluator/candidate_verifiedCreator_with_nonNviInstitution.json"),
             content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var candidate = (NviCandidate) messageBody.candidate();
     assertEquals(1, candidate.institutionPoints().size());
@@ -196,7 +196,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), ACADEMIC_ARTICLE);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var expectedPoints = BigDecimal.valueOf(1).setScale(SCALE, ROUNDING_MODE);
     var expectedEvaluatedMessage =
@@ -211,7 +211,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(ACADEMIC_CHAPTER_PATH);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_CHAPTER_PATH), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var expectedPoints = BigDecimal.valueOf(1).setScale(SCALE, ROUNDING_MODE);
     var expectedEvaluatedMessage =
@@ -226,7 +226,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(ACADEMIC_MONOGRAPH_JSON_PATH);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_MONOGRAPH_JSON_PATH), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var expectedPoints = BigDecimal.valueOf(5).setScale(SCALE, ROUNDING_MODE);
     var expectedEvaluatedMessage =
@@ -246,7 +246,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(ACADEMIC_COMMENTARY_JSON_PATH);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_COMMENTARY_JSON_PATH), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var expectedPoints = BigDecimal.valueOf(5).setScale(SCALE, ROUNDING_MODE);
     var expectedEvaluatedMessage =
@@ -267,7 +267,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(ACADEMIC_LITERATURE_REVIEW_JSON_PATH);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_LITERATURE_REVIEW_JSON_PATH), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var expectedPoints = BigDecimal.valueOf(1).setScale(SCALE, ROUNDING_MODE);
     var expectedEvaluatedMessage =
@@ -281,7 +281,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), ACADEMIC_ARTICLE);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var candidate = (NviCandidate) messageBody.candidate();
     assertThat(candidate.institutionPoints(), notNullValue());
@@ -295,7 +295,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), ACADEMIC_ARTICLE);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var candidate = (NviCandidate) messageBody.candidate();
     assertThat(candidate.institutionPoints(), notNullValue());
@@ -311,7 +311,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
   }
@@ -325,7 +325,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
   }
@@ -338,7 +338,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
   }
@@ -349,7 +349,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(ACADEMIC_MONOGRAPH_JSON_PATH);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_MONOGRAPH_JSON_PATH), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
   }
@@ -360,7 +360,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(ACADEMIC_LITERATURE_REVIEW_JSON_PATH);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_LITERATURE_REVIEW_JSON_PATH), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
   }
@@ -371,7 +371,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
     assertThat(nonCandidate.publicationId(), is(equalTo(HARDCODED_PUBLICATION_ID)));
   }
@@ -382,7 +382,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
     assertThat(nonCandidate.publicationId(), is(equalTo(HARDCODED_PUBLICATION_ID)));
   }
@@ -393,7 +393,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
     assertThat(nonCandidate.publicationId(), is(equalTo(HARDCODED_PUBLICATION_ID)));
   }
@@ -404,7 +404,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
     assertThat(nonCandidate.publicationId(), is(equalTo(HARDCODED_PUBLICATION_ID)));
   }
@@ -415,7 +415,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
     assertThat(nonCandidate.publicationId(), is(equalTo(HARDCODED_PUBLICATION_ID)));
   }
@@ -426,7 +426,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
     assertThat(nonCandidate.publicationId(), is(equalTo(HARDCODED_PUBLICATION_ID)));
   }
@@ -435,7 +435,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
   void shouldThrowExceptionIfFileDoesntExist() {
     var event =
         createEvent(new PersistedResourceMessage(UriWrapper.fromUri("s3://dummy").getUri()));
-    assertThrows(RuntimeException.class, () -> handler.handleRequest(event, context));
+    assertThrows(RuntimeException.class, () -> handler.handleRequest(event, CONTEXT));
   }
 
   @Test
@@ -443,7 +443,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     mockCristinResponseAndCustomerApiResponseForNviInstitution(notFoundResponse);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), ACADEMIC_ARTICLE);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var nonCandidate = (NonNviCandidate) getMessageBody().candidate();
     assertThat(nonCandidate.publicationId(), is(equalTo(HARDCODED_PUBLICATION_ID)));
   }
@@ -455,7 +455,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), ACADEMIC_ARTICLE);
     var event = createEvent(new PersistedResourceMessage(fileUri));
     var appender = LogUtils.getTestingAppenderForRootLogger();
-    assertThrows(RuntimeException.class, () -> handler.handleRequest(event, context));
+    assertThrows(RuntimeException.class, () -> handler.handleRequest(event, CONTEXT));
     assertThat(appender.getMessages(), containsString(ERROR_COULD_NOT_FETCH_CRISTIN_ORG));
   }
 
@@ -465,7 +465,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), ACADEMIC_ARTICLE);
     var event = createEvent(new PersistedResourceMessage(fileUri));
     var appender = LogUtils.getTestingAppenderForRootLogger();
-    assertThrows(RuntimeException.class, () -> handler.handleRequest(event, context));
+    assertThrows(RuntimeException.class, () -> handler.handleRequest(event, CONTEXT));
     assertThat(appender.getMessages(), containsString("status code: 500"));
   }
 
@@ -474,7 +474,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     mockCristinResponseAndCustomerApiResponseForNviInstitution(okResponse);
     var fileUri = s3Driver.insertFile(UnixPath.of(ACADEMIC_ARTICLE_PATH), ACADEMIC_ARTICLE);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = (NviCandidate) getMessageBody().candidate();
     assertThat(candidate.publicationBucketUri(), is(equalTo(fileUri)));
   }
@@ -487,7 +487,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var expectedPoints = BigDecimal.valueOf(5).setScale(SCALE, ROUNDING_MODE);
     var expectedEvaluatedMessage =
@@ -509,7 +509,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     var content = IoUtils.inputStreamFromResources(path);
     var fileUri = s3Driver.insertFile(UnixPath.of(path), content);
     var event = createEvent(new PersistedResourceMessage(fileUri));
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var messageBody = getMessageBody();
     var expectedPoints = ONE.setScale(SCALE, ROUNDING_MODE);
     var expectedEvaluatedMessage =
@@ -734,7 +734,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     void shouldIdentifyCandidateWithOnlyVerifiedNviCreators() throws IOException {
       var testScenario = getCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -751,7 +751,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
                   CRISTIN_NVI_ORG_TOP_LEVEL_ID, expectedTotalPoints, emptyList()));
       var testScenario = getCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -763,7 +763,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       verifiedContributors = List.of(verifiedContributor);
       var testScenario = getCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -776,7 +776,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       unverifiedContributors = List.of(unnamedContributor);
       var testScenario = getNonCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -799,7 +799,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       creatorShareCount = 2;
       var testScenario = getCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -817,7 +817,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       verifiedContributors = List.of(contributor);
       var testScenario = getCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -831,7 +831,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       verifiedContributors = List.of(swedishContributor);
       var testScenario = getNonCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -847,7 +847,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       var year = HARDCODED_JSON_PUBLICATION_DATE.year();
       setupOpenPeriod(year, periodRepository);
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -864,7 +864,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       setupCandidateMatchingPublication(buildExpectedPublication());
       var testScenario = getCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -883,7 +883,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       publicationInstanceType = "ComicBook";
       var testScenario = getNonCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -901,7 +901,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       setupClosedPeriod(year, periodRepository);
       var testScenario = getNonCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
 
       assertEquals(testScenario.expectedEvaluatedMessage(), messageBody);
@@ -919,7 +919,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       publicationBuilder = publicationBuilder.withPublicationDate(publicationDate);
       var testScenario = getNonCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
       var messageBody = getMessageBody();
       var nviPeriod = periodRepository.findByPublishingYear(year);
 
@@ -941,7 +941,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
           publicationBuilder.withId(existingCandidateDao.candidate().publicationId());
       var testScenario = getCandidateScenario();
 
-      handler.handleRequest(testScenario.event(), context);
+      handler.handleRequest(testScenario.event(), CONTEXT);
 
       assertEquals(0, queueClient.getSentMessages().size());
     }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithCristinDataTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithCristinDataTest.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.events.evaluator;
 
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.events.evaluator.TestUtils.createEvent;
 import static no.sikt.nva.nvi.test.TestUtils.createResponse;
@@ -50,7 +49,7 @@ class EvaluateNviCandidateWithCristinDataTest extends EvaluationTest {
 
   @BeforeEach
   void setup() {
-    setupOpenPeriod("2022", periodRepository);
+    scenario.setupOpenPeriod("2022");
   }
 
   @Test
@@ -59,7 +58,7 @@ class EvaluateNviCandidateWithCristinDataTest extends EvaluationTest {
     mockCristinApiResponsesForAllSubUnitsInAcademicArticle();
     mockCustomerApi();
     var event = setupSqsEvent("evaluator/cristin_candidate_2022_academicArticle.json");
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = getMessageBody();
     assertThat(
         getPointsForInstitution(candidate, NTNU_TOP_LEVEL_ORG_ID),
@@ -78,7 +77,7 @@ class EvaluateNviCandidateWithCristinDataTest extends EvaluationTest {
     mockCustomerApi(UIO_TOP_LEVEL_ORG_ID);
 
     var event = setupSqsEvent("evaluator/cristin_candidate_2022_academicMonograph.json");
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = getMessageBody();
     assertThat(
         getPointsForInstitution(candidate, UIO_TOP_LEVEL_ORG_ID),
@@ -94,7 +93,7 @@ class EvaluateNviCandidateWithCristinDataTest extends EvaluationTest {
     mockCustomerApi(NTNU_TOP_LEVEL_ORG_ID);
 
     var event = setupSqsEvent("evaluator/cristin_candidate_2022_academicLiteratureReview.json");
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = getMessageBody();
     assertThat(
         getPointsForInstitution(candidate, NTNU_TOP_LEVEL_ORG_ID),
@@ -109,7 +108,7 @@ class EvaluateNviCandidateWithCristinDataTest extends EvaluationTest {
     mockCustomerApi(SINTEF_TOP_LEVEL_ORG_ID);
 
     var event = setupSqsEvent("evaluator/cristin_candidate_2022_academicChapter.json");
-    handler.handleRequest(event, context);
+    handler.handleRequest(event, CONTEXT);
     var candidate = getMessageBody();
     assertThat(
         getPointsForInstitution(candidate, NTNU_TOP_LEVEL_ORG_ID),

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithCristinDataTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithCristinDataTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.events.evaluator;
 
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.events.evaluator.TestUtils.createEvent;
 import static no.sikt.nva.nvi.test.TestUtils.createResponse;
@@ -49,7 +50,7 @@ class EvaluateNviCandidateWithCristinDataTest extends EvaluationTest {
 
   @BeforeEach
   void setup() {
-    scenario.setupOpenPeriod("2022");
+    setupOpenPeriod(scenario, "2022");
   }
 
   @Test

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.events.evaluator;
 
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.test.TestConstants.HARDCODED_JSON_PUBLICATION_DATE;
 import static no.sikt.nva.nvi.test.TestUtils.createResponse;
 import static org.mockito.Mockito.mock;
@@ -73,7 +74,7 @@ public class EvaluationTest {
     uriRetriever = scenario.getUriRetriever();
     candidateRepository = scenario.getCandidateRepository();
     periodRepository = scenario.getPeriodRepository();
-    scenario.setupOpenPeriod(HARDCODED_JSON_PUBLICATION_DATE.year());
+    setupOpenPeriod(scenario, HARDCODED_JSON_PUBLICATION_DATE.year());
 
     setupHttpResponses();
     mockSecretManager();

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.events.evaluator;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.test.TestConstants.HARDCODED_JSON_PUBLICATION_DATE;
 import static no.sikt.nva.nvi.test.TestUtils.createResponse;
@@ -11,7 +12,6 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URI;
 import java.net.http.HttpResponse;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.S3StorageReader;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -30,7 +30,7 @@ import nva.commons.core.Environment;
 import nva.commons.core.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 
-public class EvaluationTest extends LocalDynamoTestSetup {
+public class EvaluationTest {
 
   protected static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
@@ -1,7 +1,5 @@
 package no.sikt.nva.nvi.events.evaluator;
 
-import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.test.TestConstants.HARDCODED_JSON_PUBLICATION_DATE;
 import static no.sikt.nva.nvi.test.TestUtils.createResponse;
 import static org.mockito.Mockito.mock;
@@ -13,7 +11,7 @@ import java.math.RoundingMode;
 import java.net.URI;
 import java.net.http.HttpResponse;
 import no.sikt.nva.nvi.common.S3StorageReader;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
+import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.queue.FakeSqsClient;
@@ -28,18 +26,20 @@ import no.unit.nva.stubs.FakeS3Client;
 import no.unit.nva.stubs.FakeSecretsManagerClient;
 import nva.commons.core.Environment;
 import nva.commons.core.StringUtils;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
 public class EvaluationTest {
 
   protected static final RoundingMode ROUNDING_MODE = RoundingMode.HALF_UP;
-
+  protected static final Environment ENVIRONMENT = mock(Environment.class);
+  protected static final Context CONTEXT = mock(Context.class);
   protected static final int SCALE = 4;
 
   protected static final String BUCKET_NAME = "ignoredBucket";
   protected static final String CUSTOMER_API_NVI_RESPONSE =
       "{" + "\"nviInstitution\" : \"true\"" + "}";
-  protected final Context context = mock(Context.class);
+  protected TestScenario scenario;
   protected HttpResponse<String> notFoundResponse;
   protected HttpResponse<String> internalServerErrorResponse;
   protected HttpResponse<String> okResponse;
@@ -49,7 +49,6 @@ public class EvaluationTest {
   protected UriRetriever uriRetriever;
   protected FakeSqsClient queueClient;
   protected CandidateRepository candidateRepository;
-  protected Environment env;
   protected S3StorageReader storageReader;
   protected PeriodRepository periodRepository;
   protected EvaluatorService evaluatorService;
@@ -62,30 +61,33 @@ public class EvaluationTest {
         .orElseThrow();
   }
 
+  @BeforeAll
+  static void init() {
+    when(ENVIRONMENT.readEnv("CANDIDATE_QUEUE_URL")).thenReturn("My test candidate queue url");
+    when(ENVIRONMENT.readEnv("CANDIDATE_DLQ_URL")).thenReturn("My test candidate dlq url");
+  }
+
   @BeforeEach
   void commonSetup() {
-    env = mock(Environment.class);
-    when(env.readEnv("CANDIDATE_QUEUE_URL")).thenReturn("My test candidate queue url");
-    when(env.readEnv("CANDIDATE_DLQ_URL")).thenReturn("My test candidate dlq url");
+    scenario = new TestScenario();
+    uriRetriever = scenario.getUriRetriever();
+    candidateRepository = scenario.getCandidateRepository();
+    periodRepository = scenario.getPeriodRepository();
+    scenario.setupOpenPeriod(HARDCODED_JSON_PUBLICATION_DATE.year());
+
     setupHttpResponses();
     mockSecretManager();
     var s3Client = new FakeS3Client();
     authorizedBackendUriRetriever = mock(AuthorizedBackendUriRetriever.class);
     queueClient = new FakeSqsClient();
     s3Driver = new S3Driver(s3Client, BUCKET_NAME);
-    var dynamoDbClient = initializeTestDatabase();
-    uriRetriever = mock(UriRetriever.class);
     storageReader = new S3StorageReader(s3Client, BUCKET_NAME);
-    periodRepository = new PeriodRepository(dynamoDbClient);
-    setupOpenPeriod(HARDCODED_JSON_PUBLICATION_DATE.year(), periodRepository);
     var calculator = new CreatorVerificationUtil(authorizedBackendUriRetriever, uriRetriever);
-    var organizationRetriever = new OrganizationRetriever(uriRetriever);
-    var pointCalculator = new PointService(organizationRetriever);
-    candidateRepository = new CandidateRepository(dynamoDbClient);
+    var pointCalculator = new PointService(scenario.getOrganizationRetriever());
     evaluatorService =
         new EvaluatorService(
             storageReader, calculator, pointCalculator, candidateRepository, periodRepository);
-    handler = new EvaluateNviCandidateHandler(evaluatorService, queueClient, env);
+    handler = new EvaluateNviCandidateHandler(evaluatorService, queueClient, ENVIRONMENT);
   }
 
   private static void mockSecretManager() {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -147,7 +147,7 @@ class UpsertNviCandidateHandlerTest {
   @Test
   void shouldUpdateExistingNviCandidateToNonCandidateWhenIncomingEventIsNonCandidate() {
     var candidate =
-        CandidateFixtures.randomApplicableCandidate(candidateRepository, periodRepository);
+        CandidateFixtures.setupRandomApplicableCandidate(candidateRepository, periodRepository);
     var eventMessage = nonCandidateMessageForExistingCandidate(candidate);
     handler.handleRequest(createEvent(eventMessage), CONTEXT);
     var updatedCandidate =

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.events.persist;
 
 import static java.util.Collections.emptyList;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.model.InstanceTypeFixtures.randomInstanceType;
 import static no.sikt.nva.nvi.test.TestUtils.generatePublicationId;
@@ -36,7 +37,6 @@ import java.time.Year;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
@@ -74,7 +74,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 // Should be refactored, technical debt task: https://sikt.atlassian.net/browse/NP-48093
 @SuppressWarnings("PMD.CouplingBetweenObjects")
-class UpsertNviCandidateHandlerTest extends LocalDynamoTestSetup {
+class UpsertNviCandidateHandlerTest {
 
   public static final Context CONTEXT = mock(Context.class);
   public static final String ERROR_MESSAGE_BODY_INVALID = "Message body invalid";
@@ -89,8 +89,7 @@ class UpsertNviCandidateHandlerTest extends LocalDynamoTestSetup {
 
   @BeforeEach
   void setup() {
-    localDynamo = initializeTestDatabase();
-    candidateRepository = new CandidateRepository(localDynamo);
+    candidateRepository = new CandidateRepository(initializeTestDatabase());
     periodRepository =
         PeriodRepositoryFixtures.periodRepositoryReturningOpenedPeriod(Year.now().getValue());
     queueClient = mock(QueueClient.class);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.index;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
-import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.QueueServiceTestUtils.createEvent;
 import static no.sikt.nva.nvi.common.QueueServiceTestUtils.createEventWithOneInvalidRecord;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
@@ -58,9 +57,9 @@ import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.S3StorageReader;
+import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.model.CandidateFixtures;
 import no.sikt.nva.nvi.common.queue.FakeSqsClient;
@@ -129,11 +128,13 @@ class IndexDocumentHandlerTest {
 
   @BeforeEach
   void setup() {
+    var scenario = new TestScenario();
+    scenario.setupOpenPeriod(SOME_REPORTING_YEAR);
+    candidateRepository = scenario.getCandidateRepository();
+    periodRepository = scenario.getPeriodRepository();
+
     s3Reader = new S3Driver(s3Client, BUCKET_NAME);
     s3Writer = new S3Driver(s3Client, BUCKET_NAME);
-    candidateRepository = new CandidateRepository(initializeTestDatabase());
-    periodRepository =
-        PeriodRepositoryFixtures.periodRepositoryReturningOpenedPeriod(SOME_REPORTING_YEAR);
     uriRetriever = mock(UriRetriever.class);
     sqsClient = new FakeSqsClient();
     handler =

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.index;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.QueueServiceTestUtils.createEvent;
 import static no.sikt.nva.nvi.common.QueueServiceTestUtils.createEventWithOneInvalidRecord;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
@@ -56,7 +57,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Stream;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.S3StorageReader;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
@@ -94,7 +94,7 @@ import software.amazon.awssdk.services.sqs.model.SqsException;
 
 // Should be refactored, technical debt task: https://sikt.atlassian.net/browse/NP-48093
 @SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects"})
-class IndexDocumentHandlerTest extends LocalDynamoTestSetup {
+class IndexDocumentHandlerTest {
 
   public static final int SOME_REPORTING_YEAR = 2023;
   private static final String JSON_PTR_CONTRIBUTOR = "/publicationDetails/contributors";
@@ -131,8 +131,7 @@ class IndexDocumentHandlerTest extends LocalDynamoTestSetup {
   void setup() {
     s3Reader = new S3Driver(s3Client, BUCKET_NAME);
     s3Writer = new S3Driver(s3Client, BUCKET_NAME);
-    var localDynamoDbClient = initializeTestDatabase();
-    candidateRepository = new CandidateRepository(localDynamoDbClient);
+    candidateRepository = new CandidateRepository(initializeTestDatabase());
     periodRepository =
         PeriodRepositoryFixtures.periodRepositoryReturningOpenedPeriod(SOME_REPORTING_YEAR);
     uriRetriever = mock(UriRetriever.class);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -891,7 +891,7 @@ class IndexDocumentHandlerTest {
   }
 
   private Candidate randomApplicableCandidate() {
-    return CandidateFixtures.randomApplicableCandidate(candidateRepository, periodRepository);
+    return CandidateFixtures.setupRandomApplicableCandidate(candidateRepository, periodRepository);
   }
 
   private Candidate randomApplicableCandidate(URI topLevelOrg, URI affiliation) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -10,6 +10,7 @@ import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandid
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.db.DbApprovalStatusFixtures.randomApproval;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidateBuilder;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_AFFILIATIONS;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_BODY;
 import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_TYPE;
@@ -129,7 +130,7 @@ class IndexDocumentHandlerTest {
   @BeforeEach
   void setup() {
     var scenario = new TestScenario();
-    scenario.setupOpenPeriod(SOME_REPORTING_YEAR);
+    setupOpenPeriod(scenario, SOME_REPORTING_YEAR);
     candidateRepository = scenario.getCandidateRepository();
     periodRepository = scenario.getPeriodRepository();
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
@@ -196,6 +196,6 @@ class UpdateIndexHandlerTest {
   }
 
   private Candidate randomApplicableCandidate() {
-    return CandidateFixtures.randomApplicableCandidate(candidateRepository, periodRepository);
+    return CandidateFixtures.setupRandomApplicableCandidate(candidateRepository, periodRepository);
   }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/UpdateIndexHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.index;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.QueueServiceTestUtils.invalidSqsMessage;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.NVI_CONTEXT;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.createPath;
@@ -22,7 +23,6 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.net.URI;
 import java.util.List;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.S3StorageReader;
 import no.sikt.nva.nvi.common.StorageReader;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -44,7 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.opensearch.client.opensearch._types.OpenSearchException;
 import software.amazon.awssdk.services.s3.S3Client;
 
-class UpdateIndexHandlerTest extends LocalDynamoTestSetup {
+class UpdateIndexHandlerTest {
 
   public static final Context CONTEXT = mock(Context.class);
   public static final Environment ENVIRONMENT = new Environment();

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -112,7 +112,7 @@ class MigrationTests {
 
   private Candidate setupCandidateWithApprovalAndNotes() {
     var candidate =
-        CandidateFixtures.randomApplicableCandidate(candidateRepository, periodRepository)
+        CandidateFixtures.setupRandomApplicableCandidate(candidateRepository, periodRepository)
             .createNote(createNoteRequest(randomString(), randomString()), candidateRepository);
 
     return candidate.updateApproval(

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.common;
 
 import static java.util.Collections.emptyList;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.RequestFixtures.createNoteRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidate;
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 
-class MigrationTests extends LocalDynamoTestSetup {
+class MigrationTests {
 
   public static final int DEFAULT_PAGE_SIZE = 700;
   private CandidateRepository candidateRepository;

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.common.db;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.scanDB;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidateBuilder;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -13,7 +15,6 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.service.dto.UnverifiedNviCreatorDto;
 import no.sikt.nva.nvi.common.service.dto.VerifiedNviCreatorDto;
 import no.sikt.nva.nvi.common.service.model.Candidate;
@@ -23,9 +24,11 @@ import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
-class CandidateRepositoryTest extends LocalDynamoTestSetup {
+class CandidateRepositoryTest {
 
+  private DynamoDbClient localDynamo;
   private CandidateRepository candidateRepository;
   private PeriodRepository periodRepository;
 
@@ -43,7 +46,7 @@ class CandidateRepositoryTest extends LocalDynamoTestSetup {
     var candidate2 = randomCandidateBuilder(true).publicationId(publicationId).build();
     candidateRepository.create(candidate1, List.of());
     assertThrows(RuntimeException.class, () -> candidateRepository.create(candidate2, List.of()));
-    assertThat(scanDB().count(), is(equalTo(2)));
+    assertThat(scanDB(localDynamo).count(), is(equalTo(2)));
   }
 
   @Test
@@ -59,7 +62,7 @@ class CandidateRepositoryTest extends LocalDynamoTestSetup {
     var updatedDbCandidate =
         candidateRepository.findCandidateById(candidateDao.identifier()).get().candidate();
 
-    assertThat(scanDB().count(), is(equalTo(3)));
+    assertThat(scanDB(localDynamo).count(), is(equalTo(3)));
     assertThat(updatedDbCandidate, is(not(equalTo(originalDbCandidate))));
   }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/PeriodRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/PeriodRepositoryTest.java
@@ -1,18 +1,21 @@
 package no.sikt.nva.nvi.common.db;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.scanDB;
 import static no.sikt.nva.nvi.common.db.DbNviPeriodFixtures.randomNviPeriodBuilder;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.test.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
-class PeriodRepositoryTest extends LocalDynamoTestSetup {
+class PeriodRepositoryTest {
 
   private PeriodRepository periodRepository;
+  private DynamoDbClient localDynamo;
 
   @BeforeEach
   void setUp() {
@@ -31,7 +34,7 @@ class PeriodRepositoryTest extends LocalDynamoTestSetup {
     var nviPeriod2 = randomNviPeriodBuilder().publishingYear(year).modifiedBy(user2).build();
     periodRepository.save(nviPeriod1);
     periodRepository.save(nviPeriod2);
-    var tableItemCount = scanDB().count();
+    var tableItemCount = scanDB(localDynamo).count();
     assertThat(tableItemCount, is(equalTo(1)));
 
     var fetched = periodRepository.findByPublishingYear(year);

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
@@ -38,8 +38,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import no.sikt.nva.nvi.common.TestScenario;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
@@ -60,7 +58,6 @@ import no.sikt.nva.nvi.common.service.model.InstitutionPoints.CreatorAffiliation
 import no.sikt.nva.nvi.common.service.model.PublicationChannel;
 import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
-import no.unit.nva.auth.uriretriever.UriRetriever;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
@@ -86,9 +83,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   private static final InstanceType HARDCODED_INSTANCE_TYPE = InstanceType.ACADEMIC_ARTICLE;
   private static final BigDecimal HARDCODED_POINTS =
       BigDecimal.ONE.setScale(EXPECTED_SCALE, EXPECTED_ROUNDING_MODE);
-  private OrganizationRetriever mockOrganizationRetriever;
   private URI topLevelOrganizationId;
-  private TestScenario scenario;
 
   public static Stream<Arguments> statusProvider() {
     return Stream.of(
@@ -115,13 +110,10 @@ class CandidateApprovalTest extends CandidateTestSetup {
 
   @BeforeEach
   void setUp() {
-    var mockUriRetriever = mock(UriRetriever.class);
-    mockOrganizationRetriever = new OrganizationRetriever(mockUriRetriever);
     topLevelOrganizationId = randomUriWithSuffix("topLevelOrganization");
     mockOrganizationResponseForAffiliation(topLevelOrganizationId, null, mockUriRetriever);
     mockOrganizationResponseForAffiliation(
         HARDCODED_INSTITUTION_ID, HARDCODED_SUBUNIT_ID, mockUriRetriever);
-    scenario = new TestScenario();
   }
 
   @ParameterizedTest(name = "Should update from old status {0} to new status {1}")

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
@@ -7,11 +7,12 @@ import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBui
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandidateRequest;
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.periodRepositoryReturningClosedPeriod;
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.periodRepositoryReturningNotOpenedPeriod;
-import static no.sikt.nva.nvi.common.model.CandidateFixtures.randomApplicableCandidate;
-import static no.sikt.nva.nvi.common.model.CandidateFixtures.setupApprovedCandidate;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
+import static no.sikt.nva.nvi.common.model.CandidateFixtures.randomApplicableCandidateRequestBuilder;
+import static no.sikt.nva.nvi.common.model.CandidateFixtures.setupRandomApplicableCandidate;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.sikt.nva.nvi.test.TestUtils.randomUriWithSuffix;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -27,19 +28,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import no.sikt.nva.nvi.common.UpsertRequestBuilder;
 import no.sikt.nva.nvi.common.client.model.Organization;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.model.ChannelType;
 import no.sikt.nva.nvi.common.model.InvalidNviCandidateException;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
@@ -85,7 +84,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
       BigDecimal.ONE.setScale(EXPECTED_SCALE, EXPECTED_ROUNDING_MODE);
   private URI topLevelOrganizationId;
 
-  public static Stream<Arguments> statusProvider() {
+  private static Stream<Arguments> statusProvider() {
     return Stream.of(
         Arguments.of(ApprovalStatus.PENDING, ApprovalStatus.REJECTED),
         Arguments.of(ApprovalStatus.PENDING, ApprovalStatus.APPROVED),
@@ -93,19 +92,6 @@ class CandidateApprovalTest extends CandidateTestSetup {
         Arguments.of(ApprovalStatus.APPROVED, ApprovalStatus.REJECTED),
         Arguments.of(ApprovalStatus.REJECTED, ApprovalStatus.PENDING),
         Arguments.of(ApprovalStatus.REJECTED, ApprovalStatus.APPROVED));
-  }
-
-  public static Stream<Arguments> periodRepositoryProvider() {
-    var year = ZonedDateTime.now().getYear();
-    return Stream.of(
-        Arguments.of(
-            Named.of(
-                "Repository returning closed period", periodRepositoryReturningClosedPeriod(year))),
-        Arguments.of(
-            Named.of(
-                "Repository returning period not opened yet",
-                periodRepositoryReturningNotOpenedPeriod(year))),
-        Arguments.of(Named.of("Mocked repository", mock(PeriodRepository.class))));
   }
 
   @BeforeEach
@@ -121,7 +107,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   void shouldUpdateStatusWhenUpdateStatusRequestValid(
       ApprovalStatus oldStatus, ApprovalStatus newStatus) {
     var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    Candidate.upsert(upsertCandidateRequest, candidateRepository, periodRepository);
+    scenario.upsertCandidate(upsertCandidateRequest);
     var existingCandidate =
         Candidate.fetchByPublicationId(
             upsertCandidateRequest::publicationId, candidateRepository, periodRepository);
@@ -138,7 +124,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
       names = {"REJECTED", APPROVED})
   void shouldResetApprovalWhenChangingToPending(ApprovalStatus oldStatus) {
     var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     var assignee = randomString();
     candidate.updateApprovalAssignee(new UpdateAssigneeRequest(HARDCODED_INSTITUTION_ID, assignee));
     updateApprovalStatus(candidate, oldStatus);
@@ -154,7 +140,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   @Test
   void shouldCreatePendingApprovalsForNewCandidate() {
     var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     assertThat(candidate.getApprovals().size(), is(equalTo(1)));
     assertThat(
         candidate.getApprovals().get(HARDCODED_INSTITUTION_ID).getStatus(),
@@ -167,16 +153,15 @@ class CandidateApprovalTest extends CandidateTestSetup {
       names = {"PENDING", APPROVED})
   void shouldThrowUnsupportedOperationWhenRejectingWithoutReason(ApprovalStatus oldStatus) {
     var createRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    Candidate.upsert(createRequest, candidateRepository, periodRepository);
+    scenario.upsertCandidate(createRequest);
     var candidate =
         Candidate.fetchByPublicationId(
             createRequest::publicationId, candidateRepository, periodRepository);
     var updatedCandidate = updateApprovalStatus(candidate, oldStatus);
+    var updateRequest = createRejectionRequestWithoutReason(randomString());
     assertThrows(
         UnsupportedOperationException.class,
-        () ->
-            updatedCandidate.updateApprovalStatus(
-                createRejectionRequestWithoutReason(randomString()), mockOrganizationRetriever));
+        () -> updatedCandidate.updateApprovalStatus(updateRequest, mockOrganizationRetriever));
   }
 
   @ParameterizedTest(name = "Should remove reason when updating from rejection status to {0}")
@@ -185,7 +170,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
       names = {"PENDING", APPROVED})
   void shouldRemoveReasonWhenUpdatingFromRejectionStatusToNewStatus(ApprovalStatus newStatus) {
     var createRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    Candidate.upsert(createRequest, candidateRepository, periodRepository);
+    scenario.upsertCandidate(createRequest);
     var rejectedCandidate =
         Candidate.fetchByPublicationId(
                 createRequest::publicationId, candidateRepository, periodRepository)
@@ -211,7 +196,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   void shouldThrowIllegalArgumentExceptionWhenUpdateStatusWithoutUsername(
       ApprovalStatus newStatus) {
     var createRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = upsert(createRequest);
+    var candidate = scenario.upsertCandidate(createRequest);
     var invalidRequest = createUpdateStatusRequest(newStatus, HARDCODED_INSTITUTION_ID, null);
     assertThrows(
         IllegalArgumentException.class,
@@ -229,7 +214,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
         fromRequest(createCandidateRequest)
             .withPoints(List.of(new InstitutionPoints(keepInstitutionId, randomBigDecimal(), null)))
             .build();
-    var updatedCandidate = upsert(updateRequest);
+    var updatedCandidate = scenario.upsertCandidate(updateRequest);
     var approvalMap = updatedCandidate.getApprovals();
 
     assertThat(approvalMap.containsKey(deleteInstitutionId), is(false));
@@ -239,7 +224,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
 
   @Test
   void shouldRemoveApprovalsWhenBecomingNonCandidate() {
-    var candidate = randomApplicableCandidate(candidateRepository, periodRepository);
+    var candidate = setupRandomApplicableCandidate(scenario);
     var updateRequest = createUpsertNonCandidateRequest(candidate.getPublicationId());
     var updatedCandidate =
         Candidate.updateNonCandidate(updateRequest, candidateRepository).orElseThrow();
@@ -249,7 +234,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
 
   @Test
   void shouldThrowExceptionWhenApplicableAndNonCandidate() {
-    var candidate = randomApplicableCandidate(candidateRepository, periodRepository);
+    var candidate = setupRandomApplicableCandidate(scenario);
     var updateRequest =
         randomUpsertRequestBuilder()
             .withPublicationId(candidate.getPublicationId())
@@ -263,7 +248,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   @Test
   void shouldPersistStatusChangeWhenRequestingAndUpdate() {
     var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     updateApprovalStatus(candidate, ApprovalStatus.APPROVED);
 
     var status =
@@ -278,7 +263,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   void shouldNotOverrideAssigneeWhenAssigneeAlreadyIsSet() {
     var assignee = randomString();
     var request = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    Candidate.upsert(request, candidateRepository, periodRepository);
+    scenario.upsertCandidate(request);
     var candidate =
         Candidate.fetchByPublicationId(
                 request::publicationId, candidateRepository, periodRepository)
@@ -293,7 +278,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   @Test
   void shouldChangeAssigneeWhenValidUpdateAssigneeRequest() {
     var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     var newUsername = randomString();
     candidate.updateApprovalAssignee(
         new UpdateAssigneeRequest(HARDCODED_INSTITUTION_ID, newUsername));
@@ -315,32 +300,38 @@ class CandidateApprovalTest extends CandidateTestSetup {
   @Test
   void shouldNotAllowUpdateApprovalStatusWhenTryingToPassAnonymousImplementations() {
     var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     assertThrows(
         IllegalArgumentException.class,
         () -> candidate.updateApproval(() -> HARDCODED_INSTITUTION_ID));
   }
 
-  @ParameterizedTest
-  @MethodSource("periodRepositoryProvider")
-  void shouldNotAllowToUpdateApprovalWhenCandidateIsNotWithinPeriod(
-      PeriodRepository periodRepository) {
-    var candidate = randomApplicableCandidate(candidateRepository, periodRepository);
+  @Test
+  void shouldNotAllowUpdatingApprovalAssigneeWhenCandidateIsInClosedPeriod() {
+    setupClosedPeriod(scenario, CURRENT_YEAR);
+    var candidate = setupRandomApplicableCandidate(scenario);
+    var updateAssigneeRequest = new UpdateAssigneeRequest(randomUri(), randomString());
     assertThrows(
-        IllegalStateException.class,
-        () ->
-            candidate.updateApprovalAssignee(
-                new UpdateAssigneeRequest(randomUri(), randomString())));
+        IllegalStateException.class, () -> candidate.updateApprovalAssignee(updateAssigneeRequest));
+  }
+
+  @Test
+  void shouldNotAllowUpdatingApprovalAssigneeWhenCandidateIsInPendingPeriod() {
+    setupFuturePeriod(scenario, CURRENT_YEAR);
+    var candidate = setupRandomApplicableCandidate(scenario);
+    var updateAssigneeRequest = new UpdateAssigneeRequest(randomUri(), randomString());
+    assertThrows(
+        IllegalStateException.class, () -> candidate.updateApprovalAssignee(updateAssigneeRequest));
   }
 
   @Test
   void shouldNotResetApprovalsWhenUpdatingCandidateFieldsNotEffectingApprovals() {
     var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     candidate = updateApprovalStatus(candidate, ApprovalStatus.APPROVED);
     var approval = candidate.getApprovals().get(HARDCODED_INSTITUTION_ID);
     var newUpsertRequest = createNewUpsertRequestNotAffectingApprovals(upsertCandidateRequest);
-    var updatedCandidate = upsert(newUpsertRequest);
+    var updatedCandidate = scenario.upsertCandidate(newUpsertRequest);
     var updatedApproval = updatedCandidate.getApprovals().get(HARDCODED_INSTITUTION_ID);
 
     assertThat(updatedApproval, is(equalTo(approval)));
@@ -351,7 +342,8 @@ class CandidateApprovalTest extends CandidateTestSetup {
     var organization = scenario.getDefaultOrganization();
     var creator = createVerifiedCreator(organization);
     Map<URI, Collection<NviCreatorDto>> creatorMap = Map.of(organization.id(), List.of(creator));
-    var requestBuilder = setupApprovedCandidate(scenario, organization.id(), creatorMap);
+    var requestBuilder =
+        setupApprovedCandidateAndReturnRequestBuilder(organization.id(), creatorMap);
 
     var otherSubUnitId = organization.hasPart().get(1).id();
     var updatedCreator = new VerifiedNviCreatorDto(creator.id(), List.of(otherSubUnitId));
@@ -375,7 +367,8 @@ class CandidateApprovalTest extends CandidateTestSetup {
 
     Map<URI, Collection<NviCreatorDto>> creatorMap =
         Map.of(organization.id(), List.of(creator), otherOrganization.id(), List.of(otherCreator));
-    var requestBuilder = setupApprovedCandidate(scenario, organization.id(), creatorMap);
+    var requestBuilder =
+        setupApprovedCandidateAndReturnRequestBuilder(organization.id(), creatorMap);
 
     var updatedRequest = requestBuilder.withCreatorsAndPoints(creatorMap).build();
     var updatedCandidate = scenario.upsertCandidate(updatedRequest);
@@ -391,7 +384,8 @@ class CandidateApprovalTest extends CandidateTestSetup {
     var organization = scenario.getDefaultOrganization();
     var creator = createVerifiedCreator(organization);
     Map<URI, Collection<NviCreatorDto>> creatorMap = Map.of(organization.id(), List.of(creator));
-    var requestBuilder = setupApprovedCandidate(scenario, organization.id(), creatorMap);
+    var requestBuilder =
+        setupApprovedCandidateAndReturnRequestBuilder(organization.id(), creatorMap);
 
     var updatedCreator = new UnverifiedNviCreatorDto(randomString(), creator.affiliations());
     var updatedRequest =
@@ -411,7 +405,8 @@ class CandidateApprovalTest extends CandidateTestSetup {
     var organization = scenario.getDefaultOrganization();
     var creator = createVerifiedCreator(organization);
     Map<URI, Collection<NviCreatorDto>> creatorMap = Map.of(organization.id(), List.of(creator));
-    var requestBuilder = setupApprovedCandidate(scenario, organization.id(), creatorMap);
+    var requestBuilder =
+        setupApprovedCandidateAndReturnRequestBuilder(organization.id(), creatorMap);
 
     var otherOrganization = scenario.setupTopLevelOrganizationWithSubUnits();
     var otherSubUnitId = otherOrganization.hasPart().getFirst().id();
@@ -439,10 +434,18 @@ class CandidateApprovalTest extends CandidateTestSetup {
     return new UnverifiedNviCreatorDto(randomString(), List.of(subUnitId));
   }
 
+  private UpsertRequestBuilder setupApprovedCandidateAndReturnRequestBuilder(
+      URI approvedByOrg, Map<URI, Collection<NviCreatorDto>> creatorsPerOrganization) {
+    var requestBuilder = randomApplicableCandidateRequestBuilder(creatorsPerOrganization);
+    var candidate = scenario.upsertCandidate(requestBuilder.build());
+    scenario.updateApprovalStatus(candidate, ApprovalStatus.APPROVED, approvedByOrg);
+    return requestBuilder;
+  }
+
   @Test
   void shouldNotResetApprovalsWhenUpsertRequestContainsSameDecimalsWithAnotherScale() {
     var upsertCandidateRequest = createUpsertRequestWithDecimalScale(0, HARDCODED_INSTITUTION_ID);
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     candidate.updateApprovalStatus(
         new UpdateStatusRequest(
             HARDCODED_INSTITUTION_ID, ApprovalStatus.APPROVED, randomString(), randomString()),
@@ -459,7 +462,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
             .toList();
     var newUpsertRequest =
         fromRequest(upsertCandidateRequest).withPoints(samePointsWithDifferentScale).build();
-    var updatedCandidate = upsert(newUpsertRequest);
+    var updatedCandidate = scenario.upsertCandidate(newUpsertRequest);
     var updatedApproval = updatedCandidate.getApprovals().get(HARDCODED_INSTITUTION_ID);
 
     assertThat(updatedApproval, is(equalTo(approval)));
@@ -468,14 +471,15 @@ class CandidateApprovalTest extends CandidateTestSetup {
   @Test
   void shouldResetApprovalsWhenNonCandidateBecomesCandidate() {
     var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     var nonCandidate =
         Candidate.updateNonCandidate(
                 createUpsertNonCandidateRequest(candidate.getPublicationId()), candidateRepository)
             .orElseThrow();
     assertFalse(nonCandidate.isApplicable());
     var updatedCandidate =
-        upsert(createNewUpsertRequestNotAffectingApprovals(upsertCandidateRequest));
+        scenario.upsertCandidate(
+            createNewUpsertRequestNotAffectingApprovals(upsertCandidateRequest));
 
     assertTrue(updatedCandidate.isApplicable());
     assertThat(updatedCandidate.getApprovals().size(), is(greaterThan(0)));
@@ -488,7 +492,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
       CandidateResetCauseArgument arguments) {
     var upsertCandidateRequest = getUpsertCandidateRequestWithHardcodedValues();
 
-    var candidate = upsert(upsertCandidateRequest);
+    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
     updateApprovalStatus(candidate, ApprovalStatus.APPROVED);
 
     var creators =
@@ -506,7 +510,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
             .withPoints(arguments.institutionPoints())
             .build();
 
-    var updatedCandidate = upsert(newUpsertRequest);
+    var updatedCandidate = scenario.upsertCandidate(newUpsertRequest);
     var updatedApproval = updatedCandidate.getApprovals().get(HARDCODED_INSTITUTION_ID);
     assertThat(updatedApproval.getStatus(), is(equalTo(ApprovalStatus.PENDING)));
   }
@@ -514,7 +518,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   @Test
   void shouldAllowFinalizingNewValidCandidate() {
     var request = createUpsertCandidateRequest(topLevelOrganizationId).build();
-    var candidate = upsert(request);
+    var candidate = scenario.upsertCandidate(request);
 
     var candidateDto = candidate.toDto(topLevelOrganizationId, mockOrganizationRetriever);
 
@@ -532,7 +536,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
         createUpsertCandidateRequest(topLevelOrganizationId)
             .withUnverifiedCreators(List.of(unverifiedCreator))
             .build();
-    var candidate = upsert(request);
+    var candidate = scenario.upsertCandidate(request);
 
     var candidateDto = candidate.toDto(topLevelOrganizationId, mockOrganizationRetriever);
 
@@ -544,7 +548,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
   @Test
   void shouldHaveNoProblemsWhenCandidateIsValid() {
     var request = createUpsertCandidateRequest(topLevelOrganizationId).build();
-    var candidate = upsert(request);
+    var candidate = scenario.upsertCandidate(request);
 
     var candidateDto = candidate.toDto(topLevelOrganizationId, mockOrganizationRetriever);
 
@@ -561,7 +565,7 @@ class CandidateApprovalTest extends CandidateTestSetup {
         createUpsertCandidateRequest(topLevelOrganizationId)
             .withUnverifiedCreators(List.of(unverifiedCreator))
             .build();
-    var candidate = upsert(request);
+    var candidate = scenario.upsertCandidate(request);
 
     var candidateDto = candidate.toDto(topLevelOrganizationId, mockOrganizationRetriever);
 
@@ -651,12 +655,6 @@ class CandidateApprovalTest extends CandidateTestSetup {
                         new CreatorAffiliationPoints(
                             HARDCODED_CREATOR_ID, HARDCODED_SUBUNIT_ID, HARDCODED_POINTS)))))
         .build();
-  }
-
-  private Candidate upsert(UpsertCandidateRequest request) {
-    Candidate.upsert(request, candidateRepository, periodRepository);
-    return Candidate.fetchByPublicationId(
-        request::publicationId, candidateRepository, periodRepository);
   }
 
   // FIXME: This is duplicated and probably not needed

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -8,7 +8,7 @@ import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandid
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.db.DbApprovalStatusFixtures.randomApproval;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidate;
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.periodRepositoryReturningClosedPeriod;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
 import static no.sikt.nva.nvi.common.model.CandidateFixtures.setupRandomApplicableCandidate;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
@@ -459,23 +459,15 @@ class CandidateTest extends CandidateTestSetup {
 
   @Test
   void shouldReturnTrueWhenCandidateIsNotReportedInClosedPeriod() {
-    var periodRepository = periodRepositoryReturningClosedPeriod(CURRENT_YEAR);
-    var requestForClosedPeriod =
-        randomUpsertRequestBuilder()
-            .withPublicationDate(new PublicationDate(String.valueOf(CURRENT_YEAR), null, null))
-            .build();
-    Candidate.upsert(requestForClosedPeriod, candidateRepository, this.periodRepository);
-    var candidate =
-        Candidate.fetchByPublicationId(
-            requestForClosedPeriod::publicationId, candidateRepository, periodRepository);
-
+    setupClosedPeriod(scenario, CURRENT_YEAR);
+    var candidate = setupRandomApplicableCandidate(scenario, CURRENT_YEAR);
     assertTrue(candidate.isNotReportedInClosedPeriod());
   }
 
   @Test
   void shouldReturnFalseWhenCandidateIsReportedInClosedPeriod() {
     var dao = setupReportedCandidate(candidateRepository, String.valueOf(CURRENT_YEAR));
-    var periodRepository = periodRepositoryReturningClosedPeriod(CURRENT_YEAR);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
     var candidate = Candidate.fetch(dao::identifier, candidateRepository, periodRepository);
     assertFalse(candidate.isNotReportedInClosedPeriod());
   }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -9,7 +9,7 @@ import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandid
 import static no.sikt.nva.nvi.common.db.DbApprovalStatusFixtures.randomApproval;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidate;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.periodRepositoryReturningClosedPeriod;
-import static no.sikt.nva.nvi.common.model.CandidateFixtures.randomApplicableCandidate;
+import static no.sikt.nva.nvi.common.model.CandidateFixtures.setupRandomApplicableCandidate;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
@@ -205,7 +205,7 @@ class CandidateTest extends CandidateTestSetup {
 
   @Test
   void shouldFetchCandidateByPublicationId() {
-    var candidate = randomApplicableCandidate(candidateRepository, periodRepository);
+    var candidate = setupRandomApplicableCandidate(candidateRepository, periodRepository);
     var fetchedCandidate =
         Candidate.fetchByPublicationId(
             candidate::getPublicationId, candidateRepository, periodRepository);
@@ -303,7 +303,7 @@ class CandidateTest extends CandidateTestSetup {
 
   @Test
   void shouldReturnCandidateWithNoPeriodWhenNotApplicable() {
-    var tempCandidate = randomApplicableCandidate(candidateRepository, periodRepository);
+    var tempCandidate = setupRandomApplicableCandidate(candidateRepository, periodRepository);
     var updateRequest = createUpsertNonCandidateRequest(tempCandidate.getPublicationId());
     var candidateBO =
         Candidate.updateNonCandidate(updateRequest, candidateRepository).orElseThrow();
@@ -414,7 +414,7 @@ class CandidateTest extends CandidateTestSetup {
 
   @Test
   void shouldUpdateVersion() {
-    var candidate = randomApplicableCandidate(candidateRepository, periodRepository);
+    var candidate = setupRandomApplicableCandidate(candidateRepository, periodRepository);
     var dao = candidateRepository.findCandidateById(candidate.getIdentifier()).orElseThrow();
 
     candidate.updateVersion(candidateRepository);
@@ -511,7 +511,7 @@ class CandidateTest extends CandidateTestSetup {
   }
 
   private Candidate nonApplicableCandidate() {
-    var tempCandidate = randomApplicableCandidate(candidateRepository, periodRepository);
+    var tempCandidate = setupRandomApplicableCandidate(candidateRepository, periodRepository);
     var updateRequest = createUpsertNonCandidateRequest(tempCandidate.getPublicationId());
     var candidateBO =
         Candidate.updateNonCandidate(updateRequest, candidateRepository).orElseThrow();

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTestSetup.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTestSetup.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.common.service;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.periodRepositoryReturningOpenedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
@@ -12,7 +13,6 @@ import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
@@ -26,7 +26,7 @@ import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
 
-public class CandidateTestSetup extends LocalDynamoTestSetup {
+public class CandidateTestSetup {
 
   protected static final int EXPECTED_SCALE = 4;
   protected static final RoundingMode EXPECTED_ROUNDING_MODE = RoundingMode.HALF_UP;
@@ -61,8 +61,7 @@ public class CandidateTestSetup extends LocalDynamoTestSetup {
 
   @BeforeEach
   void setup() {
-    localDynamo = initializeTestDatabase();
-    candidateRepository = new CandidateRepository(localDynamo);
+    candidateRepository = new CandidateRepository(initializeTestDatabase());
     periodRepository = periodRepositoryReturningOpenedPeriod(ZonedDateTime.now().getYear());
   }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTestSetup.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTestSetup.java
@@ -1,18 +1,17 @@
 package no.sikt.nva.nvi.common.service;
 
-import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.periodRepositoryReturningOpenedPeriod;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
-import static org.mockito.Mockito.mock;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URI;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Map;
+import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
@@ -35,11 +34,11 @@ public class CandidateTestSetup {
   private static final String API_DOMAIN = ENVIRONMENT.readEnv("API_HOST");
   public static final URI CONTEXT_URI =
       UriWrapper.fromHost(API_DOMAIN).addChild(BASE_PATH, "context").getUri();
+  protected TestScenario scenario;
   protected CandidateRepository candidateRepository;
   protected PeriodRepository periodRepository;
-  protected UriRetriever mockUriRetriever = mock(UriRetriever.class);
-  protected OrganizationRetriever mockOrganizationRetriever =
-      new OrganizationRetriever(mockUriRetriever);
+  protected UriRetriever mockUriRetriever;
+  protected OrganizationRetriever mockOrganizationRetriever;
 
   protected static UpsertCandidateRequest createUpsertRequestWithDecimalScale(
       int scale, URI institutionId) {
@@ -61,8 +60,12 @@ public class CandidateTestSetup {
 
   @BeforeEach
   void setup() {
-    candidateRepository = new CandidateRepository(initializeTestDatabase());
-    periodRepository = periodRepositoryReturningOpenedPeriod(ZonedDateTime.now().getYear());
+    scenario = new TestScenario();
+    candidateRepository = scenario.getCandidateRepository();
+    periodRepository = scenario.getPeriodRepository();
+    mockUriRetriever = scenario.getUriRetriever();
+    mockOrganizationRetriever = scenario.getOrganizationRetriever();
+    setupOpenPeriod(scenario, CURRENT_YEAR);
   }
 
   private static InstitutionPoints createInstitutionPoints(

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviPeriodServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/NviPeriodServiceTest.java
@@ -1,17 +1,17 @@
 package no.sikt.nva.nvi.common.service;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.NviPeriodDao.DbNviPeriod;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class NviPeriodServiceTest extends LocalDynamoTestSetup {
+class NviPeriodServiceTest {
 
   private PeriodRepository periodRepository;
   private NviPeriodService nviPeriodService;

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/NviPeriodTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/model/NviPeriodTest.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.common.service.model;
 
 import static java.time.temporal.ChronoUnit.DAYS;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.model.UsernameFixtures.randomUserName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -11,7 +12,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.exception.PeriodAlreadyExistsException;
 import no.sikt.nva.nvi.common.service.exception.PeriodNotFoundException;
@@ -20,15 +20,14 @@ import nva.commons.core.paths.UriWrapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class NviPeriodTest extends LocalDynamoTestSetup {
+class NviPeriodTest {
 
   private static final int YEAR = LocalDateTime.now().getYear() + 1;
   private PeriodRepository periodRepository;
 
   @BeforeEach
   void setup() {
-    localDynamo = initializeTestDatabase();
-    periodRepository = new PeriodRepository(localDynamo);
+    periodRepository = new PeriodRepository(initializeTestDatabase());
   }
 
   @Test

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.common.utils;
 
 import static java.util.Collections.emptyList;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createNumberOfCandidatesForYear;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.getYearIndexStartMarker;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
@@ -21,7 +22,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.IntStream;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,10 +30,11 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 
-class BatchScanUtilTest extends LocalDynamoTestSetup {
+class BatchScanUtilTest {
 
   private static final int DEFAULT_PAGE_SIZE = 700;
   private static final int SECOND_ROW = 1;
+  private DynamoDbClient localDynamo;
   private BatchScanUtil batchScanUtil;
   private CandidateRepositoryHelper candidateRepository;
 

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/LocalDynamoTestSetup.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/LocalDynamoTestSetup.java
@@ -9,13 +9,13 @@ import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_HASH
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_RANGE_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SORT_KEY;
 import static no.sikt.nva.nvi.common.utils.ApplicationConstants.NVI_TABLE_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.amazonaws.services.dynamodbv2.local.embedded.DynamoDBEmbedded;
 import java.util.ArrayList;
 import java.util.List;
-import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.StringContains;
-import org.junit.jupiter.api.Assertions;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 import software.amazon.awssdk.services.dynamodb.model.AttributeDefinition;
 import software.amazon.awssdk.services.dynamodb.model.CreateTableRequest;
@@ -23,39 +23,42 @@ import software.amazon.awssdk.services.dynamodb.model.CreateTableResponse;
 import software.amazon.awssdk.services.dynamodb.model.GlobalSecondaryIndex;
 import software.amazon.awssdk.services.dynamodb.model.KeySchemaElement;
 import software.amazon.awssdk.services.dynamodb.model.KeyType;
+import software.amazon.awssdk.services.dynamodb.model.ListTablesResponse;
 import software.amazon.awssdk.services.dynamodb.model.Projection;
 import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
 import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import software.amazon.awssdk.services.dynamodb.model.ScanRequest;
 import software.amazon.awssdk.services.dynamodb.model.ScanResponse;
+import software.amazon.awssdk.services.dynamodb.model.TableDescription;
 import software.amazon.awssdk.services.dynamodb.model.TableStatus;
 
 public class LocalDynamoTestSetup {
 
   public static final int SINGLE_TABLE_EXPECTED = 1;
   private static final Long CAPACITY_DOES_NOT_MATTER = 1000L;
-  protected DynamoDbClient localDynamo;
 
-  public DynamoDbClient initializeTestDatabase() {
-
+  public static DynamoDbClient initializeTestDatabase() {
     var localDynamo = DynamoDBEmbedded.create().dynamoDbClient();
-
     var tableName = NVI_TABLE_NAME;
     var createTableResult = createTable(localDynamo, tableName);
     var tableDescription = createTableResult.tableDescription();
-    Assertions.assertEquals(tableName, tableDescription.tableName());
-    assertThatTableKeySchemaContainsBothKeys(tableDescription.keySchema());
-    Assertions.assertEquals(TableStatus.ACTIVE, tableDescription.tableStatus());
-    MatcherAssert.assertThat(tableDescription.tableArn(), StringContains.containsString(tableName));
-
     var tables = localDynamo.listTables();
-    Assertions.assertEquals(SINGLE_TABLE_EXPECTED, tables.tableNames().size());
+    validateTableSetup(tableDescription, tables);
     return localDynamo;
   }
 
-  protected ScanResponse scanDB() {
-    return localDynamo.scan(ScanRequest.builder().tableName(NVI_TABLE_NAME).build());
+  private static void validateTableSetup(
+      TableDescription tableDescription, ListTablesResponse tables) {
+    assertEquals(NVI_TABLE_NAME, tableDescription.tableName());
+    assertThatTableKeySchemaContainsBothKeys(tableDescription.keySchema());
+    assertEquals(TableStatus.ACTIVE, tableDescription.tableStatus());
+    assertThat(tableDescription.tableArn(), StringContains.containsString(NVI_TABLE_NAME));
+    assertEquals(SINGLE_TABLE_EXPECTED, tables.tableNames().size());
+  }
+
+  public static ScanResponse scanDB(DynamoDbClient dbClient) {
+    return dbClient.scan(ScanRequest.builder().tableName(NVI_TABLE_NAME).build());
   }
 
   private static CreateTableResponse createTable(DynamoDbClient client, String tableName) {
@@ -130,8 +133,9 @@ public class LocalDynamoTestSetup {
         .build();
   }
 
-  private void assertThatTableKeySchemaContainsBothKeys(List<KeySchemaElement> tableKeySchema) {
-    MatcherAssert.assertThat(tableKeySchema.toString(), StringContains.containsString(HASH_KEY));
-    MatcherAssert.assertThat(tableKeySchema.toString(), StringContains.containsString(SORT_KEY));
+  private static void assertThatTableKeySchemaContainsBothKeys(
+      List<KeySchemaElement> tableKeySchema) {
+    assertThat(tableKeySchema.toString(), StringContains.containsString(HASH_KEY));
+    assertThat(tableKeySchema.toString(), StringContains.containsString(SORT_KEY));
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.common;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliations;
 import static no.sikt.nva.nvi.test.TestUtils.randomUriWithSuffix;
@@ -19,7 +20,7 @@ import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
-public class TestScenario extends LocalDynamoTestSetup {
+public class TestScenario {
 
   private final DynamoDbClient localDynamo = initializeTestDatabase();
   private final CandidateRepository candidateRepository;

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -31,7 +31,6 @@ public class TestScenario {
   private final Organization defaultOrganization;
 
   public TestScenario() {
-    super();
     this.candidateRepository = new CandidateRepository(localDynamo);
     this.periodRepository = new PeriodRepository(localDynamo);
     this.defaultOrganization = setupTopLevelOrganizationWithSubUnits();

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -16,6 +16,7 @@ import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -52,20 +53,40 @@ public class TestScenario {
     return periodRepository;
   }
 
+  public OrganizationRetriever getOrganizationRetriever() {
+    return mockOrganizationRetriever;
+  }
+
+  public UriRetriever getUriRetriever() {
+    return mockUriRetriever;
+  }
+
   public Organization getDefaultOrganization() {
     return defaultOrganization;
   }
 
-  public void setupFuturePeriod(String year) {
-    PeriodRepositoryFixtures.setupFuturePeriod(year, periodRepository);
+  public NviPeriod setupFuturePeriod(String year) {
+    return PeriodRepositoryFixtures.setupFuturePeriod(year, periodRepository);
   }
 
-  public void setupOpenPeriod(String year) {
-    PeriodRepositoryFixtures.setupOpenPeriod(year, periodRepository);
+  public NviPeriod setupFuturePeriod(int year) {
+    return setupFuturePeriod(String.valueOf(year));
   }
 
-  public void setupClosedPeriod(String year) {
-    PeriodRepositoryFixtures.setupClosedPeriod(year, periodRepository);
+  public NviPeriod setupOpenPeriod(String year) {
+    return PeriodRepositoryFixtures.setupOpenPeriod(year, periodRepository);
+  }
+
+  public NviPeriod setupOpenPeriod(int year) {
+    return setupOpenPeriod(String.valueOf(year));
+  }
+
+  public NviPeriod setupClosedPeriod(String year) {
+    return PeriodRepositoryFixtures.setupClosedPeriod(year, periodRepository);
+  }
+
+  public NviPeriod setupClosedPeriod(int year) {
+    return setupClosedPeriod(String.valueOf(year));
   }
 
   public Candidate upsertCandidate(UpsertCandidateRequest request) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -13,10 +13,8 @@ import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
-import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.common.service.requests.UpsertCandidateRequest;
 import no.unit.nva.auth.uriretriever.UriRetriever;
 import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
@@ -63,30 +61,6 @@ public class TestScenario {
 
   public Organization getDefaultOrganization() {
     return defaultOrganization;
-  }
-
-  public NviPeriod setupFuturePeriod(String year) {
-    return PeriodRepositoryFixtures.setupFuturePeriod(year, periodRepository);
-  }
-
-  public NviPeriod setupFuturePeriod(int year) {
-    return setupFuturePeriod(String.valueOf(year));
-  }
-
-  public NviPeriod setupOpenPeriod(String year) {
-    return PeriodRepositoryFixtures.setupOpenPeriod(year, periodRepository);
-  }
-
-  public NviPeriod setupOpenPeriod(int year) {
-    return setupOpenPeriod(String.valueOf(year));
-  }
-
-  public NviPeriod setupClosedPeriod(String year) {
-    return PeriodRepositoryFixtures.setupClosedPeriod(year, periodRepository);
-  }
-
-  public NviPeriod setupClosedPeriod(int year) {
-    return setupClosedPeriod(String.valueOf(year));
   }
 
   public Candidate upsertCandidate(UpsertCandidateRequest request) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbCandidateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbCandidateFixtures.java
@@ -1,10 +1,10 @@
 package no.sikt.nva.nvi.common.db;
 
 import static no.sikt.nva.nvi.common.model.InstanceTypeFixtures.randomInstanceType;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomBoolean;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
-import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 
 import java.net.URI;
@@ -33,6 +33,7 @@ public class DbCandidateFixtures {
     var creatorId = randomUri();
     var institutionPoints = TestUtils.randomBigDecimal();
     var instanceType = randomInstanceType().getValue();
+    var publicationDate = new DbPublicationDate(String.valueOf(CURRENT_YEAR), "10", "10");
     return DbCandidate.builder()
         .publicationId(randomUri())
         .publicationBucketUri(randomUri())
@@ -49,7 +50,7 @@ public class DbCandidateFixtures {
         .level(DbLevel.LEVEL_ONE)
         .channelType(randomElement(ChannelType.values()))
         .channelId(randomUri())
-        .publicationDate(new DbPublicationDate(randomString(), randomString(), randomString()))
+        .publicationDate(publicationDate)
         .internationalCollaboration(randomBoolean())
         .creatorCount(randomInteger())
         .createdDate(Instant.now())

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/PeriodRepositoryFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/PeriodRepositoryFixtures.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.Optional;
+import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.db.NviPeriodDao.DbNviPeriod;
 import no.sikt.nva.nvi.common.service.model.CreatePeriodRequest;
 import no.sikt.nva.nvi.common.service.model.NviPeriod;
@@ -58,16 +59,28 @@ public class PeriodRepositoryFixtures {
     return mockPeriodRepositoryReturn(period);
   }
 
-  public static NviPeriod setupFuturePeriod(String year, PeriodRepository periodRepository) {
-    return upsertPeriod(year, nextMonth, nextYear, periodRepository);
+  public static NviPeriod setupFuturePeriod(TestScenario scenario, String year) {
+    return upsertPeriod(year, nextMonth, nextYear, scenario.getPeriodRepository());
   }
 
-  public static NviPeriod setupOpenPeriod(String year, PeriodRepository periodRepository) {
-    return upsertPeriod(year, previousMonth, nextYear, periodRepository);
+  public static NviPeriod setupFuturePeriod(TestScenario scenario, int year) {
+    return setupFuturePeriod(scenario, String.valueOf(year));
   }
 
-  public static NviPeriod setupClosedPeriod(String year, PeriodRepository periodRepository) {
-    return upsertPeriod(year, previousYear, previousMonth, periodRepository);
+  public static NviPeriod setupOpenPeriod(TestScenario scenario, String year) {
+    return upsertPeriod(year, previousMonth, nextYear, scenario.getPeriodRepository());
+  }
+
+  public static NviPeriod setupOpenPeriod(TestScenario scenario, int year) {
+    return setupOpenPeriod(scenario, String.valueOf(year));
+  }
+
+  public static NviPeriod setupClosedPeriod(TestScenario scenario, String year) {
+    return upsertPeriod(year, previousYear, previousMonth, scenario.getPeriodRepository());
+  }
+
+  public static NviPeriod setupClosedPeriod(TestScenario scenario, int year) {
+    return setupClosedPeriod(scenario, String.valueOf(year));
   }
 
   private static NviPeriod upsertPeriod(

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/PeriodRepositoryFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/PeriodRepositoryFixtures.java
@@ -38,16 +38,6 @@ public class PeriodRepositoryFixtures {
     return nviPeriodRepository;
   }
 
-  public static PeriodRepository periodRepositoryReturningNotOpenedPeriod(int year) {
-    var period =
-        DbNviPeriod.builder()
-            .publishingYear(String.valueOf(year))
-            .startDate(nextMonth)
-            .reportingDate(nextYear)
-            .build();
-    return mockPeriodRepositoryReturn(period);
-  }
-
   public static PeriodRepository periodRepositoryReturningOpenedPeriod(int year) {
     var period =
         DbNviPeriod.builder()

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
@@ -1,9 +1,17 @@
 package no.sikt.nva.nvi.common.model;
 
+import static no.sikt.nva.nvi.common.UpsertRequestBuilder.fromRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
 
+import java.net.URI;
+import java.util.Collection;
+import java.util.Map;
+import no.sikt.nva.nvi.common.TestScenario;
+import no.sikt.nva.nvi.common.UpsertRequestBuilder;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.service.dto.NviCreatorDto;
+import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 
 public class CandidateFixtures {
@@ -14,5 +22,25 @@ public class CandidateFixtures {
     Candidate.upsert(request, candidateRepository, periodRepository);
     return Candidate.fetchByPublicationId(
         request::publicationId, candidateRepository, periodRepository);
+  }
+
+  public static Candidate randomApplicableCandidate(
+      TestScenario scenario, Map<URI, Collection<NviCreatorDto>> creatorsPerOrganization) {
+    var candidateRequest =
+        randomUpsertRequestBuilder().withCreatorsAndPoints(creatorsPerOrganization).build();
+    return scenario.upsertCandidate(candidateRequest);
+  }
+
+  public static UpsertRequestBuilder setupApprovedCandidate(
+      TestScenario scenario,
+      URI approvedByOrg,
+      Map<URI, Collection<NviCreatorDto>> creatorsPerOrganization) {
+    var candidateRequest =
+        randomUpsertRequestBuilder().withCreatorsAndPoints(creatorsPerOrganization).build();
+    scenario.setupOpenPeriod(candidateRequest.publicationDate().year());
+    var candidate = scenario.upsertCandidate(candidateRequest);
+
+    scenario.updateApprovalStatus(candidate, ApprovalStatus.APPROVED, approvedByOrg);
+    return fromRequest(candidateRequest);
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.common.model;
 
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.fromRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 
 import java.net.URI;
 import java.util.Collection;
@@ -37,7 +38,7 @@ public class CandidateFixtures {
       Map<URI, Collection<NviCreatorDto>> creatorsPerOrganization) {
     var candidateRequest =
         randomUpsertRequestBuilder().withCreatorsAndPoints(creatorsPerOrganization).build();
-    scenario.setupOpenPeriod(candidateRequest.publicationDate().year());
+    setupOpenPeriod(scenario, candidateRequest.publicationDate().year());
     var candidate = scenario.upsertCandidate(candidateRequest);
 
     scenario.updateApprovalStatus(candidate, ApprovalStatus.APPROVED, approvedByOrg);

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
@@ -1,8 +1,6 @@
 package no.sikt.nva.nvi.common.model;
 
-import static no.sikt.nva.nvi.common.UpsertRequestBuilder.fromRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 
 import java.net.URI;
 import java.util.Collection;
@@ -12,12 +10,11 @@ import no.sikt.nva.nvi.common.UpsertRequestBuilder;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.dto.NviCreatorDto;
-import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 
 public class CandidateFixtures {
 
-  public static Candidate randomApplicableCandidate(
+  public static Candidate setupRandomApplicableCandidate(
       CandidateRepository candidateRepository, PeriodRepository periodRepository) {
     var request = randomUpsertRequestBuilder().build();
     Candidate.upsert(request, candidateRepository, periodRepository);
@@ -25,23 +22,20 @@ public class CandidateFixtures {
         request::publicationId, candidateRepository, periodRepository);
   }
 
-  public static Candidate randomApplicableCandidate(
+  public static UpsertRequestBuilder randomApplicableCandidateRequestBuilder(
+      Map<URI, Collection<NviCreatorDto>> creatorsPerOrganization) {
+    return randomUpsertRequestBuilder().withCreatorsAndPoints(creatorsPerOrganization);
+  }
+
+  public static Candidate setupRandomApplicableCandidate(
       TestScenario scenario, Map<URI, Collection<NviCreatorDto>> creatorsPerOrganization) {
     var candidateRequest =
         randomUpsertRequestBuilder().withCreatorsAndPoints(creatorsPerOrganization).build();
     return scenario.upsertCandidate(candidateRequest);
   }
 
-  public static UpsertRequestBuilder setupApprovedCandidate(
-      TestScenario scenario,
-      URI approvedByOrg,
-      Map<URI, Collection<NviCreatorDto>> creatorsPerOrganization) {
-    var candidateRequest =
-        randomUpsertRequestBuilder().withCreatorsAndPoints(creatorsPerOrganization).build();
-    setupOpenPeriod(scenario, candidateRequest.publicationDate().year());
-    var candidate = scenario.upsertCandidate(candidateRequest);
-
-    scenario.updateApprovalStatus(candidate, ApprovalStatus.APPROVED, approvedByOrg);
-    return fromRequest(candidateRequest);
+  public static Candidate setupRandomApplicableCandidate(TestScenario scenario) {
+    var candidateRequest = randomUpsertRequestBuilder().build();
+    return scenario.upsertCandidate(candidateRequest);
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
@@ -11,6 +11,7 @@ import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.dto.NviCreatorDto;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.model.PublicationDetails.PublicationDate;
 
 public class CandidateFixtures {
 
@@ -31,6 +32,14 @@ public class CandidateFixtures {
       TestScenario scenario, Map<URI, Collection<NviCreatorDto>> creatorsPerOrganization) {
     var candidateRequest =
         randomUpsertRequestBuilder().withCreatorsAndPoints(creatorsPerOrganization).build();
+    return scenario.upsertCandidate(candidateRequest);
+  }
+
+  public static Candidate setupRandomApplicableCandidate(
+      TestScenario scenario, int publicationYear) {
+    var publicationDate = new PublicationDate(String.valueOf(publicationYear), null, null);
+    var candidateRequest =
+        randomUpsertRequestBuilder().withPublicationDate(publicationDate).build();
     return scenario.upsertCandidate(candidateRequest);
   }
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.rest;
 
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandidateRequest;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.model.CandidateFixtures.randomApplicableCandidate;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
@@ -75,7 +76,7 @@ public abstract class BaseCandidateRestHandlerTest {
   @BeforeEach
   protected void commonSetup() {
     scenario = new TestScenario();
-    scenario.setupOpenPeriod(CURRENT_YEAR);
+    setupOpenPeriod(scenario, CURRENT_YEAR);
     topLevelOrganizationId = scenario.getDefaultOrganization().id();
     subOrganizationId = scenario.getDefaultOrganization().hasPart().getFirst().id();
     mockOrganizationRetriever = scenario.getOrganizationRetriever();

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.rest;
 
 import static java.math.BigDecimal.ZERO;
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandidateRequest;
@@ -28,7 +29,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.UpsertRequestBuilder;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -56,7 +56,7 @@ import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
 
 /** Base test class for handlers that return a CandidateDto. */
 @SuppressWarnings("PMD.CouplingBetweenObjects")
-public abstract class BaseCandidateRestHandlerTest extends LocalDynamoTestSetup {
+public abstract class BaseCandidateRestHandlerTest {
   protected static final ViewingScopeValidator mockViewingScopeValidator =
       new FakeViewingScopeValidator(true);
   protected static final Context CONTEXT = mock(Context.class);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
@@ -7,7 +7,6 @@ import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandid
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.randomBigDecimal;
-import static no.sikt.nva.nvi.test.TestUtils.randomUriWithSuffix;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -55,9 +54,8 @@ public abstract class BaseCandidateRestHandlerTest {
   protected static final ViewingScopeValidator mockViewingScopeValidator =
       new FakeViewingScopeValidator(true);
   protected static final Context CONTEXT = mock(Context.class);
-  protected UriRetriever mockUriRetriever = mock(UriRetriever.class);
-  protected OrganizationRetriever mockOrganizationRetriever =
-      new OrganizationRetriever(mockUriRetriever);
+  protected UriRetriever mockUriRetriever;
+  protected OrganizationRetriever mockOrganizationRetriever;
   protected String resourcePathParameter;
   protected URI topLevelOrganizationId;
   protected URI subOrganizationId;
@@ -84,16 +82,14 @@ public abstract class BaseCandidateRestHandlerTest {
 
   @BeforeEach
   protected void commonSetup() {
-    mockUriRetriever = mock(UriRetriever.class);
-    mockOrganizationRetriever = new OrganizationRetriever(mockUriRetriever);
-    subOrganizationId = randomUriWithSuffix("subOrganization");
-    topLevelOrganizationId = randomUriWithSuffix("topLevelOrganization");
-    mockOrganizationResponseForAffiliation(
-        topLevelOrganizationId, subOrganizationId, mockUriRetriever);
+    scenario = new TestScenario();
+    scenario.setupOpenPeriod(CURRENT_YEAR);
+    topLevelOrganizationId = scenario.getDefaultOrganization().id();
+    subOrganizationId = scenario.getDefaultOrganization().hasPart().getFirst().id();
+    mockOrganizationRetriever = scenario.getOrganizationRetriever();
+    mockUriRetriever = scenario.getUriRetriever();
 
     output = new ByteArrayOutputStream();
-    scenario = new TestScenario();
-    scenario.setupOpenPeriod(String.valueOf(CURRENT_YEAR));
     handler = createHandler();
   }
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/BaseCandidateRestHandlerTest.java
@@ -3,7 +3,6 @@ package no.sikt.nva.nvi.rest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandidateRequest;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
-import static no.sikt.nva.nvi.common.model.CandidateFixtures.randomApplicableCandidate;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
@@ -25,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
+import no.sikt.nva.nvi.common.model.CandidateFixtures;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.dto.UnverifiedNviCreatorDto;
@@ -132,7 +132,7 @@ public abstract class BaseCandidateRestHandlerTest {
 
   protected Candidate setupValidCandidate(URI topLevelOrganizationId) {
     var verifiedCreator = setupDefaultVerifiedCreator();
-    return randomApplicableCandidate(
+    return CandidateFixtures.setupRandomApplicableCandidate(
         scenario, Map.of(topLevelOrganizationId, List.of(verifiedCreator)));
   }
 
@@ -147,14 +147,14 @@ public abstract class BaseCandidateRestHandlerTest {
   protected Candidate setupCandidateWithUnverifiedCreator() {
     var verifiedCreator = setupDefaultVerifiedCreator();
     var unverifiedCreator = setupDefaultUnverifiedCreator();
-    return randomApplicableCandidate(
+    return CandidateFixtures.setupRandomApplicableCandidate(
         scenario, Map.of(topLevelOrganizationId, List.of(verifiedCreator, unverifiedCreator)));
   }
 
   protected Candidate setupCandidateWithApproval() {
     var verifiedCreator = setupDefaultVerifiedCreator();
     var candidate =
-        randomApplicableCandidate(
+        CandidateFixtures.setupRandomApplicableCandidate(
             scenario, Map.of(topLevelOrganizationId, List.of(verifiedCreator)));
     return scenario.updateApprovalStatus(
         candidate, ApprovalStatus.APPROVED, topLevelOrganizationId);
@@ -166,7 +166,7 @@ public abstract class BaseCandidateRestHandlerTest {
     var unverifiedCreator =
         setupUnverifiedCreator(randomString(), List.of(otherInstitutionId), otherInstitutionId);
 
-    return randomApplicableCandidate(
+    return CandidateFixtures.setupRandomApplicableCandidate(
         scenario,
         Map.of(
             topLevelOrganizationId,

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/CreateNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/CreateNviPeriodHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -15,7 +16,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.time.ZonedDateTime;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.rest.create.CreateNviPeriodHandler;
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
-class CreateNviPeriodHandlerTest extends LocalDynamoTestSetup {
+class CreateNviPeriodHandlerTest {
 
   private Context context;
   private ByteArrayOutputStream output;

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/CreateNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/CreateNviPeriodHandlerTest.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.nvi.rest;
 
-import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -16,7 +15,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.time.ZonedDateTime;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.rest.create.CreateNviPeriodHandler;
 import no.sikt.nva.nvi.rest.model.UpsertNviPeriodRequest;
@@ -33,14 +32,14 @@ class CreateNviPeriodHandlerTest {
   private Context context;
   private ByteArrayOutputStream output;
   private CreateNviPeriodHandler handler;
-  private PeriodRepository periodRepository;
+  private TestScenario scenario;
 
   @BeforeEach
   void init() {
+    scenario = new TestScenario();
     output = new ByteArrayOutputStream();
     context = mock(Context.class);
-    periodRepository = new PeriodRepository(initializeTestDatabase());
-    handler = new CreateNviPeriodHandler(periodRepository);
+    handler = new CreateNviPeriodHandler(scenario.getPeriodRepository());
   }
 
   @Test
@@ -62,8 +61,8 @@ class CreateNviPeriodHandlerTest {
 
   @Test
   void shouldReturnBadRequestWhenPeriodExists() throws IOException {
-    var year = String.valueOf(ZonedDateTime.now().getYear());
-    setupFuturePeriod(year, periodRepository);
+    var year = String.valueOf(CURRENT_YEAR);
+    scenario.setupFuturePeriod(year);
     var period = upsertRequest(year);
     handler.handleRequest(createRequest(period), output, context);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
@@ -72,10 +71,10 @@ class CreateNviPeriodHandlerTest {
 
   @Test
   void shouldCreateNviPeriod() throws IOException {
-    var year = String.valueOf(ZonedDateTime.now().getYear());
+    var year = String.valueOf(CURRENT_YEAR);
     var period = upsertRequest(year);
     handler.handleRequest(createRequest(period), output, context);
-    var persistedPeriod = NviPeriod.fetchByPublishingYear(year, periodRepository);
+    var persistedPeriod = NviPeriod.fetchByPublishingYear(year, scenario.getPeriodRepository());
     assertThat(
         period.publishingYear(), is(equalTo(persistedPeriod.getPublishingYear().toString())));
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/CreateNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/CreateNviPeriodHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest;
 
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -62,7 +63,7 @@ class CreateNviPeriodHandlerTest {
   @Test
   void shouldReturnBadRequestWhenPeriodExists() throws IOException {
     var year = String.valueOf(CURRENT_YEAR);
-    scenario.setupFuturePeriod(year);
+    setupFuturePeriod(scenario, year);
     var period = upsertRequest(year);
     handler.handleRequest(createRequest(period), output, context);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/UpdateNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/UpdateNviPeriodHandlerTest.java
@@ -31,7 +31,7 @@ import org.zalando.problem.Problem;
 
 class UpdateNviPeriodHandlerTest {
 
-  private Context context;
+  private static final Context CONTEXT = mock(Context.class);
   private ByteArrayOutputStream output;
   private UpdateNviPeriodHandler handler;
   private TestScenario scenario;
@@ -40,13 +40,12 @@ class UpdateNviPeriodHandlerTest {
   void init() {
     scenario = new TestScenario();
     output = new ByteArrayOutputStream();
-    context = mock(Context.class);
     handler = new UpdateNviPeriodHandler(scenario.getPeriodRepository());
   }
 
   @Test
   void shouldReturnUnauthorizedWhenMissingAccessRights() throws IOException {
-    handler.handleRequest(createRequestWithoutAccessRights(), output, context);
+    handler.handleRequest(createRequestWithoutAccessRights(), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_UNAUTHORIZED)));
@@ -54,7 +53,7 @@ class UpdateNviPeriodHandlerTest {
 
   @Test
   void shouldReturnNotFoundWhenPeriodDoesNotExists() throws IOException {
-    handler.handleRequest(toInputStream(randomUpsertNviPeriodRequest()), output, context);
+    handler.handleRequest(toInputStream(randomUpsertNviPeriodRequest()), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
     assertThat(response.getStatusCode(), is(equalTo(HttpURLConnection.HTTP_NOT_FOUND)));
@@ -65,7 +64,7 @@ class UpdateNviPeriodHandlerTest {
     var year = String.valueOf(ZonedDateTime.now().getYear());
     var persistedPeriod = scenario.setupFuturePeriod(year);
     var updateRequest = updateRequest(year, persistedPeriod);
-    handler.handleRequest(toInputStream(updateRequest), output, context);
+    handler.handleRequest(toInputStream(updateRequest), output, CONTEXT);
     var updatedPeriod = NviPeriod.fetchByPublishingYear(year, scenario.getPeriodRepository());
 
     assertThat(

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/UpdateNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/UpdateNviPeriodHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest;
 
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -62,7 +63,7 @@ class UpdateNviPeriodHandlerTest {
   @Test
   void shouldUpdateNviPeriodSuccessfully() throws IOException {
     var year = String.valueOf(ZonedDateTime.now().getYear());
-    var persistedPeriod = scenario.setupFuturePeriod(year);
+    var persistedPeriod = setupFuturePeriod(scenario, year);
     var updateRequest = updateRequest(year, persistedPeriod);
     handler.handleRequest(toInputStream(updateRequest), output, CONTEXT);
     var updatedPeriod = NviPeriod.fetchByPublishingYear(year, scenario.getPeriodRepository());

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/UpdateNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/UpdateNviPeriodHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -17,7 +18,6 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.rest.model.UpsertNviPeriodRequest;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 
-class UpdateNviPeriodHandlerTest extends LocalDynamoTestSetup {
+class UpdateNviPeriodHandlerTest {
 
   private Context context;
   private ByteArrayOutputStream output;

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -111,7 +111,7 @@ class CreateNoteHandlerTest extends BaseCandidateRestHandlerTest {
     var request =
         createRequest(
             candidate.getIdentifier(), new NviNoteRequest(randomString()), randomString());
-    scenario.setupClosedPeriod(String.valueOf(CURRENT_YEAR));
+    scenario.setupClosedPeriod(CURRENT_YEAR);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.rest.create;
 
-import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.periodRepositoryReturningClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -41,8 +40,8 @@ class CreateNoteHandlerTest extends BaseCandidateRestHandlerTest {
   @Override
   protected ApiGatewayHandler<NviNoteRequest, CandidateDto> createHandler() {
     return new CreateNoteHandler(
-        candidateRepository,
-        periodRepository,
+        scenario.getCandidateRepository(),
+        scenario.getPeriodRepository(),
         mockViewingScopeValidator,
         mockOrganizationRetriever);
   }
@@ -69,8 +68,8 @@ class CreateNoteHandlerTest extends BaseCandidateRestHandlerTest {
     var viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(false);
     handler =
         new CreateNoteHandler(
-            candidateRepository,
-            periodRepository,
+            scenario.getCandidateRepository(),
+            scenario.getPeriodRepository(),
             viewingScopeValidatorReturningFalse,
             mockOrganizationRetriever);
     handler.handleRequest(request, output, CONTEXT);
@@ -112,12 +111,7 @@ class CreateNoteHandlerTest extends BaseCandidateRestHandlerTest {
     var request =
         createRequest(
             candidate.getIdentifier(), new NviNoteRequest(randomString()), randomString());
-    var handler =
-        new CreateNoteHandler(
-            candidateRepository,
-            periodRepositoryReturningClosedPeriod(CURRENT_YEAR),
-            mockViewingScopeValidator,
-            mockOrganizationRetriever);
+    scenario.setupClosedPeriod(String.valueOf(CURRENT_YEAR));
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/create/CreateNoteHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest.create;
 
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -111,7 +112,7 @@ class CreateNoteHandlerTest extends BaseCandidateRestHandlerTest {
     var request =
         createRequest(
             candidate.getIdentifier(), new NviNoteRequest(randomString()), randomString());
-    scenario.setupClosedPeriod(CURRENT_YEAR);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
@@ -31,8 +31,8 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
   @Override
   protected ApiGatewayHandler<Void, CandidateDto> createHandler() {
     return new FetchNviCandidateByPublicationIdHandler(
-        candidateRepository,
-        periodRepository,
+        scenario.getCandidateRepository(),
+        scenario.getPeriodRepository(),
         mockViewingScopeValidator,
         mockOrganizationRetriever);
   }
@@ -77,7 +77,8 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
   @Test
   void shouldReturnCandidateWithReportStatus() throws IOException {
     var candidate =
-        setupReportedCandidate(candidateRepository, randomYear(), topLevelOrganizationId);
+        setupReportedCandidate(
+            scenario.getCandidateRepository(), randomYear(), topLevelOrganizationId);
     var publicationId = candidate.candidate().publicationId();
     var request = createRequestWithCuratorAccess(publicationId.toString());
 
@@ -107,8 +108,8 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
     var request = createRequestWithCuratorAccess(candidate.getPublicationId().toString());
     handler =
         new FetchNviCandidateByPublicationIdHandler(
-            candidateRepository,
-            periodRepository,
+            scenario.getCandidateRepository(),
+            scenario.getPeriodRepository(),
             new FakeViewingScopeValidator(false),
             mockOrganizationRetriever);
     handler.handleRequest(request, output, CONTEXT);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateHandlerTest.java
@@ -46,8 +46,8 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
   @Override
   protected ApiGatewayHandler<Void, CandidateDto> createHandler() {
     return new FetchNviCandidateHandler(
-        candidateRepository,
-        periodRepository,
+        scenario.getCandidateRepository(),
+        scenario.getPeriodRepository(),
         mockViewingScopeValidator,
         mockOrganizationRetriever);
   }
@@ -89,8 +89,8 @@ class FetchNviCandidateHandlerTest extends BaseCandidateRestHandlerTest {
     var viewingScopeValidatorReturningFalse = new FakeViewingScopeValidator(false);
     handler =
         new FetchNviCandidateHandler(
-            candidateRepository,
-            periodRepository,
+            scenario.getCandidateRepository(),
+            scenario.getPeriodRepository(),
             viewingScopeValidatorReturningFalse,
             mockOrganizationRetriever);
     handler.handleRequest(request, output, CONTEXT);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest.fetch;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -13,7 +14,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.time.ZonedDateTime;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.dto.NviPeriodDto;
 import no.unit.nva.commons.json.JsonUtils;
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import org.zalando.problem.Problem;
 import software.amazon.awssdk.utils.MapUtils;
 
-class FetchNviPeriodHandlerTest extends LocalDynamoTestSetup {
+class FetchNviPeriodHandlerTest {
 
   private Context context;
   private ByteArrayOutputStream output;

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodHandlerTest.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.rest.fetch;
 
-import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,7 +13,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.time.ZonedDateTime;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.service.dto.NviPeriodDto;
 import no.unit.nva.commons.json.JsonUtils;
 import no.unit.nva.stubs.FakeContext;
@@ -30,14 +29,14 @@ class FetchNviPeriodHandlerTest {
   private Context context;
   private ByteArrayOutputStream output;
   private FetchNviPeriodHandler handler;
-  private PeriodRepository periodRepository;
+  private TestScenario scenario;
 
   @BeforeEach
   public void setUp() {
+    scenario = new TestScenario();
     output = new ByteArrayOutputStream();
     context = new FakeContext();
-    periodRepository = new PeriodRepository(initializeTestDatabase());
-    handler = new FetchNviPeriodHandler(periodRepository);
+    handler = new FetchNviPeriodHandler(scenario.getPeriodRepository());
   }
 
   @Test
@@ -54,7 +53,7 @@ class FetchNviPeriodHandlerTest {
   @Test
   void shouldReturnPeriodSuccessfully() throws IOException {
     var publishingYear = String.valueOf(ZonedDateTime.now().getYear());
-    var expectedPeriod = setupFuturePeriod(publishingYear, periodRepository).toDto();
+    var expectedPeriod = setupFuturePeriod(scenario, publishingYear).toDto();
     handler.handleRequest(createRequestForPeriod(publishingYear), output, context);
     var response = GatewayResponse.fromOutputStream(output, NviPeriodDto.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest.fetch;
 
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -52,8 +53,8 @@ class FetchNviPeriodsHandlerTest {
 
   @Test
   void shouldReturnPeriodsWhenUserHasAccessRights() throws IOException {
-    scenario.setupFuturePeriod(CURRENT_YEAR + 1);
-    scenario.setupFuturePeriod(CURRENT_YEAR + 2);
+    setupFuturePeriod(scenario, CURRENT_YEAR + 1);
+    setupFuturePeriod(scenario, CURRENT_YEAR + 2);
     handler.handleRequest(createRequestWithAccessRight(AccessRight.MANAGE_NVI), output, context);
     var response = GatewayResponse.fromOutputStream(output, NviPeriodsResponse.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandlerTest.java
@@ -1,6 +1,6 @@
 package no.sikt.nva.nvi.rest.fetch;
 
-import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,8 +14,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
+import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.service.NviPeriodService;
 import no.sikt.nva.nvi.rest.model.NviPeriodsResponse;
 import no.sikt.nva.nvi.rest.model.UpsertNviPeriodRequest;
@@ -32,14 +31,14 @@ class FetchNviPeriodsHandlerTest {
   private Context context;
   private ByteArrayOutputStream output;
   private FetchNviPeriodsHandler handler;
-  private PeriodRepository periodRepository;
+  private TestScenario scenario;
 
   @BeforeEach
   public void setUp() {
+    scenario = new TestScenario();
     output = new ByteArrayOutputStream();
     context = new FakeContext();
-    periodRepository = new PeriodRepository(initializeTestDatabase());
-    handler = new FetchNviPeriodsHandler(new NviPeriodService(periodRepository));
+    handler = new FetchNviPeriodsHandler(new NviPeriodService(scenario.getPeriodRepository()));
   }
 
   @Test
@@ -53,8 +52,8 @@ class FetchNviPeriodsHandlerTest {
 
   @Test
   void shouldReturnPeriodsWhenUserHasAccessRights() throws IOException {
-    PeriodRepositoryFixtures.setupFuturePeriod("2023", periodRepository);
-    PeriodRepositoryFixtures.setupFuturePeriod("2024", periodRepository);
+    scenario.setupFuturePeriod(CURRENT_YEAR + 1);
+    scenario.setupFuturePeriod(CURRENT_YEAR + 2);
     handler.handleRequest(createRequestWithAccessRight(AccessRight.MANAGE_NVI), output, context);
     var response = GatewayResponse.fromOutputStream(output, NviPeriodsResponse.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest.fetch;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -13,7 +14,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
 import no.sikt.nva.nvi.common.service.NviPeriodService;
@@ -27,7 +27,7 @@ import nva.commons.apigateway.GatewayResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-class FetchNviPeriodsHandlerTest extends LocalDynamoTestSetup {
+class FetchNviPeriodsHandlerTest {
 
   private Context context;
   private ByteArrayOutputStream output;

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest.fetch;
 
+import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.periodRepositoryReturningClosedPeriod;
@@ -18,7 +19,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Map;
-import no.sikt.nva.nvi.common.LocalDynamoTestSetup;
 import no.sikt.nva.nvi.common.UpsertRequestBuilder;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-class FetchReportStatusByPublicationIdHandlerTest extends LocalDynamoTestSetup {
+class FetchReportStatusByPublicationIdHandlerTest {
 
   private static final String PATH_PARAM_PUBLICATION_ID = "publicationId";
   private Context context;
@@ -49,8 +49,7 @@ class FetchReportStatusByPublicationIdHandlerTest extends LocalDynamoTestSetup {
   public void setUp() {
     output = new ByteArrayOutputStream();
     context = new FakeContext();
-    localDynamo = initializeTestDatabase();
-    candidateRepository = new CandidateRepository(localDynamo);
+    candidateRepository = new CandidateRepository(initializeTestDatabase());
     periodRepository = periodRepositoryReturningOpenedPeriod(CURRENT_YEAR);
   }
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.rest.remove;
 
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
 import static no.sikt.nva.nvi.common.db.UsernameFixtures.randomUsername;
 import static no.sikt.nva.nvi.rest.fetch.FetchNviCandidateHandler.CANDIDATE_IDENTIFIER;
 import static no.sikt.nva.nvi.rest.remove.RemoveNoteHandler.PARAM_NOTE_IDENTIFIER;
@@ -130,7 +131,7 @@ class RemoveNoteHandlerTest extends BaseCandidateRestHandlerTest {
         scenario.getCandidateRepository());
     var noteId = getIdOfFirstNote(candidate);
     var request = createRequest(candidate.getIdentifier(), noteId, user).build();
-    scenario.setupClosedPeriod(CURRENT_YEAR);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/remove/RemoveNoteHandlerTest.java
@@ -130,7 +130,7 @@ class RemoveNoteHandlerTest extends BaseCandidateRestHandlerTest {
         scenario.getCandidateRepository());
     var noteId = getIdOfFirstNote(candidate);
     var request = createRequest(candidate.getIdentifier(), noteId, user).build();
-    scenario.setupClosedPeriod(String.valueOf(CURRENT_YEAR));
+    scenario.setupClosedPeriod(CURRENT_YEAR);
     handler.handleRequest(request, output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.rest.upsert;
 
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -145,7 +147,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnConflictWhenUpdatingStatusAndReportingPeriodIsClosed() throws IOException {
-    scenario.setupClosedPeriod(CURRENT_YEAR);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
     var candidate = setupValidCandidate(topLevelOrganizationId);
     var request =
         createRequest(candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.APPROVED);
@@ -172,7 +174,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnConflictWhenUpdatingStatusAndNotOpenedPeriod() throws IOException {
-    scenario.setupFuturePeriod(CURRENT_YEAR);
+    setupFuturePeriod(scenario, CURRENT_YEAR);
     var candidate = setupValidCandidate(topLevelOrganizationId);
     var request =
         createRequest(candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.APPROVED);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpdateNviCandidateStatusHandlerTest.java
@@ -145,7 +145,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnConflictWhenUpdatingStatusAndReportingPeriodIsClosed() throws IOException {
-    scenario.setupClosedPeriod(String.valueOf(CURRENT_YEAR));
+    scenario.setupClosedPeriod(CURRENT_YEAR);
     var candidate = setupValidCandidate(topLevelOrganizationId);
     var request =
         createRequest(candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.APPROVED);
@@ -172,7 +172,7 @@ class UpdateNviCandidateStatusHandlerTest extends BaseCandidateRestHandlerTest {
 
   @Test
   void shouldReturnConflictWhenUpdatingStatusAndNotOpenedPeriod() throws IOException {
-    scenario.setupFuturePeriod(String.valueOf(CURRENT_YEAR));
+    scenario.setupFuturePeriod(CURRENT_YEAR);
     var candidate = setupValidCandidate(topLevelOrganizationId);
     var request =
         createRequest(candidate.getIdentifier(), topLevelOrganizationId, ApprovalStatus.APPROVED);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -2,6 +2,8 @@ package no.sikt.nva.nvi.rest.upsert;
 
 import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
@@ -120,7 +122,7 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
   void shouldReturnConflictWhenUpdatingAssigneeAndReportingPeriodIsClosed() throws IOException {
     var assignee = randomString();
     mockNviCuratorAccessForUser(assignee);
-    scenario.setupClosedPeriod(CURRENT_YEAR);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
     handler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
@@ -132,7 +134,7 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
       throws IOException {
     var assignee = randomString();
     mockNviCuratorAccessForUser(assignee);
-    scenario.setupFuturePeriod(CURRENT_YEAR);
+    setupFuturePeriod(scenario, CURRENT_YEAR);
     handler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/upsert/UpsertAssigneeHandlerTest.java
@@ -120,7 +120,7 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
   void shouldReturnConflictWhenUpdatingAssigneeAndReportingPeriodIsClosed() throws IOException {
     var assignee = randomString();
     mockNviCuratorAccessForUser(assignee);
-    scenario.setupClosedPeriod(String.valueOf(CURRENT_YEAR));
+    scenario.setupClosedPeriod(CURRENT_YEAR);
     handler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 
@@ -132,7 +132,7 @@ class UpsertAssigneeHandlerTest extends BaseCandidateRestHandlerTest {
       throws IOException {
     var assignee = randomString();
     mockNviCuratorAccessForUser(assignee);
-    scenario.setupFuturePeriod(String.valueOf(CURRENT_YEAR));
+    scenario.setupFuturePeriod(CURRENT_YEAR);
     handler.handleRequest(createRequest(candidate, assignee), output, CONTEXT);
     var response = GatewayResponse.fromOutputStream(output, Problem.class);
 


### PR DESCRIPTION
Expands and improves the use of test fixtures in various test classes.

Main changes:
- Make `LocalDynamoTestSetup` purely static helper methods instead of a base class that tests extend.
- Use `TestScenario` in more test classes to simplify setup of common fake/mocked services.