### PR TITLE
[np-49350] feat: Handle missing data during import

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
@@ -1,8 +1,8 @@
 package no.sikt.nva.nvi.events.cristin;
 
 import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
-import static no.sikt.nva.nvi.events.cristin.CristinMapper.API_HOST;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
+import static nva.commons.core.StringUtils.isNotBlank;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -13,18 +13,23 @@ import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.dataformat.csv.CsvMapper;
 import com.fasterxml.jackson.dataformat.csv.CsvSchema;
 import java.io.StringReader;
-import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
+import no.sikt.nva.nvi.common.S3StorageReader;
+import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
+import no.sikt.nva.nvi.common.dto.PublicationDto;
+import no.sikt.nva.nvi.common.service.PublicationLoaderService;
 import no.unit.nva.events.models.EventReference;
 import no.unit.nva.s3.S3Driver;
+import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import nva.commons.core.ioutils.IoUtils;
-import nva.commons.core.paths.UriWrapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.s3.S3Client;
 
 public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, Void> {
@@ -34,35 +39,78 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
   public static final String CRISTIN_DEPARTMENT_TRANSFERS = "cristin_transfer_departments.csv";
   public static final String CRISTIN_DEPARTMENT_TRANSFERS_STRING =
       IoUtils.stringFromResources(Path.of(CRISTIN_DEPARTMENT_TRANSFERS));
-  protected static final String PUBLICATION = "publication";
+  private static final String EXPANDED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
   private final CandidateRepository repository;
   private final S3Client s3Client;
   private final CristinMapper cristinMapper;
+  private final PublicationLoaderService publicationLoader;
+  private final Logger logger = LoggerFactory.getLogger(CristinNviReportEventConsumer.class);
 
   @JacocoGenerated
   public CristinNviReportEventConsumer() {
-    this.repository = new CandidateRepository(defaultDynamoClient());
-    this.s3Client = S3Driver.defaultS3Client().build();
-    this.cristinMapper = CristinMapper.withDepartmentTransfers(readCristinDepartments());
+    this(
+        new CandidateRepository(defaultDynamoClient()),
+        S3Driver.defaultS3Client().build(),
+        new Environment());
   }
 
-  public CristinNviReportEventConsumer(CandidateRepository candidateRepository, S3Client s3Client) {
+  public CristinNviReportEventConsumer(
+      CandidateRepository candidateRepository, S3Client s3Client, Environment environment) {
     this.repository = candidateRepository;
     this.s3Client = s3Client;
-    this.cristinMapper = CristinMapper.withDepartmentTransfers(readCristinDepartments());
+    this.cristinMapper =
+        CristinMapper.withDepartmentTransfers(readCristinDepartments(), environment);
+    this.publicationLoader =
+        new PublicationLoaderService(
+            new S3StorageReader(s3Client, environment.readEnv(EXPANDED_RESOURCES_BUCKET)));
   }
 
   @Override
   public Void handleRequest(SQSEvent sqsEvent, Context context) {
-
+    logger.info("Received {} messages from SQS", sqsEvent.getRecords().size());
     sqsEvent.getRecords().stream().map(SQSMessage::getBody).forEach(this::processMessageBody);
-
+    logger.info("Finished processing messages from SQS");
     return null;
   }
 
   private DbCandidate createDbCandidate(CristinNviReport cristinNviReport) {
-    return attempt(() -> cristinMapper.toDbCandidate(cristinNviReport))
-        .orElseThrow(CristinConversionException::fromFailure);
+    var historicalCandidate =
+        attempt(() -> cristinMapper.toDbCandidate(cristinNviReport))
+            .orElseThrow(CristinConversionException::fromFailure);
+    var publication =
+        publicationLoader.extractAndTransform(historicalCandidate.publicationBucketUri());
+    return createUpdatedDbCandidate(historicalCandidate, publication);
+  }
+
+  /**
+   * This uses the current version of the publication to add data missing from the imported result.
+   *
+   * @param historicalCandidate DbCandidate object based entirely on imported data (as reported)
+   * @param publication PublicationDto based on current version of persisted publication
+   * @return A DbCandidate with all required fields set
+   */
+  private DbCandidate createUpdatedDbCandidate(
+      DbCandidate historicalCandidate, PublicationDto publication) {
+    var historicalDetails = historicalCandidate.publicationDetails();
+
+    var currentTopLevelOrganizations =
+        publication.topLevelOrganizations().stream().map(Organization::toDbOrganization).toList();
+    var updatedPublicationDetails =
+        historicalDetails
+            .copy()
+            .abstractText(
+                firstValidValue(historicalDetails.abstractText(), publication.abstractText()))
+            .title(firstValidValue(historicalDetails.title(), publication.title()))
+            .language(firstValidValue(historicalDetails.language(), publication.language()))
+            .status(firstValidValue(historicalDetails.status(), publication.status()))
+            .identifier(firstValidValue(historicalDetails.identifier(), publication.identifier()))
+            .topLevelNviOrganizations(currentTopLevelOrganizations)
+            .build();
+    return historicalCandidate.copy().publicationDetails(updatedPublicationDetails).build();
+  }
+
+  private String firstValidValue(String originalValue, String updatedValue) {
+    return isNotBlank(originalValue) ? originalValue : updatedValue;
   }
 
   private List<DbApprovalStatus> createApprovals(CristinNviReport cristinNviReport) {
@@ -83,9 +131,10 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
   private CandidateDao processBody(String value) {
     var eventReference = EventReference.fromJson(value);
     var cristinNviReport = createNviReport(eventReference);
+    var publicationId = cristinMapper.constructPublicationId(cristinNviReport);
     try {
       return repository
-          .findByPublicationId(createPublicationId(cristinNviReport.publicationIdentifier()))
+          .findByPublicationId(publicationId)
           .orElseGet(() -> createAndPersist(cristinNviReport));
     } catch (Exception e) {
       ErrorReport.withMessage(e.getMessage())
@@ -112,12 +161,18 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
   }
 
   private CandidateDao createAndPersist(CristinNviReport cristinNviReport) {
+    logger.info(
+        "Processing CristinNviReport with publication identifier: {}",
+        cristinNviReport.publicationIdentifier());
     var approvals = createApprovals(cristinNviReport);
     var candidate = createDbCandidate(cristinNviReport);
     var yearReported = cristinNviReport.getYearReportedFromHistoricalData();
     if (yearReported.isEmpty()) {
       throw new IllegalArgumentException(MISSING_REPORTED_YEAR_MESSAGE);
     } else {
+      logger.info(
+          "Persisting imported NVI result with identifier: {}",
+          cristinNviReport.publicationIdentifier());
       return repository.create(candidate, approvals, yearReported.get());
     }
   }
@@ -139,12 +194,5 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-  }
-
-  public static URI createPublicationId(String publicationIdentifier) {
-    return UriWrapper.fromHost(API_HOST)
-        .addChild(PUBLICATION)
-        .addChild(publicationIdentifier)
-        .getUri();
   }
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
@@ -123,11 +123,10 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
   }
 
   /**
-   * Reads the CSV file containing mappings of transferred department identifiers.
-   * The CSV file is used to map creators' affiliations to their corresponding
-   * institutions in cases where the department has been transferred from one
-   * institution to another. This ensures that institution points are correctly
-   * calculated based on the updated affiliations.
+   * Reads the CSV file containing mappings of transferred department identifiers. The CSV file is
+   * used to map creators' affiliations to their corresponding institutions in cases where the
+   * department has been transferred from one institution to another. This ensures that institution
+   * points are correctly calculated based on the updated affiliations.
    */
   private List<CristinDepartmentTransfer> readCristinDepartments() {
     try (StringReader reader = new StringReader(CRISTIN_DEPARTMENT_TRANSFERS_STRING)) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinIdWrapper.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinIdWrapper.java
@@ -1,0 +1,121 @@
+package no.sikt.nva.nvi.events.cristin;
+
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.getAsOrganizationLeafNode;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.organizationIdFromIdentifier;
+import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_NORWAY;
+
+import java.net.URI;
+import java.util.List;
+import no.sikt.nva.nvi.common.client.model.Organization;
+
+public record CristinIdWrapper(
+    String institutionIdentifier,
+    String departmentIdentifier,
+    String subDepartmentIdentifier,
+    String groupIdentifier) {
+
+  public static CristinIdWrapper from(CristinLocale cristinLocale) {
+    return new CristinIdWrapper(
+        cristinLocale.getInstitutionIdentifier(),
+        cristinLocale.getDepartmentIdentifier(),
+        cristinLocale.getSubDepartmentIdentifier(),
+        cristinLocale.getGroupIdentifier());
+  }
+
+  public static CristinIdWrapper from(ScientificPerson scientificPerson) {
+    return new CristinIdWrapper(
+        scientificPerson.getInstitutionIdentifier(),
+        scientificPerson.getDepartmentIdentifier(),
+        scientificPerson.getSubDepartmentIdentifier(),
+        scientificPerson.getGroupIdentifier());
+  }
+
+  public String getInstitutionIdentifier() {
+    return organizationIdentifierFromUnitIdentifiers(institutionIdentifier, "0", "0", "0");
+  }
+
+  public URI getInstitutionId() {
+    return organizationIdFromIdentifier(getInstitutionIdentifier());
+  }
+
+  public String getDepartmentIdentifier() {
+    return organizationIdentifierFromUnitIdentifiers(
+        institutionIdentifier, departmentIdentifier, "0", "0");
+  }
+
+  public URI getDepartmentId() {
+    return organizationIdFromIdentifier(getDepartmentIdentifier());
+  }
+
+  public String getSubDepartmentIdentifier() {
+    return organizationIdentifierFromUnitIdentifiers(
+        institutionIdentifier, departmentIdentifier, subDepartmentIdentifier, "0");
+  }
+
+  public URI getSubDepartmentId() {
+    return organizationIdFromIdentifier(getSubDepartmentIdentifier());
+  }
+
+  public String getGroupIdentifier() {
+    return organizationIdentifierFromUnitIdentifiers(
+        institutionIdentifier, departmentIdentifier, subDepartmentIdentifier, groupIdentifier);
+  }
+
+  public URI getGroupId() {
+    return organizationIdFromIdentifier(getGroupIdentifier());
+  }
+
+  public Organization getTopLevelOrganization() {
+    var builder = Organization.builder().withCountryCode(COUNTRY_CODE_NORWAY);
+    var group =
+        builder
+            .withId(getGroupId())
+            .withPartOf(List.of(getAsOrganizationLeafNode(getSubDepartmentId())))
+            .build();
+    var subDepartment =
+        builder
+            .withId(getSubDepartmentId())
+            .withHasPart(List.of(group))
+            .withPartOf(List.of(getAsOrganizationLeafNode(getDepartmentId())))
+            .build();
+    var department =
+        builder
+            .withId(getDepartmentId())
+            .withHasPart(List.of(subDepartment))
+            .withPartOf(List.of(getAsOrganizationLeafNode(getInstitutionId())))
+            .build();
+    return builder.withId(getInstitutionId()).withHasPart(List.of(department)).build();
+  }
+
+  public Organization createLeafNodeOrganization() {
+    var builder = Organization.builder().withCountryCode(COUNTRY_CODE_NORWAY);
+    var topLevelOrganization =
+        builder
+            .withId(getInstitutionId())
+            .withHasPart(List.of(getAsOrganizationLeafNode(getDepartmentId())))
+            .build();
+    var department =
+        builder
+            .withId(getDepartmentId())
+            .withHasPart(List.of(getAsOrganizationLeafNode(getSubDepartmentId())))
+            .withPartOf(List.of(topLevelOrganization))
+            .build();
+    var subDepartment =
+        builder
+            .withId(getSubDepartmentId())
+            .withHasPart(List.of(getAsOrganizationLeafNode(getGroupId())))
+            .withPartOf(List.of(department))
+            .build();
+    return builder.withId(getGroupId()).withPartOf(List.of(subDepartment)).build();
+  }
+
+  private static String organizationIdentifierFromUnitIdentifiers(
+      String topLevelIdentifier,
+      String departmentIdentifier,
+      String subDepartmentIdentifier,
+      String groupIdentifier) {
+    return String.format(
+        "%s.%s.%s.%s",
+        topLevelIdentifier, departmentIdentifier, subDepartmentIdentifier, groupIdentifier);
+  }
+}

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinTestUtils.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/cristin/CristinTestUtils.java
@@ -1,0 +1,91 @@
+package no.sikt.nva.nvi.events.cristin;
+
+import static java.util.Objects.nonNull;
+import static no.sikt.nva.nvi.common.EnvironmentFixtures.API_HOST;
+import static no.sikt.nva.nvi.common.model.ContributorFixtures.ROLE_CREATOR;
+import static no.sikt.nva.nvi.common.model.ContributorFixtures.STATUS_VERIFIED;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.organizationIdFromIdentifier;
+import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDate;
+import static no.sikt.nva.nvi.test.TestUtils.generateUniqueIdAsString;
+import static no.unit.nva.testutils.RandomDataGenerator.randomString;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.List;
+import no.sikt.nva.nvi.common.SampleExpandedPublicationFactory;
+import no.sikt.nva.nvi.common.TestScenario;
+import no.sikt.nva.nvi.common.client.model.Organization;
+import no.sikt.nva.nvi.common.dto.ContributorDto;
+import no.sikt.nva.nvi.common.service.dto.VerifiedNviCreatorDto;
+import nva.commons.core.paths.UriWrapper;
+
+public final class CristinTestUtils {
+  public static final LocalDate DATE_CONTROLLED = LocalDate.now();
+  public static final String STATUS_CONTROLLED = "J";
+
+  private CristinTestUtils() {}
+
+  public static List<Organization> getTopLevelOrganizations(CristinNviReport cristinNviReport) {
+    return cristinNviReport.scientificResources().stream()
+        .map(ScientificResource::getCreators)
+        .flatMap(List::stream)
+        .map(CristinIdWrapper::from)
+        .map(CristinIdWrapper::getTopLevelOrganization)
+        .toList();
+  }
+
+  public static CristinLocale randomCristinLocale(String institutionIdentifier) {
+    return CristinLocale.builder()
+        .withDateControlled(DATE_CONTROLLED)
+        .withControlStatus(STATUS_CONTROLLED)
+        .withInstitutionIdentifier(institutionIdentifier)
+        .withDepartmentIdentifier("0")
+        .withSubDepartmentIdentifier("0")
+        .withOwnerCode(randomString())
+        .withGroupIdentifier("0")
+        .withControlledByUser(
+            CristinUser.builder().withIdentifier(generateUniqueIdAsString()).build())
+        .build();
+  }
+
+  public static URI expectedCreatorId(ScientificPerson person) {
+    return UriWrapper.fromHost(API_HOST.getValue())
+        .addChild("cristin")
+        .addChild("person")
+        .addChild(person.getCristinPersonIdentifier())
+        .getUri();
+  }
+
+  public static ContributorDto toContributorDto(ScientificPerson person) {
+    var creatorId = expectedCreatorId(person);
+    var cristinId = CristinIdWrapper.from(person);
+    var affiliation = cristinId.createLeafNodeOrganization();
+
+    return new ContributorDto(creatorId, null, STATUS_VERIFIED, ROLE_CREATOR, List.of(affiliation));
+  }
+
+  public static SampleExpandedPublicationFactory createPublicationFactory(
+      CristinNviReport cristinNviReport, TestScenario testScenario) {
+    var topLevelOrganizations = getTopLevelOrganizations(cristinNviReport);
+    var contributors =
+        cristinNviReport.scientificResources().stream()
+            .map(ScientificResource::getCreators)
+            .flatMap(List::stream)
+            .map(CristinTestUtils::toContributorDto)
+            .toList();
+    var publicationDate =
+        nonNull(cristinNviReport.publicationDate())
+            ? cristinNviReport.publicationDate()
+            : randomPublicationDate();
+    return new SampleExpandedPublicationFactory(testScenario)
+        .withContributors(contributors)
+        .withTopLevelOrganizations(topLevelOrganizations)
+        .withPublicationDate(publicationDate);
+  }
+
+  public static VerifiedNviCreatorDto expectedCreator(ScientificPerson person) {
+    var creatorId = expectedCreatorId(person);
+    var affiliation = organizationIdFromIdentifier(person.getOrganization());
+    return new VerifiedNviCreatorDto(creatorId, null, List.of(affiliation));
+  }
+}

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -122,6 +122,7 @@ public class CandidateRepository extends DynamoRepository {
             .identifier(identifier)
             .candidate(dbCandidate)
             .periodYear(year)
+            .version(randomUUID().toString())
             .build();
     var uniqueness = new CandidateUniquenessEntryDao(dbCandidate.publicationId().toString());
     var transactionBuilder = buildTransaction(approvalStatuses, candidate, identifier, uniqueness);

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/DbPublicationDetails.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/DbPublicationDetails.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Optional;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCreatorType;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbConvertedBy;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbIgnore;
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbImmutable;
 
 @DynamoDbImmutable(builder = DbPublicationDetails.Builder.class)
@@ -35,6 +36,24 @@ public record DbPublicationDetails(
 
   public static Builder builder() {
     return new Builder();
+  }
+
+  @DynamoDbIgnore
+  public Builder copy() {
+    return new Builder()
+        .id(this.id)
+        .publicationBucketUri(this.publicationBucketUri)
+        .pages(this.pages)
+        .publicationDate(this.publicationDate)
+        .creators(this.creators)
+        .topLevelNviOrganizations(this.topLevelNviOrganizations)
+        .modifiedDate(this.modifiedDate)
+        .contributorCount(this.contributorCount)
+        .abstractText(this.abstractText)
+        .identifier(this.identifier)
+        .language(this.language)
+        .status(this.status)
+        .title(this.title);
   }
 
   public static final class Builder {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
@@ -203,7 +203,8 @@ class BatchScanUtilTest {
     var originalCreator = new DbCreator(originalCreatorDto.id(), null, List.of(organization.id()));
 
     var publicationBuilder =
-        new SampleExpandedPublicationFactory(scenario).withTopLevelOrganizations(organization);
+        new SampleExpandedPublicationFactory(scenario)
+            .withTopLevelOrganizations(List.of(organization));
     var publication = publicationBuilder.getExpandedPublication();
 
     var originalDbCandidate =

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
@@ -27,7 +27,7 @@ public enum EnvironmentFixtures {
   // Other handler-specific environment variables
   CANDIDATE_QUEUE_URL("http://localhost:3000/candidate-queue"),
   DB_EVENTS_QUEUE_URL("http://localhost:3000/db-events-queue"),
-  EXPANDED_RESOURCES_BUCKET("persisted-resources-bucket"),
+  EXPANDED_RESOURCES_BUCKET("persisted-resources"),
   INDEX_DLQ("http://localhost:3000/index-dlq"),
   UPSERT_CANDIDATE_DLQ_QUEUE_URL("http://localhost:3000/upsert-candidate-dlq");
 
@@ -62,6 +62,10 @@ public enum EnvironmentFixtures {
         .with(EXPANDED_RESOURCES_BUCKET)
         .with(CANDIDATE_QUEUE_URL)
         .build();
+  }
+
+  public static FakeEnvironment getCristinNviReportEventConsumerEnvironment() {
+    return getDefaultEnvironmentBuilder().with(EXPANDED_RESOURCES_BUCKET).build();
   }
 
   public static FakeEnvironment getUpsertNviCandidateHandlerEnvironment() {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
@@ -1,11 +1,12 @@
 package no.sikt.nva.nvi.common.model;
 
 import static java.util.Objects.nonNull;
+import static no.sikt.nva.nvi.common.EnvironmentFixtures.API_HOST;
 import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_NORWAY;
+import static no.sikt.nva.nvi.test.TestUtils.generateUniqueIdAsString;
 import static no.sikt.nva.nvi.test.TestUtils.randomUriWithSuffix;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
-import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -24,8 +25,28 @@ import java.util.stream.IntStream;
 import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.client.model.Organization.Builder;
 import no.unit.nva.auth.uriretriever.UriRetriever;
+import nva.commons.core.paths.UriWrapper;
 
 public class OrganizationFixtures {
+
+  public static URI randomOrganizationId() {
+    var identifier =
+        String.format(
+            "%s.%s.%s.%s",
+            generateUniqueIdAsString(),
+            generateUniqueIdAsString(),
+            generateUniqueIdAsString(),
+            generateUniqueIdAsString());
+    return organizationIdFromIdentifier(identifier);
+  }
+
+  public static URI organizationIdFromIdentifier(String identifier) {
+    return UriWrapper.fromHost(API_HOST.getValue())
+        .addChild("cristin")
+        .addChild("organization")
+        .addChild(identifier)
+        .getUri();
+  }
 
   public static Organization randomTopLevelOrganization() {
     return randomOrganization(COUNTRY_CODE_NORWAY, 2).build();
@@ -50,16 +71,16 @@ public class OrganizationFixtures {
 
   public static Builder randomOrganization() {
     return Organization.builder()
-        .withId(randomUri())
+        .withId(randomOrganizationId())
         .withCountryCode(COUNTRY_CODE_NORWAY)
-        .withLabels(Map.of(COUNTRY_CODE_NORWAY.toLowerCase(Locale.ROOT), randomString()));
+        .withLabels(Map.of("nb", randomString(), "en", randomString()));
   }
 
   public static Builder randomOrganization(String countryCode) {
     return Organization.builder()
-        .withId(randomUri())
+        .withId(randomOrganizationId())
         .withCountryCode(countryCode)
-        .withLabels(Map.of(countryCode.toLowerCase(Locale.ROOT), randomString()));
+        .withLabels(Map.of("nb", randomString(), "en", randomString()));
   }
 
   public static Organization setupRandomOrganization(
@@ -93,6 +114,10 @@ public class OrganizationFixtures {
         .withId(topLevelOrganizationId)
         .withCountryCode(countryCode)
         .withHasPart(subOrganizations);
+  }
+
+  public static Organization getAsOrganizationLeafNode(URI organizationId) {
+    return Organization.builder().withId(organizationId).build();
   }
 
   public static void mockOrganizationResponseForAffiliation(

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -19,6 +19,7 @@ import java.time.Year;
 import java.util.Collection;
 import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import nva.commons.core.paths.UriWrapper;
 
 // Should be refactored, technical debt task: https://sikt.atlassian.net/browse/NP-48093
@@ -30,6 +31,7 @@ public final class TestUtils {
   public static final BigDecimal MAX_BIG_DECIMAL = BigDecimal.TEN;
   public static final int CURRENT_YEAR = Year.now().getValue();
   public static final Random RANDOM = new Random();
+  public static final AtomicInteger ID_COUNTER = new AtomicInteger(100);
 
   private static final String BUCKET_HOST = "example.org";
   private static final LocalDate START_DATE = LocalDate.of(1970, 1, 1);
@@ -40,6 +42,14 @@ public final class TestUtils {
 
   public static int randomIntBetween(int min, int max) {
     return RANDOM.nextInt(min, max);
+  }
+
+  public static int generateUniqueId() {
+    return ID_COUNTER.getAndIncrement();
+  }
+
+  public static String generateUniqueIdAsString() {
+    return String.valueOf(generateUniqueId());
   }
 
   public static URI generateS3BucketUri(UUID identifier) {


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49350

Changes:

- feat: Add missing metadata for historical candidates during import. This uses the updated expanded publication from `persisted-resources` in S3 to set data only if it is missing from the import candidate.
  - Note: This data is not "historically accurate", but is necessary metadata for search and access control. Reported data should not be altered.
- fix: Ensure `topLevelOrganizations` is always set for imported candidates.