### PR TITLE
[np-49374] feat: Add filter for exclude unassigned

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/CandidateSearchParameters.java
@@ -4,6 +4,7 @@ import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_AGG
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_ASSIGNEE;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_CATEGORY;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_EXCLUDE_SUB_UNITS;
+import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_EXCLUDE_UNASSIGNED;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_FILTER;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_OFFSET;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_ORDER_BY;
@@ -35,6 +36,7 @@ public record CandidateSearchParameters(
     String category,
     String title,
     String assignee,
+    boolean excludeUnassigned,
     URI topLevelCristinOrg,
     String aggregationType,
     List<String> excludeFields,
@@ -66,6 +68,7 @@ public record CandidateSearchParameters(
         .withCategory(extractQueryParamCategoryOrDefault(requestInfo))
         .withTitle(extractQueryParamTitle(requestInfo))
         .withAssignee(extractQueryParamAssignee(requestInfo))
+        .withExcludeUnassigned(extractQueryParamExcludeUnassignedOrDefault(requestInfo))
         .withAggregationType(aggregationType)
         .withSearchResultParameters(getResultParameters(requestInfo))
         .withTopLevelCristinOrg(requestInfo.getTopLevelOrgCristinId().orElse(null))
@@ -151,6 +154,13 @@ public record CandidateSearchParameters(
     return requestInfo.getQueryParameters().get(QUERY_PARAM_ASSIGNEE);
   }
 
+  private static boolean extractQueryParamExcludeUnassignedOrDefault(RequestInfo requestInfo) {
+    return requestInfo
+        .getQueryParameterOpt(QUERY_PARAM_EXCLUDE_UNASSIGNED)
+        .map(Boolean::parseBoolean)
+        .orElse(false);
+  }
+
   private static String extractQueryParamPublicationDateOrDefault(RequestInfo requestInfo) {
     return requestInfo
         .getQueryParameterOpt(QUERY_PARAM_YEAR)
@@ -168,6 +178,7 @@ public record CandidateSearchParameters(
     private String category;
     private String title;
     private String assignee;
+    private boolean excludeUnassigned;
     private URI topLevelCristinOrg;
     private String aggregationType;
     private List<String> excludeFields = new ArrayList<>();
@@ -221,6 +232,11 @@ public record CandidateSearchParameters(
       return this;
     }
 
+    public Builder withExcludeUnassigned(boolean excludeUnassigned) {
+      this.excludeUnassigned = excludeUnassigned;
+      return this;
+    }
+
     public Builder withTopLevelCristinOrg(URI topLevelCristinOrg) {
       this.topLevelCristinOrg = topLevelCristinOrg;
       return this;
@@ -252,6 +268,7 @@ public record CandidateSearchParameters(
           category,
           title,
           assignee,
+          excludeUnassigned,
           topLevelCristinOrg,
           aggregationType,
           excludeFields,

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchQueryParameters.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/search/SearchQueryParameters.java
@@ -12,6 +12,7 @@ public final class SearchQueryParameters {
   public static final String QUERY_PARAM_CATEGORY = "category";
   public static final String QUERY_PARAM_CONTRIBUTOR = "contributor";
   public static final String QUERY_PARAM_ASSIGNEE = "assignee";
+  public static final String QUERY_PARAM_EXCLUDE_UNASSIGNED = "excludeUnassigned";
   public static final String QUERY_PARAM_SIZE = "size";
   public static final String QUERY_PARAM_OFFSET = "offset";
   public static final String QUERY_PARAM_ORDER_BY = "orderBy";

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
@@ -22,6 +22,7 @@ import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
 import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
 import org.opensearch.client.opensearch._types.query_dsl.NestedQuery;
 import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
 import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
 import org.opensearch.client.opensearch._types.query_dsl.TermsQuery;
@@ -40,6 +41,10 @@ public final class QueryFunctions {
 
   public static Query nestedQuery(String path, Query... queries) {
     return new NestedQuery.Builder().path(path).query(mustMatch(queries)).build().toQuery();
+  }
+
+  public static Query existsQuery(String field) {
+    return QueryBuilders.exists().field(field).build().toQuery();
   }
 
   public static Query fieldValueQuery(String field, String value) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
@@ -77,6 +77,7 @@ public final class SearchConstants {
         .withCategory(params.category())
         .withTitle(params.title())
         .withAssignee(params.assignee())
+        .withExcludeUnassigned(params.excludeUnassigned())
         .build()
         .toQuery();
   }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentFixtures.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentFixtures.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.index;
 
 import static java.util.UUID.randomUUID;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationId;
+import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDateDtoInYear;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomNviContributor;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomNviContributorBuilder;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomPages;
@@ -35,7 +36,6 @@ import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument.Builder;
 import no.sikt.nva.nvi.index.model.document.PublicationDetails;
 import no.sikt.nva.nvi.index.model.document.ReportingPeriod;
 import no.unit.nva.commons.pagination.PaginatedSearchResult;
-import nva.commons.core.paths.UriWrapper;
 
 public final class IndexDocumentFixtures {
   public static final TypeReference<PaginatedSearchResult<NviCandidateIndexDocument>>
@@ -70,11 +70,10 @@ public final class IndexDocumentFixtures {
 
   public static Builder createRandomIndexDocumentBuilder(
       URI userTopLevelOrganization, String year) {
-    var publicationDate = new PublicationDateDto(year, null, null);
     var contributor = randomNviContributorBuilder(userTopLevelOrganization).build();
     var details =
-        randomPublicationDetailsBuilder(year)
-            .withPublicationDate(publicationDate)
+        randomPublicationDetailsBuilder()
+            .withPublicationDate(randomPublicationDateDtoInYear(year))
             .withContributors(List.of(contributor))
             .build();
     return randomIndexDocumentBuilder(details);
@@ -88,7 +87,7 @@ public final class IndexDocumentFixtures {
             .map(ContributorType.class::cast)
             .toList();
     var details =
-        randomPublicationDetailsBuilder(DEFAULT_YEAR)
+        randomPublicationDetailsBuilder()
             .withPublicationDate(new PublicationDateDto(DEFAULT_YEAR, null, null))
             .withContributors(contributors)
             .build();
@@ -130,30 +129,24 @@ public final class IndexDocumentFixtures {
     return randomPublicationDetailsBuilder().withContributors(contributors);
   }
 
-  // FIXME: Merge this
-  public static PublicationDetails.Builder randomPublicationDetailsBuilder(String publicationYear) {
-    var publicationDate = new PublicationDateDto(publicationYear, null, null);
-    return PublicationDetails.builder()
-        .withId(UriWrapper.fromUri(randomUri()).addChild(randomUUID().toString()).toString())
-        .withTitle(randomString())
-        .withAbstract(randomString())
-        .withPublicationDate(publicationDate)
-        .withPublicationChannel(randomPublicationChannel())
-        .withPages(randomPages())
-        .withContributors(List.of(randomNviContributor(randomOrganizationId())));
-  }
-
   public static PublicationDetails.Builder randomPublicationDetailsBuilder() {
-    var publicationDate = new PublicationDateDto(DEFAULT_YEAR, null, null);
     var publicationId = randomUriWithSuffix(randomUUID().toString());
     return PublicationDetails.builder()
         .withId(publicationId.toString())
         .withTitle(randomString())
         .withAbstract(randomString())
-        .withPublicationDate(publicationDate)
+        .withPublicationDate(randomPublicationDateDtoInYear(DEFAULT_YEAR))
         .withPublicationChannel(randomPublicationChannel())
         .withPages(randomPages())
         .withContributors(List.of(randomNviContributor(randomOrganizationId())));
+  }
+
+  private static List<Approval> randomApprovalList() {
+    return IntStream.range(0, 5).boxed().map(i -> randomApproval()).toList();
+  }
+
+  private static Approval randomApproval() {
+    return randomApproval(randomString(), randomOrganizationId());
   }
 
   public static Approval randomApproval(String assignee, URI topLevelOrganization) {
@@ -172,21 +165,6 @@ public final class IndexDocumentFixtures {
         randomGlobalApprovalStatus());
   }
 
-  private static List<Approval> randomApprovalList() {
-    return IntStream.range(0, 5).boxed().map(i -> randomApproval()).toList();
-  }
-
-  private static Approval randomApproval() {
-    return new Approval(
-        randomOrganizationId(),
-        Map.of(),
-        randomStatus(),
-        randomInstitutionPoints(),
-        Set.of(),
-        null,
-        randomGlobalApprovalStatus());
-  }
-
   public static ApprovalStatus randomStatus() {
     var values = Arrays.stream(ApprovalStatus.values()).toList();
     var size = values.size();
@@ -194,17 +172,7 @@ public final class IndexDocumentFixtures {
     return values.get(random.nextInt(size));
   }
 
-  public static InstitutionPoints randomInstitutionPoints() {
-    return new InstitutionPoints(
-        randomOrganizationId(), randomBigDecimal(SCALE), randomCreatorAffiliationPoints());
-  }
-
   public static GlobalApprovalStatus randomGlobalApprovalStatus() {
     return randomElement(GlobalApprovalStatus.values());
-  }
-
-  private static List<CreatorAffiliationPoints> randomCreatorAffiliationPoints() {
-    return List.of(
-        new CreatorAffiliationPoints(randomUri(), randomOrganizationId(), randomBigDecimal(SCALE)));
   }
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentFixtures.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentFixtures.java
@@ -156,8 +156,8 @@ public final class IndexDocumentFixtures {
         .withContributors(List.of(randomNviContributor(randomOrganizationId())));
   }
 
-  public static Approval randomApproval(
-      String assignee, URI topLevelOrganization, URI creatorAffiliation) {
+  public static Approval randomApproval(String assignee, URI topLevelOrganization) {
+    var creatorAffiliation = randomOrganizationId();
     var creatorPoint =
         new CreatorAffiliationPoints(randomUri(), creatorAffiliation, randomBigDecimal(SCALE));
     var institutionPoints =

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerIntegrationTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerIntegrationTest.java
@@ -257,14 +257,11 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
     }
 
     private static Map<String, NviCandidateIndexDocument> createDocumentsForAssigneeTests() {
-      var assignedToCurrentUser =
-          randomApproval(OUR_USER, OUR_ORGANIZATION, randomOrganizationId());
-      var assignedToOtherUser =
-          randomApproval(OUR_OTHER_USER, OUR_ORGANIZATION, randomOrganizationId());
-      var assignedToTheirUser =
-          randomApproval(THEIR_USER, THEIR_ORGANIZATION, randomOrganizationId());
-      var noAssigneeFromUs = randomApproval(null, OUR_ORGANIZATION, randomOrganizationId());
-      var noAssigneeFromThem = randomApproval(null, THEIR_ORGANIZATION, randomOrganizationId());
+      var assignedToCurrentUser = randomApproval(OUR_USER, OUR_ORGANIZATION);
+      var assignedToOtherUser = randomApproval(OUR_OTHER_USER, OUR_ORGANIZATION);
+      var assignedToTheirUser = randomApproval(THEIR_USER, THEIR_ORGANIZATION);
+      var noAssigneeFromUs = randomApproval(null, OUR_ORGANIZATION);
+      var noAssigneeFromThem = randomApproval(null, THEIR_ORGANIZATION);
 
       return Map.of(
           ASSIGNED_TO_CURRENT,

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerIntegrationTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerIntegrationTest.java
@@ -327,15 +327,6 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
     CONTAINER.addDocumentsToIndex(documents);
   }
 
-  private static void assertThatResponseHasExpectedIndexDocumentIds(
-      PaginatedSearchResult<NviCandidateIndexDocument> response,
-      Collection<URI> expectedDocumentIds) {
-    assertThat(response.getHits())
-        .hasSize(expectedDocumentIds.size())
-        .extracting(NviCandidateIndexDocument::id)
-        .containsExactlyInAnyOrderElementsOf(expectedDocumentIds);
-  }
-
   private static void assertThatResponseHasExpectedIndexDocuments(
       PaginatedSearchResult<NviCandidateIndexDocument> response,
       Collection<NviCandidateIndexDocument> expectedDocuments) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerIntegrationTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerIntegrationTest.java
@@ -5,18 +5,26 @@ import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizati
 import static no.sikt.nva.nvi.index.IndexDocumentFixtures.createRandomIndexDocument;
 import static no.sikt.nva.nvi.index.IndexDocumentFixtures.createRandomIndexDocumentBuilder;
 import static no.sikt.nva.nvi.index.IndexDocumentFixtures.createRandomIndexDocuments;
+import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomApproval;
+import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomIndexDocumentBuilder;
+import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomPublicationDetailsBuilder;
+import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_ASSIGNEE;
+import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_EXCLUDE_UNASSIGNED;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_OFFSET;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_SIZE;
 import static no.sikt.nva.nvi.index.model.search.SearchQueryParameters.QUERY_PARAM_YEAR;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
 import java.math.BigDecimal;
+import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.index.OpenSearchContainerContext;
+import no.sikt.nva.nvi.index.model.document.Approval;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.document.ReportingPeriod;
 import no.unit.nva.commons.pagination.PaginatedSearchResult;
@@ -28,13 +36,24 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandlerTestBase {
   private static final OpenSearchContainerContext CONTAINER = new OpenSearchContainerContext();
+  private static final String OUR_USER = "Current user";
+  private static final String OUR_OTHER_USER = "Curator from our organization";
+  private static final String THEIR_USER = "Curator from another organization";
+  private static final URI OUR_ORGANIZATION = randomOrganizationId();
+  private static final URI THEIR_ORGANIZATION = randomOrganizationId();
 
   @BeforeAll
   static void beforeAll() {
     CONTAINER.start();
+    mockIdentityService(OUR_USER, OUR_ORGANIZATION);
+    mockIdentityService(OUR_OTHER_USER, OUR_ORGANIZATION);
+    mockIdentityService(THEIR_USER, THEIR_ORGANIZATION);
   }
 
   @AfterAll
@@ -44,10 +63,9 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
 
   @BeforeEach
   void beforeEach() {
-    currentUsername = "CuratorNameHere";
-    currentOrganization = randomOrganizationId();
+    currentUsername = OUR_USER;
+    currentOrganization = OUR_ORGANIZATION;
     currentAccessRight = AccessRight.MANAGE_NVI_CANDIDATES;
-    mockIdentityService(currentUsername, currentOrganization);
 
     CONTAINER.createIndex();
     createHandler(CONTAINER.getOpenSearchClient());
@@ -59,8 +77,8 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
   }
 
   @Nested
-  @DisplayName("Test access control")
-  class accessControlTests {
+  @DisplayName("Access control")
+  class AccessControlTests {
 
     @Test
     void shouldNotReturnNviCandidatesOutsideViewingScope() {
@@ -89,8 +107,8 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
   }
 
   @Nested
-  @DisplayName("Test pagination and sorting")
-  class paginationTests {
+  @DisplayName("Pagination and sorting")
+  class PaginationTests {
     private static final int DEFAULT_SIZE = 10;
     private static final int DEFAULT_OFFSET = 0;
     private static final int TOTAL_DOCUMENT_COUNT = 25;
@@ -139,13 +157,15 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
               .toList();
       var expectedDocumentIds =
           expectedDocuments.stream().map(NviCandidateIndexDocument::id).toList();
-      assertThat(actualDocumentIds).hasSize(TOTAL_DOCUMENT_COUNT).isEqualTo(expectedDocumentIds);
+      assertThat(actualDocumentIds)
+          .hasSize(TOTAL_DOCUMENT_COUNT)
+          .containsExactlyInAnyOrderElementsOf(expectedDocumentIds);
     }
   }
 
   @Nested
-  @DisplayName("Test filtering by year")
-  class yearTests {
+  @DisplayName("Filter by year")
+  class YearTests {
     private NviCandidateIndexDocument documentFromCurrentYear;
     private NviCandidateIndexDocument documentFromLastYear;
 
@@ -190,6 +210,118 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
     }
   }
 
+  @Nested
+  @DisplayName("Filter by assignee and excludeUnassigned")
+  class AssigneeTests {
+    private static final String ASSIGNED_TO_CURRENT = "assignedToCurrentUser";
+    private static final String ASSIGNED_TO_OTHER = "assignedToOtherUser";
+    private static final String UNASSIGNED_BY_US = "unassignedByUs";
+    private static final String UNASSIGNED_BY_THEM = "unassignedByThem";
+    private static final String UNASSIGNED_BY_ALL = "unassignedByAll";
+    private static final String UNRELATED_ASSIGNED = "assignedAndUnrelated";
+    private static final String UNRELATED_UNASSIGNED = "unassignedAndUnrelated";
+
+    private static final Map<String, NviCandidateIndexDocument> docs =
+        createDocumentsForAssigneeTests();
+
+    @BeforeEach
+    void beforeEach() {
+      addDocumentsToIndex(docs.values());
+    }
+
+    @ParameterizedTest
+    @MethodSource("assigneeTestCaseProvider")
+    void shouldFilterByAssigneeAndExcludeUnassignedFilter(
+        Map<String, String> queryParameters, Collection<String> expectedDocumentKeys) {
+      var response = handleRequest(queryParameters);
+
+      assertThat(response.getHits())
+          .hasSameSizeAs(expectedDocumentKeys)
+          .allSatisfy(
+              doc -> {
+                var actualTitle = doc.publicationDetails().title();
+                assertThat(doc.id()).isEqualTo(docs.get(actualTitle).id());
+                assertThat(actualTitle).isIn(expectedDocumentKeys);
+              });
+    }
+
+    private static NviCandidateIndexDocument documentWithApprovals(
+        String title, Approval... approvals) {
+      var allApprovals = List.of(approvals);
+      var topLevelOrganizations = allApprovals.stream().map(Approval::institutionId).toList();
+      var details = randomPublicationDetailsBuilder(topLevelOrganizations).withTitle(title).build();
+      return randomIndexDocumentBuilder(details)
+          .withApprovals(allApprovals)
+          .withNumberOfApprovals(allApprovals.size())
+          .build();
+    }
+
+    private static Map<String, NviCandidateIndexDocument> createDocumentsForAssigneeTests() {
+      var assignedToCurrentUser =
+          randomApproval(OUR_USER, OUR_ORGANIZATION, randomOrganizationId());
+      var assignedToOtherUser =
+          randomApproval(OUR_OTHER_USER, OUR_ORGANIZATION, randomOrganizationId());
+      var assignedToTheirUser =
+          randomApproval(THEIR_USER, THEIR_ORGANIZATION, randomOrganizationId());
+      var noAssigneeFromUs = randomApproval(null, OUR_ORGANIZATION, randomOrganizationId());
+      var noAssigneeFromThem = randomApproval(null, THEIR_ORGANIZATION, randomOrganizationId());
+
+      return Map.of(
+          ASSIGNED_TO_CURRENT,
+          documentWithApprovals(ASSIGNED_TO_CURRENT, assignedToCurrentUser, noAssigneeFromThem),
+          ASSIGNED_TO_OTHER,
+          documentWithApprovals(ASSIGNED_TO_OTHER, assignedToOtherUser, assignedToTheirUser),
+          UNASSIGNED_BY_US,
+          documentWithApprovals(UNASSIGNED_BY_US, noAssigneeFromUs, assignedToTheirUser),
+          UNASSIGNED_BY_THEM,
+          documentWithApprovals(UNASSIGNED_BY_THEM, assignedToOtherUser, noAssigneeFromThem),
+          UNASSIGNED_BY_ALL,
+          documentWithApprovals(UNASSIGNED_BY_ALL, noAssigneeFromUs, noAssigneeFromThem),
+          UNRELATED_ASSIGNED,
+          documentWithApprovals(UNRELATED_ASSIGNED, assignedToTheirUser),
+          UNRELATED_UNASSIGNED,
+          documentWithApprovals(UNRELATED_UNASSIGNED, noAssigneeFromThem));
+    }
+
+    private static Stream<Arguments> assigneeTestCaseProvider() {
+      return Stream.of(
+          argumentSet(
+              "Query without filters",
+              emptyMap(),
+              List.of(
+                  ASSIGNED_TO_CURRENT,
+                  ASSIGNED_TO_OTHER,
+                  UNASSIGNED_BY_US,
+                  UNASSIGNED_BY_THEM,
+                  UNASSIGNED_BY_ALL)),
+          argumentSet(
+              "assignee=someone",
+              Map.of(QUERY_PARAM_ASSIGNEE, OUR_USER),
+              List.of(ASSIGNED_TO_CURRENT, UNASSIGNED_BY_US, UNASSIGNED_BY_ALL)),
+          argumentSet(
+              "excludeUnassigned=false",
+              Map.of(QUERY_PARAM_EXCLUDE_UNASSIGNED, "false"),
+              List.of(
+                  ASSIGNED_TO_CURRENT,
+                  ASSIGNED_TO_OTHER,
+                  UNASSIGNED_BY_US,
+                  UNASSIGNED_BY_THEM,
+                  UNASSIGNED_BY_ALL)),
+          argumentSet(
+              "excludeUnassigned=true",
+              Map.of(QUERY_PARAM_EXCLUDE_UNASSIGNED, "true"),
+              List.of(ASSIGNED_TO_CURRENT, ASSIGNED_TO_OTHER, UNASSIGNED_BY_THEM)),
+          argumentSet(
+              "assignee=someone & excludeUnassigned=false",
+              Map.of(QUERY_PARAM_ASSIGNEE, OUR_OTHER_USER, QUERY_PARAM_EXCLUDE_UNASSIGNED, "false"),
+              List.of(ASSIGNED_TO_OTHER, UNASSIGNED_BY_US, UNASSIGNED_BY_THEM, UNASSIGNED_BY_ALL)),
+          argumentSet(
+              "assignee=someone & excludeUnassigned=true",
+              Map.of(QUERY_PARAM_ASSIGNEE, OUR_OTHER_USER, QUERY_PARAM_EXCLUDE_UNASSIGNED, "true"),
+              List.of(ASSIGNED_TO_OTHER, UNASSIGNED_BY_THEM)));
+    }
+  }
+
   private static void addDocumentsToIndex(NviCandidateIndexDocument... documents) {
     CONTAINER.addDocumentsToIndex(documents);
   }
@@ -198,15 +330,24 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
     CONTAINER.addDocumentsToIndex(documents);
   }
 
+  private static void assertThatResponseHasExpectedIndexDocumentIds(
+      PaginatedSearchResult<NviCandidateIndexDocument> response,
+      Collection<URI> expectedDocumentIds) {
+    assertThat(response.getHits())
+        .hasSize(expectedDocumentIds.size())
+        .extracting(NviCandidateIndexDocument::id)
+        .containsExactlyInAnyOrderElementsOf(expectedDocumentIds);
+  }
+
   private static void assertThatResponseHasExpectedIndexDocuments(
       PaginatedSearchResult<NviCandidateIndexDocument> response,
-      List<NviCandidateIndexDocument> expectedDocuments) {
+      Collection<NviCandidateIndexDocument> expectedDocuments) {
     assertThatResultsAreEqual(response.getHits(), expectedDocuments);
   }
 
   private static void assertThatResultsAreEqual(
-      List<NviCandidateIndexDocument> actualDocuments,
-      List<NviCandidateIndexDocument> expectedDocuments) {
+      Collection<NviCandidateIndexDocument> actualDocuments,
+      Collection<NviCandidateIndexDocument> expectedDocuments) {
     assertThat(actualDocuments)
         .usingComparatorForType(BigDecimal::compareTo, BigDecimal.class)
         .usingRecursiveComparison()

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -511,30 +511,6 @@ class OpenSearchClientTest {
     assertThat(searchResponse.hits().hits(), hasSize(1));
   }
 
-  @Test
-  void shouldReturnSingleDocumentWhenFilteringByAssignee() throws IOException {
-    var customer = randomUri();
-    var assignee =
-        randomString().concat(" ").concat(randomString()).concat(" ").concat(randomString());
-    var document =
-        indexDocumentWithCustomer(customer, randomString(), assignee, YEAR, randomString());
-    addDocumentsToIndex(
-        document,
-        indexDocumentWithCustomer(
-            customer, randomString(), randomString(), randomString(), randomString()));
-
-    var searchParameters =
-        defaultSearchParameters()
-            .withAffiliations(List.of(getLastPathElement(customer)))
-            .withAssignee(getRandomWord(assignee))
-            .withYear(YEAR)
-            .build();
-
-    var searchResponse = openSearchClient.search(searchParameters);
-
-    assertThat(searchResponse.hits().hits(), hasSize(1));
-  }
-
   @ParameterizedTest(name = "shouldReturnSearchResultsUsingFilterAndSearchTermCombined {0}")
   @MethodSource("filterNameProvider")
   void shouldReturnSearchResultsUsingFilterAndSearchTermCombined(Entry<String, Integer> entry)
@@ -967,7 +943,7 @@ class OpenSearchClientTest {
     var publicationDetails =
         randomPublicationDetailsWithCustomer(customer, contributor, year, title);
     return randomIndexDocumentBuilder(publicationDetails)
-        .withApprovals(List.of(randomApproval(assignee, customer, customer)))
+        .withApprovals(List.of(randomApproval(assignee, customer)))
         .withNumberOfApprovals(1)
         .build();
   }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -1,11 +1,9 @@
 package no.sikt.nva.nvi.index.aws;
 
 import static java.util.Objects.requireNonNull;
-import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomGlobalApprovalStatus;
+import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomApproval;
 import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomIndexDocumentBuilder;
-import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomInstitutionPoints;
 import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomPublicationDetailsBuilder;
-import static no.sikt.nva.nvi.index.IndexDocumentFixtures.randomStatus;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomNviContributor;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomNviContributorBuilder;
 import static no.sikt.nva.nvi.index.IndexDocumentTestUtils.randomPages;
@@ -53,10 +51,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -971,7 +967,7 @@ class OpenSearchClientTest {
     var publicationDetails =
         randomPublicationDetailsWithCustomer(customer, contributor, year, title);
     return randomIndexDocumentBuilder(publicationDetails)
-        .withApprovals(List.of(randomApprovalWithCustomerAndAssignee(customer, assignee)))
+        .withApprovals(List.of(randomApproval(assignee, customer, customer)))
         .withNumberOfApprovals(1)
         .build();
   }
@@ -1006,17 +1002,6 @@ class OpenSearchClientTest {
         .withPublicationChannel(randomPublicationChannel())
         .withPages(randomPages())
         .build();
-  }
-
-  private static Approval randomApprovalWithCustomerAndAssignee(URI affiliation, String assignee) {
-    return new Approval(
-        affiliation,
-        Map.of(),
-        randomStatus(),
-        randomInstitutionPoints(),
-        Set.of(),
-        assignee,
-        randomGlobalApprovalStatus());
   }
 
   private static PublicationDetails publicationDetailsWithTitle(String title) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PublicationDateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PublicationDateFixtures.java
@@ -8,6 +8,10 @@ import no.sikt.nva.nvi.common.dto.PublicationDateDto;
 
 public class PublicationDateFixtures {
   public static PublicationDate randomPublicationDateInYear(int year) {
+    return randomPublicationDateInYear(String.valueOf(year));
+  }
+
+  public static PublicationDate randomPublicationDateInYear(String year) {
     var randomDate = randomLocalDate();
     return new PublicationDate(
         String.valueOf(year),
@@ -25,6 +29,14 @@ public class PublicationDateFixtures {
         String.valueOf(randomDate.getYear()),
         String.valueOf(randomDate.getMonthValue()),
         String.valueOf(randomDate.getDayOfMonth()));
+  }
+
+  public static PublicationDateDto randomPublicationDateDtoInYear(int year) {
+    return randomPublicationDateInYear(String.valueOf(year)).toDtoPublicationDate();
+  }
+
+  public static PublicationDateDto randomPublicationDateDtoInYear(String year) {
+    return randomPublicationDateInYear(year).toDtoPublicationDate();
   }
 
   public static PublicationDateDto getRandomDateInCurrentYearAsDto() {


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49374

This adds a new query parameter to the API to filter by whether or not the user's organization has a assigned a curator to the candidate. The default value is `excludeUnassigned=false`. The query parameter `assignee=<username` now ignores unassigned candidates.

Examples:

- `?assignee=MrCurator&excludeUnassigned=true`: This returns only those candidates assigned to `MrCurator`
- `?assignee=MrCurator`: This returns candidates assigned to `MrCurator` and also any candidates without an assignee from their organization.
- `?excludeUnassigned=true`: This returns all candidates that have an assignee