### PR TITLE
[np-48731] fix: Allow text search for NviContributors

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -134,6 +134,7 @@ public class CandidateQuery {
             jsonPathOf(PUBLICATION_DETAILS, IDENTIFIER),
             jsonPathOf(PUBLICATION_DETAILS, TITLE),
             jsonPathOf(PUBLICATION_DETAILS, CONTRIBUTORS, NAME),
+            jsonPathOf(PUBLICATION_DETAILS, NVI_CONTRIBUTORS, NAME),
             jsonPathOf(PUBLICATION_DETAILS, ABSTRACT))
         .operator(Operator.And)
         .type(TextQueryType.CrossFields)

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
@@ -22,7 +22,6 @@ public final class SearchConstants {
   public static final String ASSIGNEE = "assignee";
   public static final String NUMBER_OF_APPROVALS = "numberOfApprovals";
   public static final String APPROVALS = "approvals";
-  public static final String PUBLICATION_DATE = "publicationDate";
   public static final String YEAR = "year";
   public static final String TYPE = "type";
   public static final String TITLE = "title";

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -807,16 +807,14 @@ class OpenSearchClientTest {
 
   @Test
   void shouldFindDocumentByPartialAuthorName() throws IOException {
-    // Given a publication with a contributor named "John Smith"
-    // And an index document for this publication
+    // Given an index document with an NviContributor named "John Smith"
     var name = "John Smith";
     var expectedDocument =
         indexDocumentWithCustomer(randomUri(), name, randomString(), null, randomString());
     addDocumentsToIndex(expectedDocument);
 
-    // When a query is made with search term "Smith"
-    // And with the publication title as the search term
-    var searchParameters = defaultSearchParameters().withSearchTerm("Smith").build();
+    // When a query is made with search term "smith"
+    var searchParameters = defaultSearchParameters().withSearchTerm("smith").build();
     var searchResponse = openSearchClient.search(searchParameters);
 
     // Then the response includes the document

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.index.aws;
 
 import static java.util.Objects.requireNonNull;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomNviContributor;
+import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomNviContributorBuilder;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomPages;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomPublicationChannel;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
@@ -68,8 +69,6 @@ import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.document.InstitutionPoints;
 import no.sikt.nva.nvi.index.model.document.InstitutionPoints.CreatorAffiliationPoints;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
-import no.sikt.nva.nvi.index.model.document.NviContributor;
-import no.sikt.nva.nvi.index.model.document.NviOrganization;
 import no.sikt.nva.nvi.index.model.document.PublicationDate;
 import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import no.sikt.nva.nvi.index.model.document.ReportingPeriod;
@@ -806,6 +805,26 @@ class OpenSearchClientTest {
     assertEquals(expectedDocument, actualDocument);
   }
 
+  @Test
+  void shouldFindDocumentByPartialAuthorName() throws IOException {
+    // Given a publication with a contributor named "John Smith"
+    // And an index document for this publication
+    var name = "John Smith";
+    var expectedDocument =
+        indexDocumentWithCustomer(randomUri(), name, randomString(), null, randomString());
+    addDocumentsToIndex(expectedDocument);
+
+    // When a query is made with search term "Smith"
+    // And with the publication title as the search term
+    var searchParameters = defaultSearchParameters().withSearchTerm("Smith").build();
+    var searchResponse = openSearchClient.search(searchParameters);
+
+    // Then the response includes the document
+    assertThat(searchResponse.hits().hits(), hasSize(1));
+    var actualDocument = getFirstHit(searchResponse);
+    assertEquals(expectedDocument, actualDocument);
+  }
+
   private static void assertExpectedPointWithoutRejectedPoints(
       Buckets<StringTermsBucket> actualOrgBuckets) {
     actualOrgBuckets.array().forEach(OpenSearchClientTest::assertExpectedPointAggregations);
@@ -1000,22 +1019,20 @@ class OpenSearchClientTest {
   }
 
   private static PublicationDetails randomPublicationDetailsWithCustomer(
-      URI affiliation, String contributor, String year, String title) {
+      URI affiliation, String contributorName, String year, String title) {
     var publicationDate =
         year != null
             ? PublicationDate.builder().withYear(year).build()
             : PublicationDate.builder().withYear(YEAR).build();
-    var contributorBuilder =
-        NviContributor.builder()
+    var contributor =
+        randomNviContributorBuilder(affiliation)
             .withRole("Creator")
-            .withAffiliations(List.of(NviOrganization.builder().withId(affiliation).build()));
-    if (contributor != null) {
-      contributorBuilder.withName(contributor);
-    }
+            .withName(contributorName)
+            .build();
     return PublicationDetails.builder()
         .withTitle(title)
         .withPublicationDate(publicationDate)
-        .withContributors(List.of(contributorBuilder.build()))
+        .withContributors(List.of(contributor))
         .withPublicationChannel(randomPublicationChannel())
         .withPages(randomPages())
         .build();


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48731

Adds the field `publicationDetails.nviContributors.name` to search queries in order to allow full-text search on these names.
Note that this field is already mapped separately from `publicationDetails.contributors.name` (which is only searchable as a keyword), apparently as an optimization to handle publications with many irrelevant contributors.