### PR TITLE
[np-49196] fix: Handle contributors without verification status

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/dto/ContributorDto.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/dto/ContributorDto.java
@@ -26,6 +26,9 @@ public record ContributorDto(
     if (isNull(affiliations)) {
       affiliations = emptyList();
     }
+    if (isNull(verificationStatus)) {
+      verificationStatus = new VerificationStatus("Unknown");
+    }
   }
 
   public void validate() {


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49196

This avoids a `NullPointerException` when parsing documents that contain contributors with no verification status by setting a default value in the DTO.