### PR TITLE
[np-48689] perf: Simplify PointService

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandler.java
@@ -42,7 +42,6 @@ public class EvaluateNviCandidateHandler implements RequestHandler<SQSEvent, Voi
         new EvaluatorService(
             new S3StorageReader(new Environment().readEnv("EXPANDED_RESOURCES_BUCKET")),
             new CreatorVerificationUtil(authorizedUriRetriever(new Environment())),
-            new PointService(),
             new CandidateRepository(defaultDynamoClient()),
             new PeriodRepository(defaultDynamoClient())),
         new NviQueueClient(),

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandler.java
@@ -10,7 +10,6 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
 import java.util.Optional;
 import no.sikt.nva.nvi.common.S3StorageReader;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.queue.NviQueueClient;
@@ -19,7 +18,6 @@ import no.sikt.nva.nvi.events.evaluator.calculator.CreatorVerificationUtil;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
 import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
 import no.unit.nva.auth.uriretriever.AuthorizedBackendUriRetriever;
-import no.unit.nva.auth.uriretriever.UriRetriever;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.attempt.Failure;
@@ -44,7 +42,7 @@ public class EvaluateNviCandidateHandler implements RequestHandler<SQSEvent, Voi
         new EvaluatorService(
             new S3StorageReader(new Environment().readEnv("EXPANDED_RESOURCES_BUCKET")),
             new CreatorVerificationUtil(authorizedUriRetriever(new Environment())),
-            new PointService(new OrganizationRetriever(new UriRetriever())),
+            new PointService(),
             new CandidateRepository(defaultDynamoClient()),
             new PeriodRepository(defaultDynamoClient())),
         new NviQueueClient(),

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -150,7 +150,7 @@ public class EvaluatorService {
     var unverifiedCreatorsWithNviInstitutions = getUnverifiedCreators(creators);
     var pointCalculation =
         pointService.calculatePoints(
-            publication,
+            publicationDto,
             verifiedCreatorsWithNviInstitutions,
             unverifiedCreatorsWithNviInstitutions);
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -64,28 +64,28 @@ public class EvaluatorService {
   }
 
   public Optional<CandidateEvaluatedMessage> evaluateCandidacy(URI publicationBucketUri) {
-    var publicationDto = publicationLoader.extractAndTransform(publicationBucketUri);
-    logger.info("Evaluating publication with ID: {}", publicationDto.id());
+    var publication = publicationLoader.extractAndTransform(publicationBucketUri);
+    logger.info("Evaluating publication with ID: {}", publication.id());
 
-    var candidate = fetchOptionalCandidate(publicationDto.id()).orElse(null);
-    var period = fetchOptionalPeriod(publicationDto.publicationDate().year()).orElse(null);
+    var candidate = fetchOptionalCandidate(publication.id()).orElse(null);
+    var period = fetchOptionalPeriod(publication.publicationDate().year()).orElse(null);
 
     // Check if the publication can be evaluated
-    if (shouldSkipEvaluation(candidate, publicationDto.publicationDate())) {
-      logger.info(SKIPPED_EVALUATION_MESSAGE, publicationDto.id());
+    if (shouldSkipEvaluation(candidate, publication.publicationDate())) {
+      logger.info(SKIPPED_EVALUATION_MESSAGE, publication.id());
       return Optional.empty();
     }
 
     // Check if the publication meets the requirements to be a candidate
-    if (!publicationDto.isApplicable()) {
-      logger.info(NON_NVI_CANDIDATE_MESSAGE, publicationDto.id());
-      return createNonNviCandidateMessage(publicationDto.id());
+    if (!publication.isApplicable()) {
+      logger.info(NON_NVI_CANDIDATE_MESSAGE, publication.id());
+      return createNonNviCandidateMessage(publication.id());
     }
 
-    var creators = creatorVerificationUtil.getNviCreatorsWithNviInstitutions(publicationDto);
+    var creators = creatorVerificationUtil.getNviCreatorsWithNviInstitutions(publication);
     if (creators.isEmpty()) {
-      logger.info(NON_NVI_CANDIDATE_MESSAGE, publicationDto.id());
-      return createNonNviCandidateMessage(publicationDto.id());
+      logger.info(NON_NVI_CANDIDATE_MESSAGE, publication.id());
+      return createNonNviCandidateMessage(publication.id());
     }
 
     // Check that the publication can be a candidate in the target period
@@ -95,12 +95,12 @@ public class EvaluatorService {
         periodExists && nonNull(candidate) && isApplicableInPeriod(period, candidate);
     var canEvaluateInPeriod = periodIsOpen || candidateExistsInPeriod;
     if (!canEvaluateInPeriod) {
-      logger.info(NON_NVI_CANDIDATE_MESSAGE, publicationDto.id());
-      return createNonNviCandidateMessage(publicationDto.id());
+      logger.info(NON_NVI_CANDIDATE_MESSAGE, publication.id());
+      return createNonNviCandidateMessage(publication.id());
     }
 
-    logger.info(NVI_CANDIDATE_MESSAGE, publicationDto.id());
-    var nviCandidate = constructNviCandidate(publicationDto, publicationBucketUri, creators);
+    logger.info(NVI_CANDIDATE_MESSAGE, publication.id());
+    var nviCandidate = constructNviCandidate(publication, publicationBucketUri, creators);
     return createNviCandidateMessage(nviCandidate);
   }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -34,8 +34,6 @@ import no.sikt.nva.nvi.events.model.NviCandidate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// FIXME: Temporary suppression while refactoring, should be removed.
-@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.AvoidLiteralsInIfCondition"})
 public class EvaluatorService {
 
   private static final String NVI_CANDIDATE_MESSAGE =
@@ -50,7 +48,6 @@ public class EvaluatorService {
       "Publication is already reported and cannot be updated.";
   private final Logger logger = LoggerFactory.getLogger(EvaluatorService.class);
   private final CreatorVerificationUtil creatorVerificationUtil;
-  private final PointService pointService;
   private final CandidateRepository candidateRepository;
   private final PeriodRepository periodRepository;
   private final PublicationLoaderService publicationLoader;
@@ -58,11 +55,9 @@ public class EvaluatorService {
   public EvaluatorService(
       StorageReader<URI> storageReader,
       CreatorVerificationUtil creatorVerificationUtil,
-      PointService pointService,
       CandidateRepository candidateRepository,
       PeriodRepository periodRepository) {
     this.creatorVerificationUtil = creatorVerificationUtil;
-    this.pointService = pointService;
     this.candidateRepository = candidateRepository;
     this.periodRepository = periodRepository;
     this.publicationLoader = new PublicationLoaderService(storageReader);
@@ -136,7 +131,7 @@ public class EvaluatorService {
     var verifiedCreatorsWithNviInstitutions = getVerifiedCreators(creators);
     var unverifiedCreatorsWithNviInstitutions = getUnverifiedCreators(creators);
     var pointCalculation =
-        pointService.calculatePoints(
+        PointService.calculatePoints(
             publicationDto,
             verifiedCreatorsWithNviInstitutions,
             unverifiedCreatorsWithNviInstitutions);

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/PointService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/PointService.java
@@ -1,241 +1,99 @@
 package no.sikt.nva.nvi.events.evaluator;
 
-import static java.util.Objects.nonNull;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_AFFILIATIONS;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CHAPTER_PUBLISHER;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CHAPTER_SERIES;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CHAPTER_SERIES_SCIENTIFIC_VALUE;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_CONTRIBUTOR;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_COUNTRY_CODE;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ID;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_INSTANCE_TYPE;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_PUBLICATION_CONTEXT;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_PUBLISHER;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_ROLE_TYPE;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_SERIES;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_SERIES_SCIENTIFIC_VALUE;
-import static no.sikt.nva.nvi.common.utils.JsonPointers.JSON_PTR_TYPE;
-import static no.sikt.nva.nvi.common.utils.JsonUtils.extractJsonNodeTextValue;
-import static no.sikt.nva.nvi.common.utils.JsonUtils.streamNode;
-import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
-import static nva.commons.core.attempt.Try.attempt;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collection;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
-import no.sikt.nva.nvi.common.client.model.Organization;
-import no.sikt.nva.nvi.common.service.model.InstanceType;
-import no.sikt.nva.nvi.common.utils.JsonUtils;
+import java.util.Optional;
+import no.sikt.nva.nvi.common.dto.ContributorDto;
+import no.sikt.nva.nvi.common.dto.PublicationChannelDto;
+import no.sikt.nva.nvi.common.dto.PublicationDto;
 import no.sikt.nva.nvi.events.evaluator.calculator.PointCalculator;
 import no.sikt.nva.nvi.events.evaluator.model.Channel;
+import no.sikt.nva.nvi.events.evaluator.model.NviCreator;
+import no.sikt.nva.nvi.events.evaluator.model.NviOrganization;
 import no.sikt.nva.nvi.events.evaluator.model.PointCalculation;
+import no.sikt.nva.nvi.events.evaluator.model.PublicationChannel;
 import no.sikt.nva.nvi.events.evaluator.model.UnverifiedNviCreator;
 import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
 
 public final class PointService {
 
-  private static final String COUNTRY_CODE_NORWAY = "NO";
-  private static final String ROLE_CREATOR = "Creator";
-  private static final String TYPE = "type";
-  private static final String TYPE_SERIES = "Series";
-  private static final String TYPE_JOURNAL = "Journal";
-  private static final String UNASSIGNED = "Unassigned";
-  private final OrganizationRetriever organizationRetriever;
-
-  public PointService(OrganizationRetriever organizationRetriever) {
-    this.organizationRetriever = organizationRetriever;
-  }
+  public PointService() {}
 
   public PointCalculation calculatePoints(
-      JsonNode publication,
+      PublicationDto publication,
       Collection<VerifiedNviCreator> verifiedNviCreators,
       Collection<UnverifiedNviCreator> unverifiedNviCreators) {
-    var instanceType = extractInstanceType(publication);
-    massiveHackToFixObjectsWithMultipleTypes(publication);
-    var channel = extractChannel(instanceType, publication);
-    var isInternationalCollaboration = isInternationalCollaboration(publication);
-    var creatorShareCount = countCreatorShares(publication);
+    var instanceType = publication.publicationType();
+    var channel = getNviChannel(publication);
+    var isInternationalCollaboration = publication.isInternationalCollaboration();
+    var totalShares = getTotalShares(publication, verifiedNviCreators, unverifiedNviCreators);
+
     return new PointCalculator(
             channel,
             instanceType,
             verifiedNviCreators,
             unverifiedNviCreators,
             isInternationalCollaboration,
-            creatorShareCount)
+            totalShares)
         .calculatePoints();
   }
 
-  private static boolean isInternationalCollaboration(JsonNode jsonNode) {
-    return getJsonNodeStream(jsonNode, JSON_PTR_CONTRIBUTOR)
-        .filter(PointService::isCreator)
-        .flatMap(PointService::extractAffiliations)
-        .map(PointService::extractCountryCode)
-        .filter(Objects::nonNull)
-        .anyMatch(PointService::isInternationalCountryCode);
-  }
-
-  private static String extractCountryCode(JsonNode affiliationNode) {
-    return extractJsonNodeTextValue(affiliationNode, JSON_PTR_COUNTRY_CODE);
-  }
-
-  private static Stream<JsonNode> extractAffiliations(JsonNode contributorNode) {
-    return getJsonNodeStream(contributorNode, JSON_PTR_AFFILIATIONS);
-  }
-
-  private static boolean isCreator(JsonNode contributorNode) {
-    return ROLE_CREATOR.equals(extractJsonNodeTextValue(contributorNode, JSON_PTR_ROLE_TYPE));
-  }
-
-  private static boolean isInternationalCountryCode(String countryCode) {
-    return !COUNTRY_CODE_NORWAY.equals(countryCode);
-  }
-
-  private static Integer countCreatorsWithoutAffiliations(List<JsonNode> creators) {
-    return creators.stream()
-        .filter(PointService::doesNotHaveAffiliations)
-        .map(node -> 1)
-        .reduce(0, Integer::sum);
-  }
-
-  private static Integer countCreatorsWithOnlyUnverifiedAffiliations(List<JsonNode> creators) {
-    return creators.stream()
-        .filter(PointService::hasAffiliations)
-        .filter(PointService::isOnlyAffiliatedWithOrganizationsWithOutId)
-        .map(node -> 1)
-        .reduce(0, Integer::sum);
-  }
-
-  private static boolean isOnlyAffiliatedWithOrganizationsWithOutId(JsonNode contributor) {
-    return extractAffiliations(contributor).allMatch(PointService::doesNotHaveId);
-  }
-
-  private static boolean hasId(JsonNode affiliation) {
-    return nonNull(extractId(affiliation));
-  }
-
-  private static boolean doesNotHaveId(JsonNode affiliation) {
-    return !hasId(affiliation);
-  }
-
-  private static String extractId(JsonNode affiliation) {
-    return extractJsonNodeTextValue(affiliation, JSON_PTR_ID);
-  }
-
-  private static List<JsonNode> extractCreatorNodes(JsonNode jsonNode) {
-    return streamNode(jsonNode.at(JSON_PTR_CONTRIBUTOR)).filter(PointService::isCreator).toList();
-  }
-
-  private static boolean hasAffiliations(JsonNode contributor) {
-    return !doesNotHaveAffiliations(contributor);
-  }
-
-  private static boolean doesNotHaveAffiliations(JsonNode contributor) {
-    return contributor.at(JSON_PTR_AFFILIATIONS).isEmpty();
-  }
-
-  private static InstanceType extractInstanceType(JsonNode jsonNode) {
-    return InstanceType.parse(extractJsonNodeTextValue(jsonNode, JSON_PTR_INSTANCE_TYPE));
-  }
-
-  private static Channel extractChannel(InstanceType instanceType, JsonNode jsonNode) {
-    var channel =
-        switch (instanceType) {
-          case ACADEMIC_ARTICLE, ACADEMIC_LITERATURE_REVIEW ->
-              jsonNode.at(JSON_PTR_PUBLICATION_CONTEXT).toString();
-          case ACADEMIC_MONOGRAPH, ACADEMIC_COMMENTARY -> extractBookChannel(jsonNode);
-          case ACADEMIC_CHAPTER -> extractAcademicChapterChannel(jsonNode);
+  private static Channel getNviChannel(PublicationDto publication) {
+    var channelDto =
+        switch (publication.publicationType()) {
+          case ACADEMIC_ARTICLE, ACADEMIC_LITERATURE_REVIEW -> getJournal(publication);
+          case ACADEMIC_MONOGRAPH, ACADEMIC_COMMENTARY, ACADEMIC_CHAPTER ->
+              getSeriesOrPublisher(publication);
         };
-    return attempt(() -> dtoObjectMapper.readValue(channel, Channel.class)).orElseThrow();
+    var channelType = PublicationChannel.parse(channelDto.channelType());
+    return new Channel(channelDto.id(), channelType, channelDto.scientificValue());
   }
 
-  private static String extractAcademicChapterChannel(JsonNode jsonNode) {
-    if (nonNull(extractJsonNodeTextValue(jsonNode, JSON_PTR_CHAPTER_SERIES_SCIENTIFIC_VALUE))
-        && isAssigned(
-            extractJsonNodeTextValue(jsonNode, JSON_PTR_CHAPTER_SERIES_SCIENTIFIC_VALUE))) {
-      return jsonNode.at(JSON_PTR_CHAPTER_SERIES).toString();
-    } else {
-      return jsonNode.at(JSON_PTR_CHAPTER_PUBLISHER).toString();
-    }
+  private static Optional<PublicationChannelDto> getChannel(
+      PublicationDto publication, PublicationChannel channelType) {
+    return publication.publicationChannels().stream()
+        .filter(channel -> channelType.getValue().equals(channel.channelType()))
+        .filter(channel -> channel.scientificValue().isValid())
+        .findFirst();
   }
 
-  private static String extractBookChannel(JsonNode jsonNode) {
-    if (nonNull(extractJsonNodeTextValue(jsonNode, JSON_PTR_SERIES_SCIENTIFIC_VALUE))
-        && isAssigned(extractJsonNodeTextValue(jsonNode, JSON_PTR_SERIES_SCIENTIFIC_VALUE))) {
-      return jsonNode.at(JSON_PTR_SERIES).toString();
-    } else {
-      return jsonNode.at(JSON_PTR_PUBLISHER).toString();
-    }
+  private static PublicationChannelDto getJournal(PublicationDto publication) {
+    return getChannel(publication, PublicationChannel.JOURNAL).orElseThrow();
   }
 
-  private static boolean isAssigned(String scientificValue) {
-    return !UNASSIGNED.equals(scientificValue);
+  private static PublicationChannelDto getSeriesOrPublisher(PublicationDto publication) {
+    return getChannel(publication, PublicationChannel.SERIES)
+        .orElseGet(() -> getChannel(publication, PublicationChannel.PUBLISHER).orElseThrow());
   }
 
-  private static Stream<JsonNode> getJsonNodeStream(JsonNode jsonNode, String jsonPtr) {
-    return StreamSupport.stream(jsonNode.at(jsonPtr).spliterator(), false);
+  private static int getTotalShares(
+      PublicationDto publication,
+      Collection<VerifiedNviCreator> verifiedNviCreators,
+      Collection<UnverifiedNviCreator> unverifiedNviCreators) {
+
+    var totalCreatorCount =
+        (int) publication.contributors().stream().filter(ContributorDto::isCreator).count();
+
+    var verifiedShares =
+        verifiedNviCreators.stream().mapToInt(PointService::countOfExtraCreatorShares).sum();
+
+    var unverifiedShares =
+        unverifiedNviCreators.stream().mapToInt(PointService::countOfExtraCreatorShares).sum();
+
+    return totalCreatorCount + verifiedShares + unverifiedShares;
   }
 
-  @Deprecated
-  private static void massiveHackToFixObjectsWithMultipleTypes(JsonNode jsonNode) {
-    fixSeriesType(jsonNode);
-    fixJournalType(jsonNode);
-  }
-
-  private static void fixJournalType(JsonNode jsonNode) {
-    var journal = jsonNode.at(JSON_PTR_PUBLICATION_CONTEXT);
-    if (!journal.isMissingNode() && journal.at(JSON_PTR_TYPE).isArray()) {
-      var journalObject = (ObjectNode) journal;
-      journalObject.remove(TYPE);
-      journalObject.put(TYPE, TYPE_JOURNAL);
-    }
-  }
-
-  private static void fixSeriesType(JsonNode jsonNode) {
-    var series = jsonNode.at(JSON_PTR_SERIES);
-    if (!series.isMissingNode() && series.at(JSON_PTR_TYPE).isArray()) {
-      var seriesObject = (ObjectNode) series;
-      seriesObject.remove(TYPE);
-      seriesObject.put(TYPE, TYPE_SERIES);
-    }
-    var chapterSeries = jsonNode.at(JSON_PTR_CHAPTER_SERIES);
-    if (!chapterSeries.isMissingNode() && chapterSeries.at(JSON_PTR_TYPE).isArray()) {
-      var chapterSeriesObject = (ObjectNode) chapterSeries;
-      chapterSeriesObject.remove(TYPE);
-      chapterSeriesObject.put(TYPE, TYPE_SERIES);
-    }
-  }
-
-  private int countCreatorShares(JsonNode jsonNode) {
-    var creators = extractCreatorNodes(jsonNode);
-    return Integer.sum(
-        Integer.sum(
-            countVerifiedTopLevelAffiliationsPerCreator(creators),
-            countCreatorsWithoutAffiliations(creators)),
-        countCreatorsWithOnlyUnverifiedAffiliations(creators));
-  }
-
-  private Integer countVerifiedTopLevelAffiliationsPerCreator(List<JsonNode> creators) {
-    return creators.stream().map(this::countVerifiedTopLevelAffiliations).reduce(0, Integer::sum);
-  }
-
-  // FIXME: Does this actually need to call the organization retriever?
-  // This method is only called from EvaluatorService, which has already done the same check.
-  // See NP-48364 for more information.
-  private Integer countVerifiedTopLevelAffiliations(JsonNode creator) {
-    return extractAffiliations(creator)
-        .filter(PointService::hasId)
-        .map(JsonUtils::extractId)
-        .distinct()
-        .map(organizationRetriever::fetchOrganization)
-        .map(Organization::getTopLevelOrg)
-        .map(Organization::id)
-        .distinct()
-        .map(node -> 1)
-        .reduce(0, Integer::sum);
+  /**
+   * Counts the number of extra shares for a creator based on their affiliations. Creators get one
+   * extra share for each verified top-level affiliation beyond the first one.
+   */
+  private static int countOfExtraCreatorShares(NviCreator creator) {
+    int count =
+        (int)
+            creator.nviAffiliations().stream()
+                .map(NviOrganization::topLevelOrganization)
+                .map(NviOrganization::id)
+                .distinct()
+                .count();
+    return Math.max(0, count - 1);
   }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/PointService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/PointService.java
@@ -16,9 +16,9 @@ import no.sikt.nva.nvi.events.evaluator.model.VerifiedNviCreator;
 
 public final class PointService {
 
-  public PointService() {}
+  private PointService() {}
 
-  public PointCalculation calculatePoints(
+  public static PointCalculation calculatePoints(
       PublicationDto publication,
       Collection<VerifiedNviCreator> verifiedNviCreators,
       Collection<UnverifiedNviCreator> unverifiedNviCreators) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/PointService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/PointService.java
@@ -87,13 +87,12 @@ public final class PointService {
    * extra share for each verified top-level affiliation beyond the first one.
    */
   private static int countOfExtraCreatorShares(NviCreator creator) {
-    int count =
-        (int)
-            creator.nviAffiliations().stream()
-                .map(NviOrganization::topLevelOrganization)
-                .map(NviOrganization::id)
-                .distinct()
-                .count();
-    return Math.max(0, count - 1);
+    var affiliationCount =
+        creator.nviAffiliations().stream()
+            .map(NviOrganization::topLevelOrganization)
+            .map(NviOrganization::id)
+            .distinct()
+            .count();
+    return (int) Math.max(0, affiliationCount - 1);
   }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/PublicationChannel.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/PublicationChannel.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.events.evaluator.model;
 
+import java.util.Arrays;
+
 public enum PublicationChannel {
   JOURNAL("Journal"),
   SERIES("Series"),
@@ -9,6 +11,13 @@ public enum PublicationChannel {
 
   PublicationChannel(String value) {
     this.value = value;
+  }
+
+  public static PublicationChannel parse(String value) {
+    return Arrays.stream(values())
+        .filter(channelType -> channelType.getValue().equalsIgnoreCase(value))
+        .findFirst()
+        .orElseThrow();
   }
 
   public String getValue() {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -54,7 +54,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
 import no.sikt.nva.nvi.common.dto.PublicationDateDto;
@@ -601,8 +600,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
 
   private void setupEvaluatorService(PeriodRepository periodRepository) {
     var calculator = new CreatorVerificationUtil(authorizedBackendUriRetriever);
-    var organizationRetriever = new OrganizationRetriever(uriRetriever);
-    var pointCalculator = new PointService(organizationRetriever);
+    var pointCalculator = new PointService();
     evaluatorService =
         new EvaluatorService(
             storageReader, calculator, pointCalculator, candidateRepository, periodRepository);

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -600,10 +600,8 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
 
   private void setupEvaluatorService(PeriodRepository periodRepository) {
     var calculator = new CreatorVerificationUtil(authorizedBackendUriRetriever);
-    var pointCalculator = new PointService();
     evaluatorService =
-        new EvaluatorService(
-            storageReader, calculator, pointCalculator, candidateRepository, periodRepository);
+        new EvaluatorService(storageReader, calculator, candidateRepository, periodRepository);
   }
 
   private URI setupCandidate(int year) throws IOException {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
@@ -84,7 +84,7 @@ public class EvaluationTest {
     s3Driver = new S3Driver(s3Client, BUCKET_NAME);
     storageReader = new S3StorageReader(s3Client, BUCKET_NAME);
     var calculator = new CreatorVerificationUtil(authorizedBackendUriRetriever);
-    var pointCalculator = new PointService(scenario.getOrganizationRetriever());
+    var pointCalculator = new PointService();
     evaluatorService =
         new EvaluatorService(
             storageReader, calculator, pointCalculator, candidateRepository, periodRepository);

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluationTest.java
@@ -83,11 +83,10 @@ public class EvaluationTest {
     queueClient = new FakeSqsClient();
     s3Driver = new S3Driver(s3Client, BUCKET_NAME);
     storageReader = new S3StorageReader(s3Client, BUCKET_NAME);
-    var calculator = new CreatorVerificationUtil(authorizedBackendUriRetriever);
-    var pointCalculator = new PointService();
+    var creatorVerificationUtil = new CreatorVerificationUtil(authorizedBackendUriRetriever);
     evaluatorService =
         new EvaluatorService(
-            storageReader, calculator, pointCalculator, candidateRepository, periodRepository);
+            storageReader, creatorVerificationUtil, candidateRepository, periodRepository);
     handler = new EvaluateNviCandidateHandler(evaluatorService, queueClient, ENVIRONMENT);
   }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonPointers.java
@@ -6,32 +6,13 @@ public final class JsonPointers {
   public static final String JSON_PTR_AFFILIATIONS = "/affiliations";
   public static final String JSON_PTR_ID = "/id";
   public static final String JSON_PTR_TYPE = "/type";
-  public static final String JSON_PTR_COUNTRY_CODE = "/countryCode";
   public static final String JSON_PTR_PUBLICATION_DATE = "/entityDescription/publicationDate";
   public static final String JSON_PTR_MAIN_TITLE = "/entityDescription/mainTitle";
   public static final String JSON_PTR_ABSTRACT = "/entityDescription/abstract";
-  public static final String JSON_POINTER_IDENTITY_ID = "/identity/id";
-  public static final String JSON_POINTER_IDENTITY_NAME = "/identity/name";
-  public static final String JSON_POINTER_IDENTITY_VERIFICATION_STATUS =
-      "/identity/verificationStatus";
   public static final String JSON_PTR_INSTANCE_TYPE =
       "/entityDescription/reference/publicationInstance/type";
   public static final String JSON_PTR_PUBLICATION_CONTEXT =
       "/entityDescription/reference/publicationContext";
-  public static final String JSON_PTR_SERIES_SCIENTIFIC_VALUE =
-      "/entityDescription/reference/publicationContext/series/scientificValue";
-  public static final String JSON_PTR_SERIES =
-      "/entityDescription/reference/publicationContext/series";
-  public static final String JSON_PTR_PUBLISHER =
-      "/entityDescription/reference/publicationContext/publisher";
-  public static final String JSON_PTR_CHAPTER_PUBLISHER =
-      "/entityDescription/reference/publicationContext/entityDescription/reference/publicationContext"
-          + "/publisher";
-  public static final String JSON_PTR_CHAPTER_SERIES_SCIENTIFIC_VALUE =
-      "/entityDescription/reference/publicationContext/entityDescription/reference/publicationContext/series"
-          + "/scientificValue";
-  public static final String JSON_PTR_CHAPTER_SERIES =
-      "/entityDescription/reference/publicationContext/entityDescription/reference/publicationContext/series";
   public static final String JSON_PTR_PAGES_BEGIN =
       "/entityDescription/reference/publicationInstance/pages/begin";
   public static final String JSON_PRT_PAGES_END =

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/JsonUtils.java
@@ -29,10 +29,6 @@ public final class JsonUtils {
     return StreamSupport.stream(node.spliterator(), false);
   }
 
-  public static URI extractId(JsonNode jsonNode) {
-    return URI.create(extractJsonNodeTextValue(jsonNode, JSON_PTR_ID));
-  }
-
   private static boolean isNotMissingNode(JsonNode node) {
     return !node.isMissingNode() && !node.isNull() && node.isValueNode();
   }

--- a/nvi-commons/src/main/resources/publication_query.sparql
+++ b/nvi-commons/src/main/resources/publication_query.sparql
@@ -137,15 +137,6 @@ WHERE {
   OPTIONAL { ?organization :label ?label }
   OPTIONAL { ?organization :country ?country }
 
-  # Check if the publication is an international collaboration
-  OPTIONAL {
-    BIND(EXISTS {
-      ?nonNorwegianOrganization a :Organization ;
-      :country ?country .
-      FILTER(?country != "NO")
-    } AS ?isInternationalCollaboration)
-  }
-
   # Find all contributors
   OPTIONAL {
     ?publication :entityDescription/:contributor ?contributor .
@@ -177,5 +168,16 @@ WHERE {
         FILTER NOT EXISTS { ?topLevelOrganization :partOf ?parent }
       }
     }
+  }
+
+  # Check if any contributor is a Creator with a non-Norwegian affiliation.
+  # If so, the publication counts as an international collaboration.
+  OPTIONAL {
+    BIND(EXISTS {
+      ?contributor :role [ a :Creator ] ;
+      :affiliation [ :country ?countryCode ] .
+      FILTER (?countryCode != "NO")
+    } AS ?isInternationalCollaboration
+    )
   }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/JsonUtilsTest.java
@@ -63,11 +63,4 @@ class JsonUtilsTest {
         JsonUtils.streamNode(randomJsonNode).toList(),
         StreamSupport.stream(randomJsonNode.spliterator(), false).toList());
   }
-
-  @Test
-  void shouldExtractId() {
-    var id = randomUri();
-    var jsonNode = objectMapper.createObjectNode().put(ID_FIELD, id.toString());
-    assertEquals(JsonUtils.extractId(jsonNode), id);
-  }
 }

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/SampleExpandedPublicationChannel.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/SampleExpandedPublicationChannel.java
@@ -9,7 +9,6 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.net.URI;
-import java.util.Locale;
 
 public record SampleExpandedPublicationChannel(String type, URI id, String name, String level) {
 
@@ -35,7 +34,7 @@ public record SampleExpandedPublicationChannel(String type, URI id, String name,
     private Builder() {}
 
     public Builder withType(String type) {
-      this.type = type.toLowerCase(Locale.ROOT);
+      this.type = type;
       return this;
     }
 


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-48689

This refactors `PointService` to use `PublicationDto` instead of re-creating the necessary data using `JsonNode` and extra networks calls. This in effect eliminates network calls checking for top-level organizations of Contributors during the evaluation stage. Note that we still check the NVI status of top-level organizations here and that the old logic is duplicated in the indexing stage, which must be addressed separately.

It also fixes a bug in the "is this an international collaboration" part of the SPARQL query, as this did not previously check that the affiliation was for a `Creator`.

This PR shrinks `PointService` to the point that it perhaps does not make sense to keep it as a separate "service class", but it is left for now to keep the PR short and readable.