### PR TITLE
removing approvals for the same institution when migrating nvi candidates from Cristin

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
@@ -159,6 +159,13 @@ public final class CristinMapper {
             cristinLocale ->
                 nonNull(cristinLocale.getInstitutionIdentifier()) || isKreftReg(cristinLocale))
         .map(CristinMapper::toApproval)
+        .collect(
+            Collectors.toMap(
+                DbApprovalStatus::institutionId,
+                approval -> approval,
+                (existing, replacement) -> existing))
+        .values()
+        .stream()
         .toList();
   }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinMapperTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinMapperTest.java
@@ -585,6 +585,21 @@ class CristinMapperTest {
     assertThat(nviCandidate.level(), is(equalTo(DbLevel.LEVEL_TWO)));
   }
 
+  @Test
+  void
+      shouldFilterOutDuplicatedApprovalsBasedOnInstitutionIdWhenMappingCristinLocalesToApprovals() {
+    var institutionIdentifier = randomString();
+    var cristinLocale =
+        cristinLocaleWithInstitutionIdentifierAndOwnerCode(institutionIdentifier, randomString());
+    var report =
+        CristinNviReport.builder()
+            .withCristinLocales(List.of(cristinLocale, cristinLocale))
+            .build();
+    var approvals = cristinMapper.toApprovals(report);
+
+    assertThat(approvals.size(), is(1));
+  }
+
   private static CristinNviReport nviReportWithInstanceTypeAndReference(
       String instanceType, String reference) {
     var institutionIdentifier = randomString();


### PR DESCRIPTION
When migrating nvi candidates from Cristin, we use CristinLocales to construct approvals. It shows up that nvi candidate in Cristin can contain multiple "approvals" pointing to the same institution. Removing those duplicates when importing them, as today they are failing on condition when persisting to database, cause institutionId for approval is primary key in DynamoDB. 

`Transaction request cannot include multiple operations on one item (Service: DynamoDb, Status Code: 400, Request ID: VOQHVFCPJ25L4D77N1SU5LTF4BVV4KQNSO5AEMVJF66Q9ASUAAJG) (SDK Attempt Count: 1)`