### PR TITLE
fix: Use dynamic permissions for streams

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -562,7 +562,7 @@ Resources:
                   - dynamodb:ListStreams
                   - dynamodb:GetRecords
                 Resource:
-                  - !GetAtt NvaNviTable.StreamArn
+                  - !Sub 'arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${NvaNviTable}/stream/*'
 
   GenerateIndexDocumentQueuePolicy:
     Type: AWS::SQS::QueuePolicy


### PR DESCRIPTION
Fixes CloudFormation issue with re-created streams (new ARN), same as in https://github.com/BIBSYSDEV/nva-publication-api/pull/2221