### PR TITLE
fix: Handle parsing of large documents

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithSyntheticDataTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithSyntheticDataTest.java
@@ -1,0 +1,84 @@
+package no.sikt.nva.nvi.events.evaluator;
+
+import static no.sikt.nva.nvi.events.evaluator.TestUtils.createEvent;
+import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_NORWAY;
+import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_SWEDEN;
+import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import no.sikt.nva.nvi.common.SampleExpandedPublicationFactory;
+import no.sikt.nva.nvi.common.client.model.Organization;
+import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
+import no.sikt.nva.nvi.events.model.NviCandidate;
+import no.sikt.nva.nvi.events.model.PersistedResourceMessage;
+import no.sikt.nva.nvi.test.SampleExpandedPublication;
+import nva.commons.core.paths.UnixPath;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Timeout;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class EvaluateNviCandidateWithSyntheticDataTest extends EvaluationTest {
+  private SampleExpandedPublicationFactory factory;
+  private Organization nviOrganization1;
+  private Organization nonNviOrganization;
+
+  @BeforeEach
+  void setup() {
+    factory = new SampleExpandedPublicationFactory(authorizedBackendUriRetriever, uriRetriever);
+
+    // Set up default organizations suitable for most test cases
+    nviOrganization1 = factory.setupTopLevelOrganization(COUNTRY_CODE_NORWAY, true);
+    nonNviOrganization = factory.setupTopLevelOrganization(COUNTRY_CODE_SWEDEN, false);
+  }
+
+  // The parser should be able to handle documents with 10 000 contributors in 30 seconds.
+  @ParameterizedTest
+  @Timeout(value = 30, unit = TimeUnit.SECONDS)
+  @ValueSource(ints = {100, 1_000, 5_000, 10_000})
+  void shouldParseDocumentWithManyContributorsWithinTimeOut(int numberOfForeignContributors) {
+    var numberOfNorwegianContributors = 10;
+    var publication =
+        factory
+            .withTopLevelOrganizations(nviOrganization1, nonNviOrganization)
+            .withRandomCreatorsAffiliatedWith(
+                numberOfNorwegianContributors, COUNTRY_CODE_NORWAY, nviOrganization1)
+            .withRandomCreatorsAffiliatedWith(
+                numberOfForeignContributors, COUNTRY_CODE_SWEDEN, nonNviOrganization)
+            .getExpandedPublication();
+
+    var expectedCreatorShares = numberOfNorwegianContributors + numberOfForeignContributors;
+    var candidate = getEvaluatedCandidate(publication);
+    assertThat(candidate.creatorShareCount()).isEqualTo(expectedCreatorShares);
+  }
+
+  private URI addPublicationToS3(SampleExpandedPublication publication) {
+    try {
+      return s3Driver.insertFile(
+          UnixPath.of(publication.identifier().toString()), publication.toJsonString());
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to add publication to S3", e);
+    }
+  }
+
+  private CandidateEvaluatedMessage getMessageBody() {
+    try {
+      var sentMessages = queueClient.getSentMessages();
+      var message = sentMessages.getFirst();
+      return objectMapper.readValue(message.messageBody(), CandidateEvaluatedMessage.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private NviCandidate getEvaluatedCandidate(SampleExpandedPublication publication) {
+    var fileUri = addPublicationToS3(publication);
+    var event = createEvent(new PersistedResourceMessage(fileUri));
+    handler.handleRequest(event, CONTEXT);
+    return (NviCandidate) getMessageBody().candidate();
+  }
+}

--- a/nvi-commons/src/main/resources/publication_query.sparql
+++ b/nvi-commons/src/main/resources/publication_query.sparql
@@ -55,44 +55,36 @@ CONSTRUCT {
 }
 
 WHERE {
-  # Find the main publication object and basic fields
-  ?publication a :Publication ;
-  :status ?status .
-
-  OPTIONAL { ?publication :entityDescription ?entityDescription }
-  OPTIONAL { ?publication :identifier ?identifier }
-  OPTIONAL { ?publication :modifiedDate ?modifiedDate }
-  OPTIONAL { ?entityDescription :mainTitle ?title }
-  OPTIONAL { ?entityDescription :language ?language }
-
-  # Find publication date
-  OPTIONAL {
+  # Find the main publication object and top-level values
+  ?publication a :Publication .
+  ?publication :status ?status .
+  {
+    OPTIONAL { ?publication :identifier ?identifier }
+    OPTIONAL { ?publication :modifiedDate ?modifiedDate }
+  } UNION {
+    # Find basic values under the entityDescription node
+    ?publication :entityDescription ?entityDescription .
+    OPTIONAL { ?entityDescription :mainTitle ?title }
+    OPTIONAL { ?entityDescription :language ?language }
+  } UNION {
+    # Find the publication date
+    ?publication :entityDescription ?entityDescription .
     ?entityDescription :publicationDate ?date .
     ?date a :PublicationDate .
     ?date :year ?year
-  }
-  OPTIONAL { ?date :month ?month }
-  OPTIONAL { ?date :day ?day }
-
-  # Find publication type (if applicable)
-  VALUES ?applicablePublicationType {
-    :AcademicMonograph :AcademicCommentary :AcademicChapter :AcademicArticle :AcademicLiteratureReview
-  }
-  OPTIONAL {
+    OPTIONAL { ?date :month ?month }
+    OPTIONAL { ?date :day ?day }
+  } UNION {
+    # Find all publication channels
     ?reference a :Reference ;
     :publicationInstance ?instance .
     ?instance a ?instanceType .
-    FILTER (?instanceType = ?applicablePublicationType)
-  }
-
-  # Find all publication channels
-  VALUES ?journalPublications {
-    :AcademicArticle :AcademicLiteratureReview
-  }
-  VALUES ?nonJournalPublications {
-    :AcademicMonograph :AcademicCommentary :AcademicChapter
-  }
-  OPTIONAL {
+    VALUES ?journalPublications {
+      :AcademicArticle :AcademicLiteratureReview
+    }
+    VALUES ?nonJournalPublications {
+      :AcademicMonograph :AcademicCommentary :AcademicChapter
+    }
     # In rare cases a channel can be listed as both a Journal and a Series, but only one of these
     # is relevant for a given publication type.
     # This filter should ensure that we only keep relevant channel types.
@@ -108,10 +100,19 @@ WHERE {
     OPTIONAL { ?channel :year ?channelYear }
     OPTIONAL { ?channel :onlineIssn ?onlineIssn }
     OPTIONAL { ?channel :printIssn ?printIssn }
-  }
+  } UNION {
+    # Check whether the publication is 'applicable', i.e. can be an NVI candidate
+    ?publication a :Publication ;
+    :status ?status .
 
-  # Check whether the publication is 'applicable', i.e. can be an NVI candidate
-  OPTIONAL {
+    # Find publication type (if applicable)
+    VALUES ?applicablePublicationType {
+      :AcademicMonograph :AcademicCommentary :AcademicChapter :AcademicArticle :AcademicLiteratureReview
+    }
+    ?reference a :Reference ;
+    :publicationInstance ?instance .
+    ?instance a ?instanceType .
+
     # Filter on valid status and publication type
     FILTER (?status = :PUBLISHED)
     FILTER (?instanceType = ?applicablePublicationType)
@@ -131,18 +132,18 @@ WHERE {
       ?channelForLevel :scientificValue ?scientificLevel .
       FILTER(?scientificLevel = ?applicableLevel)
     } AS ?isApplicable)
-  }
-
-  # Find all organizations
-  OPTIONAL { ?organization a :Organization }
-  OPTIONAL { ?organization :partOf ?parent }
-  OPTIONAL { ?organization :hasPart ?child }
-  OPTIONAL { ?organization :label ?label }
-  OPTIONAL { ?organization :country ?country }
-
-  # Find all contributors
-  OPTIONAL {
+  } UNION {
+    # Find all organizations
+    ?organization a :Organization .
+    OPTIONAL { ?organization :partOf ?parent }
+    OPTIONAL { ?organization :hasPart ?child }
+    OPTIONAL { ?organization :label ?label }
+    OPTIONAL { ?organization :country ?country }
+  } UNION {
+    # Find all contributors
+    ?publication :entityDescription ?entityDescription .
     ?entityDescription :contributor ?contributor .
+
     ?contributor :identity ?personId ;
     :role ?role .
     ?role a ?roleType .
@@ -171,16 +172,16 @@ WHERE {
         FILTER NOT EXISTS { ?topLevelOrganization :partOf ?parent }
       }
     }
-  }
 
-  # Check if any contributor is a Creator with a non-Norwegian affiliation.
-  # If so, the publication counts as an international collaboration.
-  OPTIONAL {
-    BIND(EXISTS {
-      ?contributor :role [ a :Creator ] ;
-      :affiliation [ :country ?countryCode ] .
-      FILTER (?countryCode != "NO")
-    } AS ?isInternationalCollaboration
-    )
+    # Check if any contributor is a Creator with a non-Norwegian affiliation.
+    # If so, the publication counts as an international collaboration.
+    OPTIONAL {
+      BIND(EXISTS {
+        ?contributor :role [ a :Creator ] ;
+        :affiliation [ :country ?countryCode ] .
+        FILTER (?countryCode != "NO")
+      } AS ?isInternationalCollaboration
+      )
+    }
   }
 }


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49010

This replaces some `OPTIONAL` blocks with `UNION`, which significantly increases performance. The synthetic test case has similar performance (roughly 1 second per 1000 contributors) as the "production" documents that were causing time-outs.