### PR TITLE
[np-49197] fix: Handle contributors with multiple roles

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithSyntheticDataTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithSyntheticDataTest.java
@@ -145,6 +145,27 @@ class EvaluateNviCandidateWithSyntheticDataTest extends EvaluationTest {
         .build();
   }
 
+  @Test
+  void shouldHandleDuplicateContributorWithMultipleRoles() {
+    var expandedAffiliations = List.of(mapOrganizationToAffiliation(nviOrganization));
+    var contributorBuilder =
+        SampleExpandedContributor.builder()
+            .withId(randomUri())
+            .withVerificationStatus("Verified")
+            .withAffiliations(expandedAffiliations);
+    var creator = contributorBuilder.withRole("Creator").build();
+    var nonCreator = contributorBuilder.withRole("NonCreator").build();
+
+    var publication =
+        factory.withContributor(creator).withContributor(nonCreator).getExpandedPublication();
+
+    var candidate = getEvaluatedCandidate(publication);
+    assertThat(candidate.publicationDetails().contributors()).hasSize(1);
+    assertThat(candidate.nviCreators()).hasSize(1).extracting("id").containsExactly(creator.id());
+  }
+
+  // TODO: Add test case for single creator object with multiple roles in array
+
   private static Stream<Arguments> pageCountProvider() {
     return Stream.of(
         argumentSet("Monograph with page count", PAGE_NUMBER_AS_DTO, "AcademicMonograph", "Series"),

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithSyntheticDataTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateWithSyntheticDataTest.java
@@ -164,8 +164,6 @@ class EvaluateNviCandidateWithSyntheticDataTest extends EvaluationTest {
     assertThat(candidate.nviCreators()).hasSize(1).extracting("id").containsExactly(creator.id());
   }
 
-  // TODO: Add test case for single creator object with multiple roles in array
-
   private static Stream<Arguments> pageCountProvider() {
     return Stream.of(
         argumentSet("Monograph with page count", PAGE_NUMBER_AS_DTO, "AcademicMonograph", "Series"),

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/dto/ContributorDto.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/dto/ContributorDto.java
@@ -26,6 +26,9 @@ public record ContributorDto(
     if (isNull(affiliations)) {
       affiliations = emptyList();
     }
+    if (isNull(verificationStatus)) {
+      verificationStatus = new VerificationStatus("Unknown");
+    }
   }
 
   public void validate() {

--- a/nvi-commons/src/main/resources/publication_query.sparql
+++ b/nvi-commons/src/main/resources/publication_query.sparql
@@ -159,13 +159,15 @@ WHERE {
     OPTIONAL { ?organization :label ?label }
     OPTIONAL { ?organization :country ?country }
   } UNION {
-    # Find all contributors
+    # Find all contributors with the role of Creator
     ?publication :entityDescription ?entityDescription .
     ?entityDescription :contributor ?contributor .
 
     ?contributor :identity ?personId ;
     :role ?role .
     ?role a ?roleType .
+    FILTER (?roleType = :Creator)
+
     OPTIONAL { ?personId :verificationStatus ?verificationStatus }
     OPTIONAL {
       ?personId :name ?contributorName

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/dto/ContributorDtoTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/dto/ContributorDtoTest.java
@@ -4,7 +4,6 @@ import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_1_CONT
 import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_1;
 import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_2;
 import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_3;
-import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_4;
 import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_5;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -42,7 +41,6 @@ class ContributorDtoTest {
         argumentSet("EXAMPLE_2_CONTRIBUTOR_1", EXAMPLE_2_CONTRIBUTOR_1),
         argumentSet("EXAMPLE_2_CONTRIBUTOR_2", EXAMPLE_2_CONTRIBUTOR_2),
         argumentSet("EXAMPLE_2_CONTRIBUTOR_3", EXAMPLE_2_CONTRIBUTOR_3),
-        argumentSet("EXAMPLE_2_CONTRIBUTOR_4", EXAMPLE_2_CONTRIBUTOR_4),
         argumentSet("EXAMPLE_2_CONTRIBUTOR_5", EXAMPLE_2_CONTRIBUTOR_5));
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/examples/ExamplePublications.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/examples/ExamplePublications.java
@@ -5,7 +5,6 @@ import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_1_CONT
 import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_1;
 import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_2;
 import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_3;
-import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_4;
 import static no.sikt.nva.nvi.common.examples.ExampleContributors.EXAMPLE_2_CONTRIBUTOR_5;
 import static no.sikt.nva.nvi.common.examples.ExampleOrganizations.EXAMPLE_TOP_LEVEL_ORGANIZATION_3;
 import static no.sikt.nva.nvi.common.examples.ExampleOrganizations.TOP_LEVEL_ORGANIZATION_NTNU;
@@ -82,7 +81,6 @@ public class ExamplePublications {
                   EXAMPLE_2_CONTRIBUTOR_1,
                   EXAMPLE_2_CONTRIBUTOR_2,
                   EXAMPLE_2_CONTRIBUTOR_3,
-                  EXAMPLE_2_CONTRIBUTOR_4,
                   EXAMPLE_2_CONTRIBUTOR_5))
           .withTopLevelOrganizations(
               List.of(


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49197

Adds handling of documents where the same contributors is listed multiple times with different roles.
For simplicity, this is done by discarding all contributors that are not creators, as they are irrelevant here.
If non-creator contributors become relevant, we will have to handle this differently.