### PR TITLE
[np-49367] fix: Migrate data for existing imported candidates in BatchScan

### DIFF
--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -28,7 +28,6 @@ import java.util.List;
 import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
-import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.model.ListingResult;
 import no.sikt.nva.nvi.common.queue.FakeSqsClient;
 import no.sikt.nva.nvi.common.utils.BatchScanUtil;
@@ -52,18 +51,17 @@ class ReEvaluateNviCandidatesHandlerTest {
   private static final String OUTPUT_TOPIC = environment.readEnv("TOPIC_REEVALUATE_CANDIDATES");
   private static final int BATCH_SIZE = 10;
   private final Context context = mock(Context.class);
+  private TestScenario scenario;
   private ByteArrayOutputStream outputStream;
   private ReEvaluateNviCandidatesHandler handler;
   private FakeSqsClient sqsClient;
-  private CandidateRepository candidateRepository;
   private FakeEventBridgeClient eventBridgeClient;
 
   @BeforeEach
   void setUp() {
-    var scenario = new TestScenario();
+    scenario = new TestScenario();
     outputStream = new ByteArrayOutputStream();
     sqsClient = new FakeSqsClient();
-    candidateRepository = scenario.getCandidateRepository();
     var nviService =
         new BatchScanUtil(
             scenario.getCandidateRepository(),
@@ -100,7 +98,7 @@ class ReEvaluateNviCandidatesHandlerTest {
   @Test
   void shouldNotSendMessagesForReportedCandidates() {
     var year = randomYear();
-    setupReportedCandidate(candidateRepository, year);
+    setupReportedCandidate(scenario.getCandidateRepository(), year);
     handler.handleRequest(eventStream(createRequest(year)), outputStream, context);
     var sentBatches = sqsClient.getSentBatches();
     assertEquals(0, sentBatches.size());
@@ -110,7 +108,7 @@ class ReEvaluateNviCandidatesHandlerTest {
   void shouldSendMessageBatchWithSize10() {
     var numberOfCandidates = 11;
     var year = randomYear();
-    createNumberOfCandidatesForYear(year, numberOfCandidates, candidateRepository);
+    createNumberOfCandidatesForYear(year, numberOfCandidates, scenario);
     handler.handleRequest(eventStream(createRequest(year)), outputStream, context);
     var sentBatches = sqsClient.getSentBatches();
     var expectedBatches = 2;
@@ -124,8 +122,8 @@ class ReEvaluateNviCandidatesHandlerTest {
   @Test
   void shouldSendMessagesForCandidatesPublishedInGivenYear() {
     var year = "2023";
-    var candidates = createNumberOfCandidatesForYear(year, 10, candidateRepository);
-    createNumberOfCandidatesForYear("2022", 10, candidateRepository);
+    var candidates = createNumberOfCandidatesForYear(year, 10, scenario);
+    createNumberOfCandidatesForYear("2022", 10, scenario);
     handler.handleRequest(eventStream(createRequest(year)), outputStream, context);
     var batch = sqsClient.getSentBatches().get(0);
     var expectedCandidates =
@@ -157,7 +155,7 @@ class ReEvaluateNviCandidatesHandlerTest {
     var numberOfCandidates = 10;
     var pageSize = 5;
     var year = randomYear();
-    var candidates = createNumberOfCandidatesForYear(year, numberOfCandidates, candidateRepository);
+    var candidates = createNumberOfCandidatesForYear(year, numberOfCandidates, scenario);
     handler.handleRequest(eventStream(createRequest(year, pageSize)), outputStream, context);
     var expectedStartMarker =
         getYearIndexStartMarker(sortByIdentifier(candidates, numberOfCandidates).get(pageSize - 1));
@@ -172,7 +170,7 @@ class ReEvaluateNviCandidatesHandlerTest {
     var numberOfCandidates = 9;
     var pageSize = 10;
     var year = randomYear();
-    createNumberOfCandidatesForYear(year, numberOfCandidates, candidateRepository);
+    createNumberOfCandidatesForYear(year, numberOfCandidates, scenario);
     handler.handleRequest(eventStream(createRequest(year, pageSize)), outputStream, context);
     var emittedEvents = eventBridgeClient.getRequestEntries();
     assertEquals(0, emittedEvents.size());

--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -34,6 +34,7 @@ dependencies {
     testImplementation libs.bundles.cucumber
     testImplementation libs.bundles.testContainers
     testImplementation libs.dynamodDbLocal
+    testImplementation libs.nva.identifiers
     testImplementation libs.openCsv
     testImplementation project(':nvi-test')
     testImplementation(testFixtures(project(":nvi-commons")))
@@ -41,13 +42,13 @@ dependencies {
 
 test {
     useJUnitPlatform()
-    environment("EXPANDED_RESOURCES_BUCKET", "ignoredBucket")
+    environment("EXPANDED_RESOURCES_BUCKET", "persisted-resources")
     environment("SEARCH_INFRASTRUCTURE_API_HOST", "localhost")
     environment("SEARCH_INFRASTRUCTURE_AUTH_URI", "localhost")
     environment("SEARCH_INFRASTRUCTURE_API_URI", "localhost")
     environment("NVI_TABLE_NAME", "some-table")
     environment("ALLOWED_ORIGIN", "*")
-    environment("API_HOST", "example.com")
+    environment("API_HOST", "api.fake.nva.aws.unit.no")
     environment("CUSTOM_DOMAIN_BASE_PATH", "scientific-index")
     environment("BACKEND_CLIENT_AUTH_URL", "My url")
     environment("BACKEND_CLIENT_SECRET_NAME", "My secret name")

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -2,8 +2,10 @@ package no.sikt.nva.nvi.index;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.nonNull;
+import static no.sikt.nva.nvi.common.EnvironmentFixtures.getIndexDocumentHandlerEnvironment;
 import static no.sikt.nva.nvi.common.QueueServiceTestUtils.createEvent;
 import static no.sikt.nva.nvi.common.QueueServiceTestUtils.createEventWithOneInvalidRecord;
+import static no.sikt.nva.nvi.common.TestScenario.constructPublicationBucketPath;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequestWithSingleAffiliation;
@@ -111,7 +113,7 @@ class IndexDocumentHandlerTest {
 
   private static final String JSON_PTR_CONTRIBUTOR = "/publicationDetails/contributors";
   private static final String JSON_PTR_APPROVALS = "/approvals";
-  private static final Environment ENVIRONMENT = new Environment();
+  private static final Environment ENVIRONMENT = getIndexDocumentHandlerEnvironment();
   private static final String BODY = "body";
   private static final String ORGANIZATION_CONTEXT =
       "https://bibsysdev.github.io/src/organization-context.json";
@@ -752,9 +754,7 @@ class IndexDocumentHandlerTest {
   }
 
   private static String extractResourceIdentifier(Candidate persistedCandidate) {
-    return UriWrapper.fromUri(persistedCandidate.getPublicationDetails().publicationBucketUri())
-        .getPath()
-        .getLastPathElement();
+    return persistedCandidate.getPublicationDetails().publicationIdentifier().toString();
   }
 
   private static ObjectNode orgWithThreeLevels(URI affiliationId) {
@@ -820,7 +820,7 @@ class IndexDocumentHandlerTest {
         removeTopLevelOrganization((ObjectNode) expandedResource);
     insertResourceInS3(
         createResourceIndexDocument(expandedResourceWithoutTopLevelOrganization),
-        UnixPath.of(extractResourceIdentifier(candidate)));
+        constructPublicationBucketPath(extractResourceIdentifier(candidate)));
   }
 
   private void setupResourceWithInvalidObjectInS3(JsonNode expandedResource, Candidate candidate) {
@@ -830,7 +830,7 @@ class IndexDocumentHandlerTest {
     ((ObjectNode) expandedResource).set("topLevelOrganizations", invalidObject);
     insertResourceInS3(
         createResourceIndexDocument(expandedResource),
-        UnixPath.of(extractResourceIdentifier(candidate)));
+        constructPublicationBucketPath(extractResourceIdentifier(candidate)));
   }
 
   private JsonNode removeTopLevelOrganization(ObjectNode expandedResource) {
@@ -907,7 +907,7 @@ class IndexDocumentHandlerTest {
 
   private void insertInS3(JsonNode expandedResource, String resourceIdentifier) {
     var resourceIndexDocument = createResourceIndexDocument(expandedResource);
-    insertResourceInS3(resourceIndexDocument, UnixPath.of(resourceIdentifier));
+    insertResourceInS3(resourceIndexDocument, constructPublicationBucketPath(resourceIdentifier));
   }
 
   private JsonNode createResourceIndexDocument(JsonNode expandedResource) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/DbPublicationDetails.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/model/DbPublicationDetails.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.common.db.model;
 
 import static java.util.Collections.emptyList;
+import static no.sikt.nva.nvi.common.utils.Validator.isMissing;
 
 import java.net.URI;
 import java.time.Instant;
@@ -32,6 +33,22 @@ public record DbPublicationDetails(
     creators = Optional.ofNullable(creators).map(List::copyOf).orElse(emptyList());
     topLevelNviOrganizations =
         Optional.ofNullable(topLevelNviOrganizations).map(List::copyOf).orElse(emptyList());
+  }
+
+  @DynamoDbIgnore
+  public boolean hasNullOrEmptyValues() {
+    return isMissing(id)
+        || isMissing(publicationBucketUri)
+        || isMissing(pages)
+        || isMissing(publicationDate)
+        || isMissing(creators)
+        || isMissing(topLevelNviOrganizations)
+        || isMissing(modifiedDate)
+        || isMissing(abstractText)
+        || isMissing(identifier)
+        || isMissing(language)
+        || isMissing(status)
+        || isMissing(title);
   }
 
   public static Builder builder() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/BatchScanUtil.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/BatchScanUtil.java
@@ -155,7 +155,6 @@ public class BatchScanUtil {
             .publicationBucketUri(dbCandidate.publicationBucketUri())
             .publicationDate(dbCandidate.publicationDate())
             .contributorCount(updatedDbCreators.size())
-            .modifiedDate(dbCandidate.modifiedDate())
 
             // Always update these
             .topLevelNviOrganizations(updatedOrganizations) // Used for access control
@@ -200,14 +199,8 @@ public class BatchScanUtil {
         .build();
   }
 
-  private <T> T getFieldOrDefault(
-      DbPublicationDetails publicationDetails,
-      Function<DbPublicationDetails, T> getter,
-      T defaultValue) {
-    return Optional.ofNullable(publicationDetails)
-        .map(getter)
-        .filter(Objects::nonNull)
-        .orElse(defaultValue);
+  private <T, R> T getFieldOrDefault(R object, Function<R, T> getter, T defaultValue) {
+    return Optional.ofNullable(object).map(getter).filter(Objects::nonNull).orElse(defaultValue);
   }
 
   private List<DbOrganization> getRelevantTopLevelOrganizations(

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/Validator.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/Validator.java
@@ -63,4 +63,8 @@ public final class Validator {
   public static <K, V> boolean hasElements(Map<K, V> collection) {
     return nonNull(collection) && !collection.isEmpty();
   }
+
+  public static boolean isMissing(Object object) {
+    return isNull(object) || (object instanceof Collection<?> collection && collection.isEmpty());
+  }
 }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/MigrationTests.java
@@ -1,6 +1,7 @@
 package no.sikt.nva.nvi.common;
 
 import static java.util.Collections.emptyList;
+import static no.sikt.nva.nvi.common.EnvironmentFixtures.getEventBasedBatchScanHandlerEnvironment;
 import static no.sikt.nva.nvi.common.RequestFixtures.createNoteRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidate;
@@ -50,7 +51,7 @@ class MigrationTests {
             candidateRepository,
             scenario.getS3StorageReaderForExpandedResourcesBucket(),
             new FakeSqsClient(),
-            FakeEnvironment.builder().build());
+            getEventBasedBatchScanHandlerEnvironment());
   }
 
   @Test

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/BatchScanUtilTest.java
@@ -318,10 +318,13 @@ class BatchScanUtilTest {
     var verifiedCreator = verifiedNviCreatorFrom(nviOrganization1);
     var expectedNviCreators = List.of(verifiedCreator);
     var expectedTopLevelOrganizations = List.of(nviOrganization1);
+    var expectedModifiedDate = Instant.now();
     var publication =
         publicationBuilder
             .withContributor(mapToContributorDto(verifiedCreator))
-            .getExpandedPublication();
+            .getExpandedPublicationBuilder()
+            .withModifiedDate(expectedModifiedDate.toString())
+            .build();
 
     // Set up an existing Candidate in the database with identifiers matching the publication
     var dbCreators = mapToDbCreators(expectedNviCreators);
@@ -330,7 +333,7 @@ class BatchScanUtilTest {
             .topLevelNviOrganizations(null)
             .abstractText(randomString())
             .contributorCount(randomInteger())
-            .modifiedDate(Instant.now())
+            .modifiedDate(expectedModifiedDate)
             .creators(dbCreators)
             .build();
     var originalDbCandidate =

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
@@ -27,6 +27,7 @@ public enum EnvironmentFixtures {
   // Other handler-specific environment variables
   CANDIDATE_QUEUE_URL("http://localhost:3000/candidate-queue"),
   DB_EVENTS_QUEUE_URL("http://localhost:3000/db-events-queue"),
+  PERSISTED_INDEX_DOCUMENT_QUEUE_URL("http://localhost:3000/index-document-queue"),
   EXPANDED_RESOURCES_BUCKET("persisted-resources"),
   INDEX_DLQ("http://localhost:3000/index-dlq"),
   UPSERT_CANDIDATE_DLQ_QUEUE_URL("http://localhost:3000/upsert-candidate-dlq"),
@@ -104,6 +105,14 @@ public enum EnvironmentFixtures {
         .with(TOPIC_APPROVAL_INSERT)
         .with(TOPIC_APPROVAL_UPDATE)
         .with(TOPIC_APPROVAL_REMOVE)
+        .build();
+  }
+
+  public static FakeEnvironment getIndexDocumentHandlerEnvironment() {
+    return getDefaultEnvironmentBuilder()
+        .with(EXPANDED_RESOURCES_BUCKET)
+        .with(PERSISTED_INDEX_DOCUMENT_QUEUE_URL)
+        .with(INDEX_DLQ)
         .build();
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -120,7 +120,7 @@ public class TestScenario {
   public URI setupExpandedPublicationInS3(SampleExpandedPublication publication) {
     try {
       return s3Driver.insertFile(
-          constructPublicationBucketUri(publication.identifier().toString()),
+          constructPublicationBucketPath(publication.identifier().toString()),
           publication.toJsonString());
     } catch (IOException e) {
       throw new RuntimeException("Failed to add publication to S3", e);
@@ -129,13 +129,13 @@ public class TestScenario {
 
   public URI setupExpandedPublicationInS3(String publicationJson) {
     try {
-      return s3Driver.insertFile(constructPublicationBucketUri(randomString()), publicationJson);
+      return s3Driver.insertFile(constructPublicationBucketPath(randomString()), publicationJson);
     } catch (IOException e) {
       throw new RuntimeException("Failed to add publication to S3", e);
     }
   }
 
-  private static UnixPath constructPublicationBucketUri(String publicationIdentifier) {
+  public static UnixPath constructPublicationBucketPath(String publicationIdentifier) {
     return UnixPath.of("resources", publicationIdentifier + ".gz");
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/UpsertRequestBuilder.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/UpsertRequestBuilder.java
@@ -1,11 +1,11 @@
 package no.sikt.nva.nvi.common;
 
 import static java.math.BigDecimal.ZERO;
+import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.getExpectedPublicationBucketUri;
 import static no.sikt.nva.nvi.common.dto.PointCalculationDtoBuilder.randomPointCalculationDto;
 import static no.sikt.nva.nvi.common.dto.PublicationDetailsDtoBuilder.randomPublicationDetailsDto;
 import static no.sikt.nva.nvi.common.model.ContributorFixtures.randomVerifiedNviCreatorDto;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomTopLevelOrganization;
-import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 
 import java.math.BigDecimal;
 import java.net.URI;
@@ -38,12 +38,13 @@ public class UpsertRequestBuilder {
     var topLevelOrganization = randomTopLevelOrganization();
     var affiliationId = topLevelOrganization.hasPart().getFirst().id();
     var nviCreator = randomVerifiedNviCreatorDto(affiliationId);
+    var publicationDetails = randomPublicationDetailsDto();
 
     return new UpsertRequestBuilder()
-        .withPublicationBucketUri(randomUri())
+        .withPublicationBucketUri(getExpectedPublicationBucketUri(publicationDetails.identifier()))
         .withPointCalculation(randomPointCalculationDto())
         .withCreatorsAndPoints(Map.of(topLevelOrganization, List.of(nviCreator)))
-        .withPublicationDetails(randomPublicationDetailsDto());
+        .withPublicationDetails(publicationDetails);
   }
 
   public static UpsertRequestBuilder fromRequest(UpsertNviCandidateRequest request) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPublicationDetailsFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPublicationDetailsFixtures.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.common.db;
 
 import static java.util.Objects.isNull;
 import static java.util.UUID.randomUUID;
+import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.getExpectedPublicationBucketUri;
 import static no.sikt.nva.nvi.common.model.NviCreatorFixtures.mapToDbCreators;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.mapToDbPublicationDate;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDateInCurrentYear;
@@ -28,7 +29,7 @@ public class DbPublicationDetailsFixtures {
     return DbPublicationDetails.builder()
         .id(publicationId)
         .identifier(publicationIdentifier.toString())
-        .publicationBucketUri(randomUri())
+        .publicationBucketUri(getExpectedPublicationBucketUri(publicationIdentifier.toString()))
         .publicationDate(randomPublicationDateInCurrentYear().toDbPublicationDate())
         .modifiedDate(Instant.now())
         .topLevelNviOrganizations(List.of(topLevelNviOrganization))
@@ -49,7 +50,7 @@ public class DbPublicationDetailsFixtures {
     return DbPublicationDetails.builder()
         .id(request.publicationId())
         .identifier(dtoPublicationDetails.identifier())
-        .publicationBucketUri(request.publicationBucketUri())
+        .publicationBucketUri(getExpectedPublicationBucketUri(dtoPublicationDetails.identifier()))
         .title(dtoPublicationDetails.title())
         .status(dtoPublicationDetails.status())
         .publicationDate(mapToDbPublicationDate(dtoPublicationDetails.publicationDate()))

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/SampleExpandedPublication.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/SampleExpandedPublication.java
@@ -59,6 +59,7 @@ public record SampleExpandedPublication(
     String abstractText,
     String language,
     String status,
+    String modifiedDate,
     List<SampleExpandedContributor> contributors,
     List<SampleExpandedOrganization> topLevelOrganizations) {
 
@@ -107,6 +108,7 @@ public record SampleExpandedPublication(
       root.put(ID_FIELD, id.toString());
       root.put(IDENTIFIER_FIELD, identifier.toString());
       root.put(STATUS_FIELD, status);
+      putIfNotBlank(root, "modifiedDate", modifiedDate);
 
       root.set(ENTITY_DESCRIPTION_FIELD, createEntityDescriptionNode());
       root.set(TOP_LEVEL_ORGANIZATIONS_FIELD, createTopLevelOrganizationsNode());
@@ -206,6 +208,7 @@ public record SampleExpandedPublication(
     private SampleExpandedPublicationDate publicationDate;
     private String instanceType = ACADEMIC_ARTICLE;
     private String publicationContextType = "Book";
+    private String modifiedDate;
     private List<SampleExpandedPublicationChannel> publicationChannels;
     private List<SampleExpandedContributor> contributors;
     private List<SampleExpandedOrganization> topLevelOrganizations;
@@ -267,6 +270,11 @@ public record SampleExpandedPublication(
       return this;
     }
 
+    public Builder withModifiedDate(String modifiedDate) {
+      this.modifiedDate = modifiedDate;
+      return this;
+    }
+
     public Builder withPublicationChannels(
         List<SampleExpandedPublicationChannel> publicationChannels) {
       this.publicationChannels = publicationChannels;
@@ -300,6 +308,7 @@ public record SampleExpandedPublication(
           abstractText,
           language,
           status,
+          modifiedDate,
           contributors,
           topLevelOrganizations);
     }

--- a/template.yaml
+++ b/template.yaml
@@ -1588,3 +1588,21 @@ Resources:
       ComparisonOperator: GreaterThanOrEqualToThreshold
       AlarmActions:
         - !Ref SlackSnsArn
+
+  BatchScanRecoveryQueueAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: NVI BatchScan Recovery failed
+      AlarmDescription: If this alarm is triggered, then check sqs messages on BatchScanRecoveryQueue.
+      MetricName: ApproximateNumberOfMessagesVisible
+      Namespace: AWS/SQS
+      Statistic: Sum
+      Dimensions:
+        - Name: QueueName
+          Value: !GetAtt BatchScanRecoveryQueue.QueueName
+      Period: 300
+      EvaluationPeriods: 1
+      Threshold: 1
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      AlarmActions:
+        - !Ref SlackSnsArn


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49367

Changes:
- fix: Rewrites the temporary migration code in `BatchScanUtil` so that it should handle both:
  - Existing candidates with data we want to restructure
  - Existing candidates imported previously with missing data
 - refactor: Set up minimal data required for existing tests in fake S3