### PR TITLE
fix: Increase lambda timeout

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -102,7 +102,7 @@ Parameters:
   DefaultTimeoutForParsingLambdas:
     Type: Number
     Description: Timeout in seconds for functions that parse JSON-LD documents. These need a high timeout in order to handle unusually large documents.
-    Default: 300
+    Default: 300 # 5 minutes
 
 Conditions:
   WithSuffix: !Not [ !Equals [ !Ref Suffix, '' ] ]
@@ -737,8 +737,6 @@ Resources:
       CodeUri: event-handlers
       Handler: no.sikt.nva.nvi.events.evaluator.EvaluateNviCandidateHandler::handleRequest
       Role: !GetAtt NvaNviRole.Arn
-      #For publications with many contributors, evaluation can take more than 30 sec due to
-      #many external requests. Timeout is set to 5 minutes.
       Timeout: !Ref DefaultTimeoutForParsingLambdas
       MemorySize: 1536
       AutoPublishAlias: live

--- a/template.yaml
+++ b/template.yaml
@@ -99,6 +99,10 @@ Parameters:
     Type: String
     Description: comma separated list of external clients that are allowed to contact the HTTP APIs, "*" indicates that all origins are allowed
     Default: '*'
+  DefaultTimeoutForParsingLambdas:
+    Type: Number
+    Description: Timeout in seconds for functions that parse JSON-LD documents. These need a high timeout in order to handle unusually large documents.
+    Default: 300
 
 Conditions:
   WithSuffix: !Not [ !Equals [ !Ref Suffix, '' ] ]
@@ -735,7 +739,7 @@ Resources:
       Role: !GetAtt NvaNviRole.Arn
       #For publications with many contributors, evaluation can take more than 30 sec due to
       #many external requests. Timeout is set to 5 minutes.
-      Timeout: 300
+      Timeout: !Ref DefaultTimeoutForParsingLambdas
       MemorySize: 1536
       AutoPublishAlias: live
       SnapStart:
@@ -966,7 +970,7 @@ Resources:
       CodeUri: event-handlers
       Handler: no.sikt.nva.nvi.events.cristin.CristinNviReportEventConsumer::handleRequest
       Role: !GetAtt NvaNviRole.Arn
-      Timeout: 30
+      Timeout: !Ref DefaultTimeoutForParsingLambdas
       MemorySize: 1536
       Environment:
         Variables:


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49439

This increases the timeout for the `CristinNviEventConsumer` lambda to match the existing `EvaluateNVICandidateHandler` lambda. These both need the same high timeout to handle rare cases with large documents.