### PR TITLE
not failing when importing already existing nvi candidate

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
@@ -35,6 +35,7 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
   public static final String CRISTIN_DEPARTMENT_TRANSFERS = "cristin_transfer_departments.csv";
   public static final String CRISTIN_DEPARTMENT_TRANSFERS_STRING =
       IoUtils.stringFromResources(Path.of(CRISTIN_DEPARTMENT_TRANSFERS));
+  protected static final String PUBLICATION = "publication";
   private final CandidateRepository repository;
   private final S3Client s3Client;
   private final CristinMapper cristinMapper;
@@ -136,7 +137,7 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
     }
   }
 
-  public static URI createPublicationId(String identifier) {
-    return UriWrapper.fromHost(API_HOST).addChild("publication").addChild(identifier).getUri();
+  public static URI createPublicationId(String publicationIdentifier) {
+    return UriWrapper.fromHost(API_HOST).addChild(PUBLICATION).addChild(publicationIdentifier).getUri();
   }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
@@ -302,16 +302,4 @@ class CristinNviReportEventConsumerTest {
     sqsEvent.setRecords(List.of(message));
     return sqsEvent;
   }
-
-  private SQSEvent createEvent(String value) throws IOException {
-    var fullPath = UnixPath.of(randomString(), randomString());
-    var fileUri = s3Driver.insertFile(fullPath, value);
-    var eventReference = new EventReference(randomString(), randomString(), fileUri, Instant.now());
-    s3Driver.insertFile(fullPath, value);
-    var sqsEvent = new SQSEvent();
-    var message = new SQSMessage();
-    message.setBody(eventReference.toJsonString());
-    sqsEvent.setRecords(List.of(message));
-    return sqsEvent;
-  }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumerTest.java
@@ -11,6 +11,9 @@ import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -39,6 +42,7 @@ import nva.commons.core.paths.UriWrapper;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
 
 class CristinNviReportEventConsumerTest {
 
@@ -72,6 +76,29 @@ class CristinNviReportEventConsumerTest {
         Candidate.fetchByPublicationId(() -> publicationId, candidateRepository, periodRepository);
 
     assertThatNviCandidateHasExpectedValues(nviCandidate, cristinNviReport);
+  }
+
+  @Test
+  void shouldNotFailAnNotPersistErrorReportWhenAttemptingToImportAlreadyExistingNviCandidate()
+      throws IOException {
+    var cristinNviReport = randomCristinNviReport().build();
+    periodRepository.save(periodForYear(cristinNviReport.yearReported()));
+    handler.handleRequest(createEvent(cristinNviReport), CONTEXT);
+
+    var existingCandidate =
+        Candidate.fetchByPublicationId(
+            () -> toPublicationId(cristinNviReport), candidateRepository, periodRepository);
+    assertThat(existingCandidate, is(notNullValue()));
+
+    handler.handleRequest(createEvent(cristinNviReport), CONTEXT);
+
+    var s3ReportPath =
+        UriWrapper.fromHost(BUCKET_NAME)
+            .addChild(NVI_ERRORS)
+            .addChild(cristinNviReport.publicationIdentifier())
+            .toS3bucketPath();
+
+    assertThrows(NoSuchKeyException.class, () -> s3Driver.getFile(s3ReportPath));
   }
 
   @Test
@@ -269,6 +296,18 @@ class CristinNviReportEventConsumerTest {
     var fileUri = s3Driver.insertFile(fullPath, cristinNviReport.toJsonString());
     var eventReference = new EventReference(randomString(), randomString(), fileUri, Instant.now());
     s3Driver.insertFile(fullPath, cristinNviReport.toJsonString());
+    var sqsEvent = new SQSEvent();
+    var message = new SQSMessage();
+    message.setBody(eventReference.toJsonString());
+    sqsEvent.setRecords(List.of(message));
+    return sqsEvent;
+  }
+
+  private SQSEvent createEvent(String value) throws IOException {
+    var fullPath = UnixPath.of(randomString(), randomString());
+    var fileUri = s3Driver.insertFile(fullPath, value);
+    var eventReference = new EventReference(randomString(), randomString(), fileUri, Instant.now());
+    s3Driver.insertFile(fullPath, value);
     var sqsEvent = new SQSEvent();
     var message = new SQSMessage();
     message.setBody(eventReference.toJsonString());


### PR DESCRIPTION
Some sqs messages are received multiple when importing nvi candidates. This makes that we get error reports failing on conditional check when attempting to import already imported candidate. 

- Making a check that candidate already exists before importing it. 