### PR TITLE
fix: Use null-check for migrated fields

### DIFF
--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/PublicationDetails.java
@@ -85,18 +85,11 @@ public record PublicationDetails(
         builder()
             .withId(dbCandidate.publicationId())
             .withPublicationBucketUri(dbCandidate.publicationBucketUri())
-            .withTitle(dbDetails.title())
-            .withStatus(dbDetails.status())
-            .withLanguage(dbDetails.language())
-            .withAbstract(dbDetails.abstractText())
             .withPublicationDate(PublicationDate.from(dbCandidate.getPublicationDate()))
-            .withPageCount(PageCount.from(dbDetails.pages()))
             .withIsApplicable(dbCandidate.applicable())
             .withPublicationChannel(PublicationChannel.from(candidateDao))
             .withNviCreators(nviCreators)
-            .withCreatorCount(dbDetails.contributorCount())
-            .withTopLevelOrganizations(topLevelOrganizations)
-            .withModifiedDate(dbDetails.modifiedDate());
+            .withTopLevelOrganizations(topLevelOrganizations);
 
     if (nonNull(dbDetails)) {
       return getPublicationDetailsWithMigratedFields(dbDetails, builder);


### PR DESCRIPTION
Fixes null-pointer exceptions on records that are not migrated yet.