### PR TITLE
[np-48710] fix: Use year param in search

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -99,7 +99,7 @@ public class CandidateQuery {
                             AFFILIATIONS,
                             PART_OF_IDENTIFIERS))))
             .build()
-            ._toQuery());
+            .toQuery());
   }
 
   private static Query contributorQueryExcludingSubUnits(List<String> organizations) {
@@ -111,7 +111,7 @@ public class CandidateQuery {
                     organizations,
                     jsonPathOf(PUBLICATION_DETAILS, NVI_CONTRIBUTORS, AFFILIATIONS, IDENTIFIER)))
             .build()
-            ._toQuery());
+            .toQuery());
   }
 
   private static Query yearQuery(String year) {
@@ -138,7 +138,7 @@ public class CandidateQuery {
         .operator(Operator.And)
         .type(TextQueryType.CrossFields)
         .build()
-        ._toQuery();
+        .toQuery();
   }
 
   private List<Query> specificMatch() {
@@ -233,7 +233,7 @@ public class CandidateQuery {
                     .field(jsonPathOf(PUBLICATION_DETAILS, TITLE))
                     .query(t)
                     .build()
-                    ._toQuery());
+                    .toQuery());
   }
 
   private Optional<Query> createAssigneeQuery(String assignee) {
@@ -244,7 +244,7 @@ public class CandidateQuery {
                     .field(jsonPathOf(APPROVALS, ASSIGNEE))
                     .query(a)
                     .build()
-                    ._toQuery());
+                    .toQuery());
   }
 
   public enum QueryFilterType {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -27,8 +27,8 @@ import static no.sikt.nva.nvi.index.utils.SearchConstants.KEYWORD;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.NAME;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.NVI_CONTRIBUTORS;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.PART_OF_IDENTIFIERS;
-import static no.sikt.nva.nvi.index.utils.SearchConstants.PUBLICATION_DATE;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.PUBLICATION_DETAILS;
+import static no.sikt.nva.nvi.index.utils.SearchConstants.REPORTING_PERIOD;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.TITLE;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.TYPE;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.YEAR;
@@ -116,7 +116,7 @@ public class CandidateQuery {
 
   private static Query yearQuery(String year) {
     return fieldValueQuery(
-        jsonPathOf(PUBLICATION_DETAILS, PUBLICATION_DATE, YEAR, KEYWORD),
+        jsonPathOf(REPORTING_PERIOD, YEAR, KEYWORD),
         nonNull(year) ? year : String.valueOf(ZonedDateTime.now().getYear()));
   }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/PaginatedResultConverter.java
@@ -11,6 +11,7 @@ import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PAR
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SORT_ORDER;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_TITLE;
+import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_YEAR;
 import static nva.commons.apigateway.RestRequestHandler.COMMA;
 
 import java.net.URI;
@@ -74,6 +75,7 @@ public final class PaginatedResultConverter {
         queryParams, QUERY_PARAM_ORDER_BY, parameters.searchResultParameters().orderBy());
     putIfValueNotNull(
         queryParams, QUERY_PARAM_SORT_ORDER, parameters.searchResultParameters().sortOrder());
+    putIfValueNotNull(queryParams, QUERY_PARAM_YEAR, parameters.year());
     return queryParams;
   }
 

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
@@ -35,16 +35,16 @@ public final class QueryFunctions {
   private QueryFunctions() {}
 
   public static Query nestedQuery(String path, Query query) {
-    return new NestedQuery.Builder().path(path).query(query).build()._toQuery();
+    return new NestedQuery.Builder().path(path).query(query).build().toQuery();
   }
 
   public static Query nestedQuery(String path, Query... queries) {
-    return new NestedQuery.Builder().path(path).query(mustMatch(queries)).build()._toQuery();
+    return new NestedQuery.Builder().path(path).query(mustMatch(queries)).build().toQuery();
   }
 
   public static Query fieldValueQuery(String field, String value) {
     return nonNull(value)
-        ? new TermQuery.Builder().field(field).value(getFieldValue(value)).build()._toQuery()
+        ? new TermQuery.Builder().field(field).value(getFieldValue(value)).build().toQuery()
         : matchAllQuery();
   }
 
@@ -54,7 +54,7 @@ public final class QueryFunctions {
         .field(field)
         .terms(new TermsQueryField.Builder().value(termsFields).build())
         .build()
-        ._toQuery();
+        .toQuery();
   }
 
   public static Query rangeFromQuery(String field, int greaterThanOrEqualTo) {
@@ -62,7 +62,7 @@ public final class QueryFunctions {
         .field(field)
         .gte(JsonData.of(greaterThanOrEqualTo))
         .build()
-        ._toQuery();
+        .toQuery();
   }
 
   public static Query mustNotMatch(String value, String field) {
@@ -70,7 +70,7 @@ public final class QueryFunctions {
   }
 
   public static Query mustNotMatch(Query query) {
-    return new Builder().mustNot(query).build()._toQuery();
+    return new Builder().mustNot(query).build().toQuery();
   }
 
   public static Query matchAtLeastOne(Query... queries) {
@@ -86,7 +86,7 @@ public final class QueryFunctions {
   }
 
   public static Query matchQuery(String value, String field) {
-    return new MatchQuery.Builder().field(field).query(getFieldValue(value)).build()._toQuery();
+    return new MatchQuery.Builder().field(field).query(getFieldValue(value)).build().toQuery();
   }
 
   public static Query containsNonFinalizedStatusQuery() {
@@ -133,7 +133,7 @@ public final class QueryFunctions {
   }
 
   private static Query matchAllQuery() {
-    return new MatchAllQuery.Builder().build()._toQuery();
+    return new MatchAllQuery.Builder().build().toQuery();
   }
 
   private static FieldValue getFieldValue(String value) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
@@ -29,6 +29,7 @@ public final class SearchConstants {
   public static final String ABSTRACT = "abstract";
   public static final String KEYWORD = "keyword";
   public static final String APPROVAL_STATUS = "approvalStatus";
+  public static final String REPORTING_PERIOD = "reportingPeriod";
   public static final String PUBLICATION_DETAILS = "publicationDetails";
   public static final String CONTRIBUTORS = "contributors";
   public static final String NVI_CONTRIBUTORS = "nviContributors";

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -25,6 +25,7 @@ import static no.sikt.nva.nvi.test.TestConstants.HARDCODED_ENGLISH_LABEL;
 import static no.sikt.nva.nvi.test.TestConstants.HARDCODED_NORWEGIAN_LABEL;
 import static no.sikt.nva.nvi.test.TestConstants.LABELS_FIELD;
 import static no.sikt.nva.nvi.test.TestConstants.NB_FIELD;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.s3.S3Driver.S3_SCHEME;
@@ -96,7 +97,6 @@ import software.amazon.awssdk.services.sqs.model.SqsException;
 @SuppressWarnings({"PMD.GodClass", "PMD.CouplingBetweenObjects"})
 class IndexDocumentHandlerTest {
 
-  public static final int SOME_REPORTING_YEAR = 2023;
   private static final String JSON_PTR_CONTRIBUTOR = "/publicationDetails/contributors";
   private static final String JSON_PTR_APPROVALS = "/approvals";
   private static final Environment ENVIRONMENT = new Environment();
@@ -130,7 +130,7 @@ class IndexDocumentHandlerTest {
   @BeforeEach
   void setup() {
     var scenario = new TestScenario();
-    setupOpenPeriod(scenario, SOME_REPORTING_YEAR);
+    setupOpenPeriod(scenario, CURRENT_YEAR);
     candidateRepository = scenario.getCandidateRepository();
     periodRepository = scenario.getPeriodRepository();
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentTestUtils.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentTestUtils.java
@@ -466,7 +466,7 @@ public final class IndexDocumentTestUtils {
   }
 
   private static NviOrganization nviOrganization(URI id) {
-    return NviOrganization.builder().withId(id).build();
+    return NviOrganization.builder().withId(id).withPartOf(emptyList()).build();
   }
 
   private static Organization randomNonNviAffiliation() {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerTest.java
@@ -11,6 +11,8 @@ import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PAR
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SEARCH_TERM;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SORT_ORDER;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_TITLE;
+import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_YEAR;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 import static no.unit.nva.testutils.RandomDataGenerator.randomInteger;
@@ -458,6 +460,23 @@ class SearchNviCandidatesHandlerTest {
     handler.handleRequest(requestWithoutQueryParameters(userName), output, context);
     Mockito.verify(openSearchClient, times(1))
         .search(argThat(argument -> argument.excludeFields().equals(expectedExcludeFields)));
+  }
+
+  @Test
+  void shouldSearchByReportingPeriodWhenYearParamIsSet() throws IOException {
+    var reportedYear = String.valueOf(CURRENT_YEAR - 1);
+    var userName = randomString();
+    mockIdentityService(userName);
+    mockOpenSearchClient();
+
+    var request =
+        createRequest(TOP_LEVEL_CRISTIN_ORG, Map.of(QUERY_PARAM_YEAR, reportedYear), userName);
+    handler.handleRequest(request, output, context);
+    var response = GatewayResponse.fromOutputStream(output, PaginatedSearchResult.class);
+    var paginatedSearchResult = response.getBodyObject(PaginatedSearchResult.class);
+
+    var actualId = paginatedSearchResult.getId().toString();
+    assertThat(actualId, containsString(QUERY_PARAM_YEAR + "=" + reportedYear));
   }
 
   private static void mockOpenSearchClientWithParameterMatchingViewingScope(

--- a/index-handlers/src/test/resources/document_approved.json
+++ b/index-handlers/src/test/resources/document_approved.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e7",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_approved_collaboration_new.json
+++ b/index-handlers/src/test/resources/document_approved_collaboration_new.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e51244",
   "numberOfApprovals": 2,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_approved_collaboration_pending.json
+++ b/index-handlers/src/test/resources/document_approved_collaboration_pending.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e8",
   "numberOfApprovals": 2,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_dispute_not_sikt.json
+++ b/index-handlers/src/test/resources/document_dispute_not_sikt.json
@@ -4,6 +4,11 @@
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e57925",
   "numberOfApprovals": 1,
   "globalApprovalStatus": "Dispute",
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_new.json
+++ b/index-handlers/src/test/resources/document_new.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e0",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_new_collaboration.json
+++ b/index-handlers/src/test/resources/document_new_collaboration.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e1",
   "numberOfApprovals": 2,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_organization_aggregation_collaboration.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_collaboration.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e57100",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_organization_aggregation_dispute.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_dispute.json
@@ -4,6 +4,11 @@
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e57924",
   "numberOfApprovals": 1,
   "globalApprovalStatus": "Dispute",
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_organization_aggregation_new.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_new.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e57999",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_organization_aggregation_pending.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_pending.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e57920",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_organization_aggregation_rejected.json
+++ b/index-handlers/src/test/resources/document_organization_aggregation_rejected.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e57929",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_pending.json
+++ b/index-handlers/src/test/resources/document_pending.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e2",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_pending_category_degree_bachelor.json
+++ b/index-handlers/src/test/resources/document_pending_category_degree_bachelor.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e9",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "DegreeBachelor",

--- a/index-handlers/src/test/resources/document_pending_collaboration.json
+++ b/index-handlers/src/test/resources/document_pending_collaboration.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e4",
   "numberOfApprovals": 2,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_rejected.json
+++ b/index-handlers/src/test/resources/document_rejected.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e5",
   "numberOfApprovals": 1,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_rejected_collaboration_new.json
+++ b/index-handlers/src/test/resources/document_rejected_collaboration_new.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e12111",
   "numberOfApprovals": 2,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_rejected_collaboration_pending.json
+++ b/index-handlers/src/test/resources/document_rejected_collaboration_pending.json
@@ -3,6 +3,11 @@
   "type": "NviCandidate",
   "identifier": "37e1863b-f72a-4b2b-bbe4-fc7de3e579e6",
   "numberOfApprovals": 2,
+  "reportingPeriod" : {
+    "type" : "ReportingPeriod",
+    "year" : "2023"
+  },
+  "reported" : false,
   "publicationDetails": {
     "id": "https://api.dev.nva.aws.unit.no/publication/01892ad6fc07-4ddfbfc5-3145-4b06-9f77-d4202d074380",
     "type": "AcademicArticle",

--- a/index-handlers/src/test/resources/document_with_contributor_from_ntnu_subunit.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_ntnu_subunit.json
@@ -1,7 +1,12 @@
 {
     "@context" : "https://bibsysdev.github.io/src/nvi-context.json",
-  "type": "NviCandidate",
+    "type": "NviCandidate",
     "identifier" : "8fbef194-4935-4ba0-9b33-5662ed223b3f",
+    "reportingPeriod" : {
+      "type" : "ReportingPeriod",
+      "year" : "2023"
+    },
+    "reported" : false,
     "publicationDetails" : {
       "id" : "https://api.dev.nva.aws.unit.no/publication/018a03b59fd9-88b45d41-03e8-4feb-a3e5-3ad865aea1ca",
       "type" : "AcademicArticle",

--- a/index-handlers/src/test/resources/document_with_contributor_from_ntnu_toplevel.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_ntnu_toplevel.json
@@ -2,6 +2,11 @@
     "@context" : "https://bibsysdev.github.io/src/nvi-context.json",
     "type": "NviCandidate",
     "identifier" : "27a0f52b-2d86-447d-a2cc-48ac4b8789dd",
+    "reportingPeriod" : {
+      "type" : "ReportingPeriod",
+      "year" : "2023"
+    },
+    "reported" : false,
     "publicationDetails" : {
       "id" : "https://api.dev.nva.aws.unit.no/publication/018a03b59fd9-88b45d41-03e8-4feb-a3e5-3ad865aea1ca",
       "type" : "AcademicArticle",

--- a/index-handlers/src/test/resources/document_with_contributor_from_sikt.json
+++ b/index-handlers/src/test/resources/document_with_contributor_from_sikt.json
@@ -2,6 +2,11 @@
     "@context" : "https://bibsysdev.github.io/src/nvi-context.json",
     "type": "NviCandidate",
     "identifier" : "10b6f194-3d39-4aae-a1fa-eee20bf39f31",
+    "reportingPeriod" : {
+      "type" : "ReportingPeriod",
+      "year" : "2023"
+    },
+    "reported" : false,
     "publicationDetails" : {
       "id" : "https://api.dev.nva.aws.unit.no/publication/018a03b59fd9-88b45d41-03e8-4feb-a3e5-3ad865aea1ca",
       "type" : "AcademicArticle",


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48710

This changes candidate search to filter by reporting period year instead of publication year.
These should be identical, but some existing data has a mismatch between these fields which caused the candidate to show up for the wrong year in the curator workflow.