### PR TITLE
batch scan recovery handler

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
@@ -65,7 +65,9 @@ public class BatchScanRecoveryHandler implements RequestStreamHandler {
       var candidateIdentifiers = getCandidateIdentifiers(messages);
       batchScanUtil.migrateAndUpdateVersion(candidateIdentifiers);
       messages.forEach(
-          message -> queueClient.deleteMessage(RECOVERY_BATCH_SCAN_QUEUE, message.receiptHandle()));
+          message ->
+              queueClient.deleteMessage(
+                  environment.readEnv(RECOVERY_BATCH_SCAN_QUEUE), message.receiptHandle()));
       counter += messages.size();
     }
   }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
@@ -1,0 +1,65 @@
+package no.sikt.nva.nvi.events.batch;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.queue.NviReceiveMessage;
+import no.sikt.nva.nvi.common.queue.QueueClient;
+import no.sikt.nva.nvi.common.utils.BatchScanUtil;
+import nva.commons.core.Environment;
+
+public class BatchScanRecoveryHandler implements RequestStreamHandler {
+
+  protected static final String RECOVERY_BATCH_SCAN_QUEUE = "BATCH_SCAN_RECOVERY_QUEUE";
+  protected static final String CANDIDATE_IDENTIFIER = "candidateIdentifier";
+  private final QueueClient queueClient;
+  private final Environment environment;
+  private final BatchScanUtil batchScanUtil;
+
+  public BatchScanRecoveryHandler(
+      QueueClient queueClient, BatchScanUtil batchScanUtil, Environment environment) {
+    this.queueClient = queueClient;
+    this.batchScanUtil = batchScanUtil;
+    this.environment = environment;
+  }
+
+  @Override
+  public void handleRequest(InputStream inputStream, OutputStream outputStream, Context context)
+      throws IOException {
+    var request = RecoveryEvent.fromInputStream(inputStream);
+    processRequest(request);
+  }
+
+  private static List<UUID> getCandidateIdentifiers(List<NviReceiveMessage> messages) {
+    return messages.stream()
+        .map(message -> message.messageAttributes().get(CANDIDATE_IDENTIFIER))
+        .map(UUID::fromString)
+        .toList();
+  }
+
+  private void processRequest(RecoveryEvent request) {
+    int counter = 0;
+    while (counter < request.numberOfMessageToProcess()) {
+      var messages =
+          queueClient
+              .receiveMessage(
+                  environment.readEnv(RECOVERY_BATCH_SCAN_QUEUE),
+                  request.numberOfMessageToProcess())
+              .messages();
+
+      if (messages.isEmpty()) {
+        break;
+      }
+
+      var candidateIdentifiers = getCandidateIdentifiers(messages);
+      batchScanUtil.migrateAndUpdateVersion(candidateIdentifiers);
+      messages.forEach(
+          message -> queueClient.deleteMessage(RECOVERY_BATCH_SCAN_QUEUE, message.receiptHandle()));
+      counter += messages.size();
+    }
+  }
+}

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
@@ -1,5 +1,6 @@
 package no.sikt.nva.nvi.events.batch;
 
+import static no.sikt.nva.nvi.common.queue.NviQueueClient.defaultSqsClient;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import java.io.IOException;
@@ -7,10 +8,12 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
 import java.util.UUID;
