### PR TITLE
[np-49257] refactor: Remove deprecated method and fix flaky test

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -20,6 +20,7 @@ import static no.sikt.nva.nvi.common.model.InstanceType.ACADEMIC_LITERATURE_REVI
 import static no.sikt.nva.nvi.common.model.InstanceType.ACADEMIC_MONOGRAPH;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.mockOrganizationResponseForAffiliation;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDate;
+import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDateInYear;
 import static no.sikt.nva.nvi.events.evaluator.TestUtils.createEvent;
 import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_NORWAY;
 import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_SWEDEN;
@@ -27,6 +28,7 @@ import static no.sikt.nva.nvi.test.TestConstants.CRISTIN_NVI_ORG_SUB_UNIT_ID;
 import static no.sikt.nva.nvi.test.TestConstants.CRISTIN_NVI_ORG_TOP_LEVEL_ID;
 import static no.sikt.nva.nvi.test.TestConstants.HARDCODED_CREATOR_ID;
 import static no.sikt.nva.nvi.test.TestConstants.HARDCODED_PUBLICATION_ID;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.createResponse;
 import static no.unit.nva.testutils.RandomDataGenerator.objectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -997,8 +999,8 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       // And the publication is published in an open period
       // When the publication date is updated to a year with no registered NVI period
       // Then the publication should be re-evaluated as a NonCandidate
-      var openPeriod = randomPublicationDate();
-      var nonPeriod = randomPublicationDate();
+      var openPeriod = randomPublicationDateInYear(CURRENT_YEAR);
+      var nonPeriod = randomPublicationDateInYear(CURRENT_YEAR + 1);
       setupOpenPeriod(scenario, openPeriod.year());
       var publicationFactory =
           factory
@@ -1021,9 +1023,9 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       // When the publication date is updated to a year with no registered NVI period
       // And the publication date is updated to a year with an open NVI period
       // Then the publication should be re-evaluated as a Candidate
-      var openPeriod = randomPublicationDate();
-      var nonPeriod = randomPublicationDate();
-      var newPeriod = randomPublicationDate();
+      var openPeriod = randomPublicationDateInYear(CURRENT_YEAR);
+      var nonPeriod = randomPublicationDateInYear(CURRENT_YEAR + 2);
+      var newPeriod = randomPublicationDateInYear(CURRENT_YEAR + 1);
       setupOpenPeriod(scenario, openPeriod.year());
       setupOpenPeriod(scenario, newPeriod.year());
       var publicationFactory = factory.withContributor(verifiedCreatorFrom(nviOrganization));

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/persist/UpsertNviCandidateHandlerTest.java
@@ -182,7 +182,7 @@ class UpsertNviCandidateHandlerTest {
     var candidate =
         Candidate.fetchByPublicationId(
             upsertCandidateRequest::publicationId, candidateRepository, periodRepository);
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         new UpdateStatusRequest(
             institutionId, ApprovalStatus.APPROVED, randomString(), randomString()));
     var approval = candidate.getApprovals().get(institutionId);

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -51,7 +51,6 @@ import no.sikt.nva.nvi.common.model.InstanceType;
 import no.sikt.nva.nvi.common.model.InvalidNviCandidateException;
 import no.sikt.nva.nvi.common.model.PointCalculation;
 import no.sikt.nva.nvi.common.model.PublicationChannel;
-import no.sikt.nva.nvi.common.model.UpdateApprovalRequest;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
 import no.sikt.nva.nvi.common.service.dto.ApprovalDto;
@@ -330,18 +329,6 @@ public final class Candidate {
         .withReportStatus(
             Optional.ofNullable(getReportStatus()).map(ReportStatus::getValue).orElse(null))
         .build();
-  }
-
-  /**
-   * @deprecated Use either
-   * {@link #updateApprovalAssignee(UpdateAssigneeRequest input) or
-   * {@link #updateApprovalStatus(UpdateStatusRequest input)} instead.
-   */
-  @Deprecated(since = "2025-01-31", forRemoval = true)
-  public Candidate updateApproval(UpdateApprovalRequest input) {
-    validateCandidateState();
-    approvals.computeIfPresent(input.institutionId(), (uri, approval) -> approval.update(input));
-    return this;
   }
 
   public Candidate updateApprovalAssignee(UpdateAssigneeRequest input) {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -119,7 +119,7 @@ class MigrationTests {
         CandidateFixtures.setupRandomApplicableCandidate(candidateRepository, periodRepository)
             .createNote(createNoteRequest(randomString(), randomString()), candidateRepository);
 
-    return candidate.updateApproval(
+    return candidate.updateApprovalStatus(
         createUpdateStatusRequest(
             ApprovalStatus.REJECTED, getInstitutionId(candidate), randomString()));
   }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateApprovalTest.java
@@ -295,19 +295,6 @@ class CandidateApprovalTest extends CandidateTestSetup {
     assertThat(assignee, is(equalTo(newUsername)));
   }
 
-  /*
-  This is deprecated because the method being tested is deprecated, remove both.
-  */
-  @Deprecated(since = "2025-01-31", forRemoval = true)
-  @Test
-  void shouldNotAllowUpdateApprovalStatusWhenTryingToPassAnonymousImplementations() {
-    var upsertCandidateRequest = createUpsertCandidateRequest(HARDCODED_INSTITUTION_ID).build();
-    var candidate = scenario.upsertCandidate(upsertCandidateRequest);
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> candidate.updateApproval(() -> HARDCODED_INSTITUTION_ID));
-  }
-
   @Test
   void shouldNotAllowUpdatingApprovalAssigneeWhenCandidateIsInClosedPeriod() {
     setupClosedPeriod(scenario, CURRENT_YEAR);

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -242,9 +242,9 @@ class CandidateTest extends CandidateTestSetup {
     var request = createUpsertCandidateRequest(organization1, organization2).build();
     var candidate = scenario.upsertCandidate(request);
 
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         createUpdateStatusRequest(approvalStatus, organization1.id(), randomString()));
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         createUpdateStatusRequest(approvalStatus, organization2.id(), randomString()));
 
     var updatedCandidate =
@@ -297,9 +297,9 @@ class CandidateTest extends CandidateTestSetup {
     var createRequest =
         createUpsertCandidateRequest(institution1, institution2, institution3).build();
     var candidate = scenario.upsertCandidate(createRequest);
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         createUpdateStatusRequest(ApprovalStatus.APPROVED, institution1, randomString()));
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         createUpdateStatusRequest(ApprovalStatus.REJECTED, institution2, randomString()));
     assertEquals(ApprovalStatus.PENDING, candidate.getApprovals().get(institution3).getStatus());
     assertEquals(GlobalApprovalStatus.DISPUTE, candidate.getGlobalApprovalStatus());
