### PR TITLE
refactor: Add more logging to BatchScan/Recovery handlers

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/EventBasedBatchScanHandler.java
@@ -42,12 +42,13 @@ public class EventBasedBatchScanHandler
   @Override
   protected ListingResult<Dao> processInput(
       ScanDatabaseRequest input, AwsEventBridgeEvent<ScanDatabaseRequest> event, Context context) {
-    logger.info("Query starting point: {}", input.startMarker());
+    logger.info("Processing request: {}", input);
 
     var batchResult =
         batchScanUtil.migrateAndUpdateVersion(input.pageSize(), input.startMarker(), input.types());
     logger.info("Batch result: {}", batchResult);
     if (batchResult.shouldContinueScan()) {
+      logger.info("Sending event to trigger scan of next batch");
       sendEventToInvokeNewRefreshRowVersionExecution(input, context, batchResult);
     }
     return batchResult;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/BatchScanRecoveryHandlerTest.java
@@ -3,7 +3,6 @@ package no.sikt.nva.nvi.events.batch;
 import static java.util.stream.Collectors.toSet;
 import static no.sikt.nva.nvi.common.EnvironmentFixtures.BATCH_SCAN_RECOVERY_QUEUE;
 import static no.sikt.nva.nvi.common.EnvironmentFixtures.getBatchScanRecoveryHandlerEnvironment;
-import static no.sikt.nva.nvi.common.SampleExpandedPublicationFactory.defaultExpandedPublicationFactory;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createNumberOfCandidatesForYear;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
@@ -21,7 +20,6 @@ import no.sikt.nva.nvi.common.db.CandidateDao;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.queue.FakeSqsClient;
 import no.sikt.nva.nvi.common.utils.BatchScanUtil;
-import no.sikt.nva.nvi.test.SampleExpandedPublication;
 import no.unit.nva.stubs.FakeContext;
 import nva.commons.core.Environment;
 import nva.commons.core.ioutils.IoUtils;
@@ -89,21 +87,10 @@ class BatchScanRecoveryHandlerTest {
         createNumberOfCandidatesForYear(randomYear(), count, scenario).stream()
             .map(this::placeOnQueue)
             .toList();
-    candidates.stream()
-        .map(this::createMatchingPublication)
-        .forEach(scenario::setupExpandedPublicationInS3);
     var messagesOnQueue = getAllMessagesFromDlq();
 
     assertMessagesExistOnQueue(candidates, messagesOnQueue);
     return candidates;
-  }
-
-  private SampleExpandedPublication createMatchingPublication(CandidateDao candidateDao) {
-    return defaultExpandedPublicationFactory(scenario)
-        .getExpandedPublicationBuilder()
-        .withId(candidateDao.candidate().publicationId())
-        .withIdentifier(UUID.fromString(candidateDao.candidate().publicationIdentifier()))
-        .build();
   }
 
   private List<SQSMessage> getAllMessagesFromDlq() {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/BatchScanUtil.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/BatchScanUtil.java
@@ -40,6 +40,8 @@ import no.sikt.nva.nvi.common.service.PublicationLoaderService;
 import no.sikt.nva.nvi.common.service.model.PageCount;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("PMD.CouplingBetweenObjects")
 public class BatchScanUtil {
@@ -49,6 +51,7 @@ public class BatchScanUtil {
   private final PublicationLoaderService publicationLoader;
   private final QueueClient queueClient;
   private final Environment environment;
+  private final Logger logger = LoggerFactory.getLogger(BatchScanUtil.class);
 
   public BatchScanUtil(
       CandidateRepository candidateRepository,
@@ -105,8 +108,15 @@ public class BatchScanUtil {
 
   private Dao attemptToMigrateCandidate(CandidateDao candidateDao) {
     try {
+      logger.info(
+          "Migrating candidate {} with publication ID {}",
+          candidateDao.identifier(),
+          candidateDao.candidate().publicationIdentifier());
       return migrateCandidateDao(candidateDao);
     } catch (Exception e) {
+      logger.error(
+          "Unexpected failure during migration. Sending candidate {} to recovery queue",
+          candidateDao.identifier());
       queueClient.sendMessage(
           e.toString(), environment.readEnv(BATCH_SCAN_RECOVERY_QUEUE), candidateDao.identifier());
       return candidateDao;


### PR DESCRIPTION
Changes:

- refactor: Remove duplicate test method
- chore: Add more logging to handlers in order to debug failing candidates