+import no.sikt.nva.nvi.common.queue.NviQueueClient;
 import no.sikt.nva.nvi.common.queue.NviReceiveMessage;
 import no.sikt.nva.nvi.common.queue.QueueClient;
 import no.sikt.nva.nvi.common.utils.BatchScanUtil;
 import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
 
 public class BatchScanRecoveryHandler implements RequestStreamHandler {
 
@@ -20,6 +23,10 @@ public class BatchScanRecoveryHandler implements RequestStreamHandler {
   private final Environment environment;
   private final BatchScanUtil batchScanUtil;
 
+  @JacocoGenerated
+  private BatchScanRecoveryHandler() {
+    this(new NviQueueClient(), BatchScanUtil.defaultNviService(), new Environment())M
+  }
   public BatchScanRecoveryHandler(
       QueueClient queueClient, BatchScanUtil batchScanUtil, Environment environment) {
     this.queueClient = queueClient;

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
@@ -51,11 +51,10 @@ public class BatchScanRecoveryHandler implements RequestStreamHandler {
   private void processRequest(RecoveryEvent request) {
     int counter = 0;
     while (counter < request.numberOfMessageToProcess()) {
+      int batchSize = Math.min(request.numberOfMessageToProcess(), 10);
       var messages =
           queueClient
-              .receiveMessage(
-                  environment.readEnv(RECOVERY_BATCH_SCAN_QUEUE),
-                  request.numberOfMessageToProcess())
+              .receiveMessage(environment.readEnv(RECOVERY_BATCH_SCAN_QUEUE), batchSize)
               .messages();
 
       if (messages.isEmpty()) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.events.batch;
 
-import static no.sikt.nva.nvi.common.queue.NviQueueClient.defaultSqsClient;
 import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestStreamHandler;
 import java.io.IOException;
@@ -25,7 +24,7 @@ public class BatchScanRecoveryHandler implements RequestStreamHandler {
 
   @JacocoGenerated
   private BatchScanRecoveryHandler() {
-    this(new NviQueueClient(), BatchScanUtil.defaultNviService(), new Environment())M
+    this(new NviQueueClient(), BatchScanUtil.defaultNviService(), new Environment());
   }
   public BatchScanRecoveryHandler(
       QueueClient queueClient, BatchScanUtil batchScanUtil, Environment environment) {

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
@@ -26,6 +26,7 @@ public class BatchScanRecoveryHandler implements RequestStreamHandler {
   private BatchScanRecoveryHandler() {
     this(new NviQueueClient(), BatchScanUtil.defaultNviService(), new Environment());
   }
+
   public BatchScanRecoveryHandler(
       QueueClient queueClient, BatchScanUtil batchScanUtil, Environment environment) {
     this.queueClient = queueClient;

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandler.java
@@ -23,7 +23,7 @@ public class BatchScanRecoveryHandler implements RequestStreamHandler {
   private final BatchScanUtil batchScanUtil;
 
   @JacocoGenerated
-  private BatchScanRecoveryHandler() {
+  public BatchScanRecoveryHandler() {
     this(new NviQueueClient(), BatchScanUtil.defaultNviService(), new Environment());
   }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/RecoveryEvent.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/RecoveryEvent.java
@@ -1,0 +1,16 @@
+package no.sikt.nva.nvi.events.batch;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.InputStream;
+import no.unit.nva.commons.json.JsonSerializable;
+import no.unit.nva.commons.json.JsonUtils;
+import nva.commons.core.ioutils.IoUtils;
+
+public record RecoveryEvent(int numberOfMessageToProcess) implements JsonSerializable {
+
+  public static RecoveryEvent fromInputStream(InputStream inputStream)
+      throws JsonProcessingException {
+    var value = IoUtils.streamToString(inputStream);
+    return JsonUtils.dtoObjectMapper.readValue(value, RecoveryEvent.class);
+  }
+}

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandlerTest.java
@@ -1,0 +1,123 @@
+package no.sikt.nva.nvi.events.batch;
+
+import static no.sikt.nva.nvi.common.EnvironmentFixtures.BATCH_SCAN_RECOVERY_QUEUE;
+import static no.sikt.nva.nvi.common.EnvironmentFixtures.getBatchScanRecoveryHandlerEnvironment;
+import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createNumberOfCandidatesForYear;
+import static no.sikt.nva.nvi.test.TestUtils.randomYear;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import no.sikt.nva.nvi.common.TestScenario;
+import no.sikt.nva.nvi.common.db.CandidateDao;
+import no.sikt.nva.nvi.common.db.CandidateRepository;
+import no.sikt.nva.nvi.common.queue.FakeSqsClient;
+import no.sikt.nva.nvi.common.utils.BatchScanUtil;
+import no.unit.nva.stubs.FakeContext;
+import nva.commons.core.Environment;
+import nva.commons.core.ioutils.IoUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class BatchScanRecoveryHandlerTest {
+
+  protected static final FakeContext CONTEXT = new FakeContext();
+  private CandidateRepository candidateRepository;
+  private TestScenario scenario;
+  private FakeSqsClient queueClient;
+  private BatchScanRecoveryHandler handler;
+  private OutputStream output;
+  private Environment environment;
+
+  @BeforeEach
+  public void setup() {
+    scenario = new TestScenario();
+    candidateRepository = scenario.getCandidateRepository();
+    output = new ByteArrayOutputStream();
+    queueClient = new FakeSqsClient();
+    environment = getBatchScanRecoveryHandlerEnvironment();
+    var batchScanUtil =
+        new BatchScanUtil(
+            scenario.getCandidateRepository(),
+            scenario.getS3StorageReaderForExpandedResourcesBucket(),
+            queueClient,
+            environment);
+    handler = new BatchScanRecoveryHandler(queueClient, batchScanUtil, environment);
+  }
+
+  @Test
+  void shouldRerunEntriesOnRecoveryQueue() throws IOException {
+    var candidates =
+        createNumberOfCandidatesForYear(randomYear(), 2, candidateRepository).stream()
+            .map(this::placeOnQueue)
+            .toList();
+
+    var messagesOnQueue =
+        queueClient.getAllSentSqsEvents(environment.readEnv(BATCH_SCAN_RECOVERY_QUEUE.getKey()));
+
+    assertMessagesExistOnQueue(candidates, messagesOnQueue);
+
+    handler.handleRequest(createEvent(new RecoveryEvent(10)), output, CONTEXT);
+
+    candidates.forEach(
+        candidate ->
+            assertFalse(getMigratedCandidate(candidate).version().equals(candidate.version())));
+  }
+
+  @Test
+  void shouldKeepNotProcessedMessagesOnQueue() throws IOException {
+    var candidates =
+        createNumberOfCandidatesForYear(randomYear(), 5, candidateRepository).stream()
+            .map(this::placeOnQueue)
+            .toList();
+
+    var messagesOnQueue =
+        queueClient.getAllSentSqsEvents(environment.readEnv(BATCH_SCAN_RECOVERY_QUEUE.getKey()));
+
+    assertMessagesExistOnQueue(candidates, messagesOnQueue);
+
+    handler.handleRequest(createEvent(new RecoveryEvent(2)), output, CONTEXT);
+
+    assertEquals(
+        3,
+        queueClient
+            .getAllSentSqsEvents(environment.readEnv(BATCH_SCAN_RECOVERY_QUEUE.getKey()))
+            .size());
+  }
+
+  private static void assertMessagesExistOnQueue(
+      List<CandidateDao> candidates, List<SQSMessage> messagesOnQueue) {
+    candidates.forEach(
+        candidate ->
+            assertTrue(
+                messagesOnQueue.stream()
+                    .anyMatch(
+                        message ->
+                            message
+                                .getMessageAttributes()
+                                .get("candidateIdentifier")
+                                .getStringValue()
+                                .equals(candidate.identifier().toString()))));
+  }
+
+  private CandidateDao getMigratedCandidate(CandidateDao candidate) {
+    return candidateRepository.findCandidateById(candidate.identifier()).orElseThrow();
+  }
+
+  private CandidateDao placeOnQueue(CandidateDao candidateDao) {
+    queueClient.sendMessage(
+        randomString(), BATCH_SCAN_RECOVERY_QUEUE.getValue(), candidateDao.identifier());
+    return candidateDao;
+  }
+
+  private InputStream createEvent(RecoveryEvent event) {
+    return IoUtils.stringToStream(event.toJsonString());
+  }
+}

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandlerTest.java
@@ -6,7 +6,7 @@ import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createNumberOfCandi
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage;
@@ -30,7 +30,6 @@ class BatchScanRecoveryHandlerTest {
 
   protected static final FakeContext CONTEXT = new FakeContext();
   private CandidateRepository candidateRepository;
-  private TestScenario scenario;
   private FakeSqsClient queueClient;
   private BatchScanRecoveryHandler handler;
   private OutputStream output;
@@ -38,7 +37,7 @@ class BatchScanRecoveryHandlerTest {
 
   @BeforeEach
   public void setup() {
-    scenario = new TestScenario();
+    TestScenario scenario = new TestScenario();
     candidateRepository = scenario.getCandidateRepository();
     output = new ByteArrayOutputStream();
     queueClient = new FakeSqsClient();
@@ -68,7 +67,7 @@ class BatchScanRecoveryHandlerTest {
 
     candidates.forEach(
         candidate ->
-            assertFalse(getMigratedCandidate(candidate).version().equals(candidate.version())));
+            assertNotEquals(getMigratedCandidate(candidate).version(), candidate.version()));
   }
 
   @Test

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -122,6 +122,7 @@ public class CandidateRepository extends DynamoRepository {
             .identifier(identifier)
             .candidate(dbCandidate)
             .periodYear(year)
+            .version(randomUUID().toString())
             .build();
     var uniqueness = new CandidateUniquenessEntryDao(dbCandidate.publicationId().toString());
     var transactionBuilder = buildTransaction(approvalStatuses, candidate, identifier, uniqueness);

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/BatchScanUtil.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/BatchScanUtil.java
@@ -75,10 +75,12 @@ public class BatchScanUtil {
   }
 
   public void migrateAndUpdateVersion(Collection<UUID> candidateIdentifiers) {
-    var migratedCandidates = candidateIdentifiers.stream().map(candidateRepository::findCandidateById)
-                         .flatMap(Optional::stream)
-                         .map(this::migrate)
-                         .toList();
+    var migratedCandidates =
+        candidateIdentifiers.stream()
+            .map(candidateRepository::findCandidateById)
+            .flatMap(Optional::stream)
+            .map(this::migrate)
+            .toList();
     candidateRepository.writeEntries(migratedCandidates);
   }
 
@@ -102,9 +104,7 @@ public class BatchScanUtil {
       return migrateCandidateDao(candidateDao);
     } catch (Exception e) {
       queueClient.sendMessage(
-          e.toString(),
-          environment.readEnv(BATCH_SCAN_RECOVERY_QUEUE),
-          candidateDao.identifier());
+          e.toString(), environment.readEnv(BATCH_SCAN_RECOVERY_QUEUE), candidateDao.identifier());
       return candidateDao;
     }
   }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
@@ -32,7 +32,6 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -62,20 +61,20 @@ class BatchScanUtilTest {
   private BatchScanUtil batchScanUtil;
   private CandidateRepository candidateRepository;
   private TestScenario scenario;
-  private FakeSqsClient dlqClient;
+  private FakeSqsClient queueClient;
 
   @BeforeEach
   void setup() {
     scenario = new TestScenario();
     candidateRepository = scenario.getCandidateRepository();
 
-    dlqClient = new FakeSqsClient();
+    queueClient = new FakeSqsClient();
     var environment = getEventBasedBatchScanHandlerEnvironment();
     batchScanUtil =
         new BatchScanUtil(
             scenario.getCandidateRepository(),
             scenario.getS3StorageReaderForExpandedResourcesBucket(),
-            dlqClient,
+            queueClient,
             environment);
   }
 
@@ -400,7 +399,7 @@ class BatchScanUtilTest {
 
     batchScanUtil.migrateAndUpdateVersion(10, null, emptyList());
 
-    var sqsMessage = dlqClient.getAllSentSqsEvents(BATCH_SCAN_RECOVERY_QUEUE.getValue()).getFirst();
+    var sqsMessage = queueClient.getAllSentSqsEvents(BATCH_SCAN_RECOVERY_QUEUE.getValue()).getFirst();
 
     assertEquals(
         candidate.identifier().toString(),

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
@@ -32,6 +32,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
@@ -399,7 +400,8 @@ class BatchScanUtilTest {
 
     batchScanUtil.migrateAndUpdateVersion(10, null, emptyList());
 
-    var sqsMessage = queueClient.getAllSentSqsEvents(BATCH_SCAN_RECOVERY_QUEUE.getValue()).getFirst();
+    var sqsMessage =
+        queueClient.getAllSentSqsEvents(BATCH_SCAN_RECOVERY_QUEUE.getValue()).getFirst();
 
     assertEquals(
         candidate.identifier().toString(),

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
@@ -76,9 +76,9 @@ public enum EnvironmentFixtures {
 
   public static FakeEnvironment getBatchScanRecoveryHandlerEnvironment() {
     return getDefaultEnvironmentBuilder()
-               .with(EXPANDED_RESOURCES_BUCKET)
-               .with(BATCH_SCAN_RECOVERY_QUEUE)
-               .build();
+        .with(EXPANDED_RESOURCES_BUCKET)
+        .with(BATCH_SCAN_RECOVERY_QUEUE)
+        .build();
   }
 
   public static FakeEnvironment getUpsertNviCandidateHandlerEnvironment() {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
@@ -74,6 +74,13 @@ public enum EnvironmentFixtures {
         .build();
   }
 
+  public static FakeEnvironment getBatchScanRecoveryHandlerEnvironment() {
+    return getDefaultEnvironmentBuilder()
+               .with(EXPANDED_RESOURCES_BUCKET)
+               .with(BATCH_SCAN_RECOVERY_QUEUE)
+               .build();
+  }
+
   public static FakeEnvironment getUpsertNviCandidateHandlerEnvironment() {
     return getDefaultEnvironmentBuilder().with(UPSERT_CANDIDATE_DLQ_QUEUE_URL).build();
   }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/queue/FakeSqsClient.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/queue/FakeSqsClient.java
@@ -101,15 +101,22 @@ public class FakeSqsClient implements QueueClient {
   public NviReceiveMessageResponse receiveMessage(String queueUrl, int maxNumberOfMessages) {
     validateQueueUrl(queueUrl);
     var numberOfMessages = Math.min(maxNumberOfMessages, sentMessages.size());
-    return new NviReceiveMessageResponse(sentMessages.subList(0, numberOfMessages).stream()
-                                      .map(sendMessageRequest -> new NviReceiveMessage(sendMessageRequest.messageBody(), null, sendMessageRequest.messageAttributes().entrySet().stream()
-                                                                                                                                   .collect(
-                                                                                                                                       Collectors.toMap(
-                                                                                                                                           Entry::getKey, entry -> entry.getValue().stringValue())), null))
-                                      .toList());
+    return new NviReceiveMessageResponse(
+        sentMessages.subList(0, numberOfMessages).stream()
+            .map(
+                sendMessageRequest ->
+                    new NviReceiveMessage(
+                        sendMessageRequest.messageBody(),
+                        null,
+                        sendMessageRequest.messageAttributes().entrySet().stream()
+                            .collect(
+                                Collectors.toMap(
+                                    Entry::getKey, entry -> entry.getValue().stringValue())),
+                        null))
+            .toList());
   }
 
-  //TODO: Fix-me Should delete by receiptHandle
+  // TODO: Fix-me Should delete by receiptHandle
   @Override
   public void deleteMessage(String queueUrl, String receiptHandle) {
     validateQueueUrl(queueUrl);

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/queue/FakeSqsClient.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/queue/FakeSqsClient.java
@@ -7,8 +7,10 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.QueueServiceTestUtils;
 import software.amazon.awssdk.services.sqs.model.BatchResultErrorEntry;
@@ -98,15 +100,22 @@ public class FakeSqsClient implements QueueClient {
   @Override
   public NviReceiveMessageResponse receiveMessage(String queueUrl, int maxNumberOfMessages) {
     validateQueueUrl(queueUrl);
-    receivedMessages.add(createReceiveRequest(queueUrl, maxNumberOfMessages));
-    return createResponse(ReceiveMessageResponse.builder().build());
+    var numberOfMessages = Math.min(maxNumberOfMessages, sentMessages.size());
+    return new NviReceiveMessageResponse(sentMessages.subList(0, numberOfMessages).stream()
+                                      .map(sendMessageRequest -> new NviReceiveMessage(sendMessageRequest.messageBody(), null, sendMessageRequest.messageAttributes().entrySet().stream()
+                                                                                                                                   .collect(
+                                                                                                                                       Collectors.toMap(
+                                                                                                                                           Entry::getKey, entry -> entry.getValue().stringValue())), null))
+                                      .toList());
   }
 
+  //TODO: Fix-me Should delete by receiptHandle
   @Override
   public void deleteMessage(String queueUrl, String receiptHandle) {
     validateQueueUrl(queueUrl);
     var request =
         DeleteMessageRequest.builder().queueUrl(queueUrl).receiptHandle(receiptHandle).build();
+    sentMessages.remove(0);
     deleteMessages.add(request);
   }
 

--- a/template.yaml
+++ b/template.yaml
@@ -678,6 +678,23 @@ Resources:
       RestApiId: !Ref ScientificIndexApi
       Stage: !Ref ScientificIndexApi.Stage
 
+  #============================= Button Handlers ======================================================
+  BatchScanRecoveryHandler:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: event-handlers
+      Handler: no.sikt.nva.nvi.events.batch.BatchScanRecoveryHandler::handleRequest
+      Role: !GetAtt NvaNviRole.Arn
+      Timeout: 900
+      MemorySize: 1536
+      AutoPublishAlias: live
+      SnapStart:
+        ApplyOn: PublishedVersions
+      Environment:
+        Variables:
+          EXPANDED_RESOURCES_BUCKET: !Ref ResourcesBucket
+          BATCH_SCAN_RECOVERY_QUEUE: !Ref BatchScanRecoveryQueue
+
   #============================= Event Handlers ======================================================
   QueuePersistedResourceHandler:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49358

This sets up a handler to process failed messages from BatchScan in batches. When BatchScan fails to process a record, it skips the record and throws it to a DLQ which this new handler consumes (after being manually triggered).