@@ -461,7 +461,7 @@ class CandidateTest extends CandidateTestSetup {
     UpsertNviCandidateRequest request =
         createUpsertCandidateRequestWithSingleAffiliation(reviewingInstitution, randomUri());
     var candidate = scenario.upsertCandidate(request);
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         createUpdateStatusRequest(approvalStatus, reviewingInstitution, randomString()));
     assertFalse(candidate.isPendingReview());
   }
@@ -475,7 +475,7 @@ class CandidateTest extends CandidateTestSetup {
     UpsertNviCandidateRequest request =
         createUpsertCandidateRequestWithSingleAffiliation(reviewingInstitution, randomUri());
     var candidate = scenario.upsertCandidate(request);
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         createUpdateStatusRequest(approvalStatus, reviewingInstitution, randomString()));
     assertTrue(candidate.isUnderReview());
   }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PublicationDateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PublicationDateFixtures.java
@@ -7,13 +7,16 @@ import no.sikt.nva.nvi.common.db.model.DbPublicationDate;
 import no.sikt.nva.nvi.common.dto.PublicationDateDto;
 
 public class PublicationDateFixtures {
-
-  public static PublicationDate randomPublicationDateInCurrentYear() {
+  public static PublicationDate randomPublicationDateInYear(int year) {
     var randomDate = randomLocalDate();
     return new PublicationDate(
-        String.valueOf(CURRENT_YEAR),
+        String.valueOf(year),
         String.valueOf(randomDate.getMonthValue()),
         String.valueOf(randomDate.getDayOfMonth()));
+  }
+
+  public static PublicationDate randomPublicationDateInCurrentYear() {
+    return randomPublicationDateInYear(CURRENT_YEAR);
   }
 
   public static PublicationDate randomPublicationDate() {

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
@@ -114,7 +114,7 @@ class FetchReportStatusByPublicationIdHandlerTest {
     var involvedInstitutions = new URI[] {institution1, randomUri()};
     var upsertCandidateRequest = createUpsertCandidateRequest(involvedInstitutions).build();
     var candidate = upsert(upsertCandidateRequest);
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         new UpdateStatusRequest(institution1, approvalStatus, randomString(), randomString()));
 
     handler.handleRequest(createRequest(candidate.getPublicationId()), output, context);
@@ -137,10 +137,10 @@ class FetchReportStatusByPublicationIdHandlerTest {
     var organization2 = randomTopLevelOrganization();
     var request = createUpsertCandidateRequest(organization1, organization2).build();
     var candidate = scenario.upsertCandidate(request);
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         new UpdateStatusRequest(
             organization1.id(), ApprovalStatus.APPROVED, randomString(), randomString()));
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         new UpdateStatusRequest(
             organization2.id(), ApprovalStatus.APPROVED, randomString(), randomString()));
 
@@ -165,10 +165,10 @@ class FetchReportStatusByPublicationIdHandlerTest {
     var request = createUpsertCandidateRequest(organization1, organization2).build();
     var candidate = scenario.upsertCandidate(request);
 
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         new UpdateStatusRequest(
             organization1.id(), ApprovalStatus.REJECTED, randomString(), randomString()));
-    candidate.updateApproval(
+    candidate.updateApprovalStatus(
         new UpdateStatusRequest(
             organization2.id(), ApprovalStatus.REJECTED, randomString(), randomString()));
 


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49257

This is initial refactoring to simplify work on the issue and not a solution for it.

Changes:

- fix: Use non-random year in flaky tests
- refactor: Remove deprecated `updateApproval` method that is no longer needed