### PR TITLE
[np-49381] refactor: Simplify file structure

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.index.query;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.emptySet;
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static no.sikt.nva.nvi.common.utils.JsonUtils.jsonPathOf;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.APPROVED;
@@ -38,9 +37,7 @@ import static no.sikt.nva.nvi.index.utils.SearchConstants.TITLE;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.TYPE;
 import static no.sikt.nva.nvi.index.utils.SearchConstants.YEAR;
 
-import com.fasterxml.jackson.annotation.JsonValue;
 import java.time.ZonedDateTime;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -245,41 +242,6 @@ public record CandidateQuery(
     return globalStatuses.stream()
         .map(QueryFunctions::globalStatusQuery)
         .reduce(QueryFunctions::matchAtLeastOne);
-  }
-
-  public enum QueryFilterType {
-    COLLABORATION("collaboration"),
-    OTHERS_APPROVE("approvedByOthers"),
-    OTHERS_REJECT("rejectedByOthers"),
-    NEW_AGG("pending"),
-    NEW_COLLABORATION_AGG("pendingCollaboration"),
-    PENDING_AGG("assigned"),
-    PENDING_COLLABORATION_AGG("assignedCollaboration"),
-    APPROVED_AGG("approved"),
-    APPROVED_COLLABORATION_AGG("approvedCollaboration"),
-    REJECTED_AGG("rejected"),
-    REJECTED_COLLABORATION_AGG("rejectedCollaboration"),
-    DISPUTED_AGG("dispute"),
-    ASSIGNMENTS_AGG("assignments"),
-    EMPTY_FILTER("");
-
-    private final String filter;
-
-    QueryFilterType(String filter) {
-      this.filter = filter;
-    }
-
-    public static Optional<QueryFilterType> parse(String candidate) {
-      var testValue = isNull(candidate) ? "" : candidate;
-      return Arrays.stream(values())
-          .filter(item -> item.getFilter().equalsIgnoreCase(testValue))
-          .findAny();
-    }
-
-    @JsonValue
-    public String getFilter() {
-      return filter;
-    }
   }
 
   public static class Builder {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -57,6 +57,7 @@ import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.TextQueryType;
 
 public record CandidateQuery(
+    ApprovalQuery approvalQuery,
     List<String> affiliations,
     boolean excludeSubUnits,
     QueryFilterType filter,
@@ -66,9 +67,6 @@ public record CandidateQuery(
     String year,
     String category,
     String title,
-    String assignee,
-    boolean excludeUnassigned,
-    Set<ApprovalStatus> statuses,
     Set<GlobalApprovalStatus> globalStatuses) {
 
   public Query toQuery() {
@@ -144,18 +142,16 @@ public record CandidateQuery(
     var yearQuery = createYearQuery(year);
     var categoryQuery = createCategoryQuery(category);
     var titleQuery = createTitleQuery(title);
-    var approvalQuery =
-        new ApprovalQuery(topLevelCristinOrg, assignee, excludeUnassigned, statuses).toQuery();
     var globalStatusQuery = createGlobalStatusQuery();
 
     return Stream.of(
+            approvalQuery.toQuery(),
             searchTermQuery,
             institutionQuery,
             filterQuery,
             yearQuery,
             categoryQuery,
             titleQuery,
-            approvalQuery,
             globalStatusQuery)
         .filter(Optional::isPresent)
         .map(Optional::get)
@@ -373,7 +369,9 @@ public record CandidateQuery(
     }
 
     public CandidateQuery build() {
+
       return new CandidateQuery(
+          new ApprovalQuery(topLevelCristinOrg, assignee, excludeUnassigned, statuses),
           affiliationIdentifiers,
           excludeSubUnits,
           filter,
@@ -383,9 +381,6 @@ public record CandidateQuery(
           year,
           category,
           title,
-          assignee,
-          excludeUnassigned,
-          statuses,
           globalStatuses);
     }
   }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -56,37 +56,20 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 import org.opensearch.client.opensearch._types.query_dsl.QueryBuilders;
 import org.opensearch.client.opensearch._types.query_dsl.TextQueryType;
 
-public class CandidateQuery {
-
-  private final List<String> affiliations;
-  private final boolean excludeSubUnits;
-  private final QueryFilterType filter;
-  private final String username;
-  private final String topLevelCristinOrg;
-  private final String searchTerm;
-  private final String year;
-  private final String category;
-  private final String title;
-  private final String assignee;
-  private final boolean excludeUnassigned;
-  private final Set<ApprovalStatus> statuses;
-  private final Set<GlobalApprovalStatus> globalStatuses;
-
-  public CandidateQuery(CandidateQueryParameters params) {
-    this.searchTerm = params.searchTerm;
-    this.affiliations = params.affiliationIdentifiers;
-    this.excludeSubUnits = params.excludeSubUnits;
-    this.filter = params.filter;
-    this.username = params.username;
-    this.topLevelCristinOrg = params.topLevelCristinOrg;
-    this.year = params.year;
-    this.category = params.category;
-    this.title = params.title;
-    this.assignee = params.assignee;
-    this.excludeUnassigned = params.excludeUnassigned;
-    this.statuses = params.statuses;
-    this.globalStatuses = params.globalStatuses;
-  }
+public record CandidateQuery(
+    List<String> affiliations,
+    boolean excludeSubUnits,
+    QueryFilterType filter,
+    String username,
+    String topLevelCristinOrg,
+    String searchTerm,
+    String year,
+    String category,
+    String title,
+    String assignee,
+    boolean excludeUnassigned,
+    Set<ApprovalStatus> statuses,
+    Set<GlobalApprovalStatus> globalStatuses) {
 
   public Query toQuery() {
     return mustMatch(specificMatch().toArray(Query[]::new));
@@ -390,41 +373,20 @@ public class CandidateQuery {
     }
 
     public CandidateQuery build() {
-      CandidateQueryParameters params = new CandidateQueryParameters();
-
-      params.searchTerm = this.searchTerm;
-      params.affiliationIdentifiers = this.affiliationIdentifiers;
-      params.excludeSubUnits = this.excludeSubUnits;
-      params.filter = this.filter;
-      params.username = this.username;
-      params.topLevelCristinOrg = this.topLevelCristinOrg;
-      params.year = this.year;
-      params.category = this.category;
-      params.title = this.title;
-      params.assignee = this.assignee;
-      params.excludeUnassigned = this.excludeUnassigned;
-      params.statuses = this.statuses;
-      params.globalStatuses = this.globalStatuses;
-
-      return new CandidateQuery(params);
+      return new CandidateQuery(
+          affiliationIdentifiers,
+          excludeSubUnits,
+          filter,
+          username,
+          topLevelCristinOrg,
+          searchTerm,
+          year,
+          category,
+          title,
+          assignee,
+          excludeUnassigned,
+          statuses,
+          globalStatuses);
     }
-  }
-
-  public static class CandidateQueryParameters {
-
-    public String searchTerm;
-    public List<String> affiliationIdentifiers;
-    public boolean excludeSubUnits;
-    public QueryFilterType filter;
-    public String username;
-    public String topLevelCristinOrg;
-    public String year;
-    public String category;
-    public String title;
-    public String contributor;
-    public String assignee;
-    public boolean excludeUnassigned;
-    public Set<ApprovalStatus> statuses;
-    public Set<GlobalApprovalStatus> globalStatuses;
   }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/QueryFilterType.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/QueryFilterType.java
@@ -1,0 +1,42 @@
+package no.sikt.nva.nvi.index.query;
+
+import static java.util.Objects.isNull;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Arrays;
+import java.util.Optional;
+
+public enum QueryFilterType {
+  COLLABORATION("collaboration"),
+  OTHERS_APPROVE("approvedByOthers"),
+  OTHERS_REJECT("rejectedByOthers"),
+  NEW_AGG("pending"),
+  NEW_COLLABORATION_AGG("pendingCollaboration"),
+  PENDING_AGG("assigned"),
+  PENDING_COLLABORATION_AGG("assignedCollaboration"),
+  APPROVED_AGG("approved"),
+  APPROVED_COLLABORATION_AGG("approvedCollaboration"),
+  REJECTED_AGG("rejected"),
+  REJECTED_COLLABORATION_AGG("rejectedCollaboration"),
+  DISPUTED_AGG("dispute"),
+  ASSIGNMENTS_AGG("assignments"),
+  EMPTY_FILTER("");
+
+  private final String filter;
+
+  QueryFilterType(String filter) {
+    this.filter = filter;
+  }
+
+  public static Optional<QueryFilterType> parse(String candidate) {
+    var testValue = isNull(candidate) ? "" : candidate;
+    return Arrays.stream(values())
+        .filter(item -> item.getFilter().equalsIgnoreCase(testValue))
+        .findAny();
+  }
+
+  @JsonValue
+  public String getFilter() {
+    return filter;
+  }
+}

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/QueryFilterType.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/QueryFilterType.java
@@ -1,12 +1,10 @@
 package no.sikt.nva.nvi.index.query;
 
-import static java.util.Objects.isNull;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
-import java.util.Arrays;
-import java.util.Optional;
+import no.sikt.nva.nvi.common.model.ParsableEnum;
 
-public enum QueryFilterType {
+public enum QueryFilterType implements ParsableEnum {
   COLLABORATION("collaboration"),
   OTHERS_APPROVE("approvedByOthers"),
   OTHERS_REJECT("rejectedByOthers"),
@@ -22,21 +20,20 @@ public enum QueryFilterType {
   ASSIGNMENTS_AGG("assignments"),
   EMPTY_FILTER("");
 
-  private final String filter;
+  private final String value;
 
-  QueryFilterType(String filter) {
-    this.filter = filter;
+  QueryFilterType(String value) {
+    this.value = value;
   }
 
-  public static Optional<QueryFilterType> parse(String candidate) {
-    var testValue = isNull(candidate) ? "" : candidate;
-    return Arrays.stream(values())
-        .filter(item -> item.getFilter().equalsIgnoreCase(testValue))
-        .findAny();
+  @JsonCreator
+  public static QueryFilterType parse(String stringValue) {
+    return ParsableEnum.parse(QueryFilterType.class, stringValue);
   }
 
   @JsonValue
-  public String getFilter() {
-    return filter;
+  @Override
+  public String getValue() {
+    return value;
   }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.index.utils;
 
+import static nva.commons.core.StringUtils.isNotBlank;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -62,15 +64,16 @@ public final class SearchConstants {
   private SearchConstants() {}
 
   public static Query constructQuery(CandidateSearchParameters params) {
-    var filterType =
-        QueryFilterType.parse(params.filter())
-            .orElseThrow(() -> new IllegalStateException("unknown filter " + params.filter()));
+    var queryFilter =
+        isNotBlank(params.filter())
+            ? QueryFilterType.parse(params.filter())
+            : QueryFilterType.EMPTY_FILTER;
     return new CandidateQuery.Builder()
         .withSearchTerm(params.searchTerm())
         .withAffiliationIdentifiers(
             Optional.ofNullable(params.affiliationIdentifiers()).orElse(List.of()))
         .withExcludeSubUnits(params.excludeSubUnits())
-        .withFilter(filterType)
+        .withFilter(queryFilter)
         .withUsername(params.username())
         .withTopLevelCristinOrg(params.topLevelOrgUriAsString())
         .withYear(params.year())

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/SearchConstants.java
@@ -5,7 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.query.CandidateQuery;
-import no.sikt.nva.nvi.index.query.CandidateQuery.QueryFilterType;
+import no.sikt.nva.nvi.index.query.QueryFilterType;
 import nva.commons.core.Environment;
 import org.opensearch.client.opensearch._types.mapping.DateProperty;
 import org.opensearch.client.opensearch._types.mapping.DoubleNumberProperty;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -199,7 +199,7 @@ class OpenSearchClientTest {
   @Test
   void shouldThrowWhenUsingUndefinedFilterName() {
     var searchParameters = defaultSearchParameters().withFilter(UNEXISTING_FILTER).build();
-    assertThrows(IllegalStateException.class, () -> openSearchClient.search(searchParameters));
+    assertThrows(IllegalArgumentException.class, () -> openSearchClient.search(searchParameters));
   }
 
   @Test
@@ -354,7 +354,7 @@ class OpenSearchClientTest {
         documentFromString("document_dispute_not_sikt.json"));
 
     var searchParameters =
-        defaultSearchParameters().withFilter(QueryFilterType.DISPUTED_AGG.getFilter()).build();
+        defaultSearchParameters().withFilter(QueryFilterType.DISPUTED_AGG.getValue()).build();
 
     var searchResponse = openSearchClient.search(searchParameters);
     assertThat(searchResponse.hits().hits(), hasSize(1));
@@ -1007,16 +1007,16 @@ class OpenSearchClientTest {
 
   private static Stream<Entry<String, Integer>> filterNameProvider() {
     var map = new HashMap<String, Integer>();
-    map.put(QueryFilterType.NEW_AGG.getFilter(), 2);
-    map.put(QueryFilterType.NEW_COLLABORATION_AGG.getFilter(), 1);
-    map.put(QueryFilterType.PENDING_AGG.getFilter(), 2);
-    map.put(QueryFilterType.PENDING_COLLABORATION_AGG.getFilter(), 1);
-    map.put(QueryFilterType.APPROVED_AGG.getFilter(), 3);
-    map.put(QueryFilterType.APPROVED_COLLABORATION_AGG.getFilter(), 2);
-    map.put(QueryFilterType.REJECTED_AGG.getFilter(), 3);
-    map.put(QueryFilterType.REJECTED_COLLABORATION_AGG.getFilter(), 2);
-    map.put(QueryFilterType.ASSIGNMENTS_AGG.getFilter(), 5);
-    map.put(QueryFilterType.DISPUTED_AGG.getFilter(), 1);
+    map.put(QueryFilterType.NEW_AGG.getValue(), 2);
+    map.put(QueryFilterType.NEW_COLLABORATION_AGG.getValue(), 1);
+    map.put(QueryFilterType.PENDING_AGG.getValue(), 2);
+    map.put(QueryFilterType.PENDING_COLLABORATION_AGG.getValue(), 1);
+    map.put(QueryFilterType.APPROVED_AGG.getValue(), 3);
+    map.put(QueryFilterType.APPROVED_COLLABORATION_AGG.getValue(), 2);
+    map.put(QueryFilterType.REJECTED_AGG.getValue(), 3);
+    map.put(QueryFilterType.REJECTED_COLLABORATION_AGG.getValue(), 2);
+    map.put(QueryFilterType.ASSIGNMENTS_AGG.getValue(), 5);
+    map.put(QueryFilterType.DISPUTED_AGG.getValue(), 1);
     return map.entrySet().stream();
   }
 

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/aws/OpenSearchClientTest.java
@@ -65,7 +65,7 @@ import no.sikt.nva.nvi.index.model.document.ReportingPeriod;
 import no.sikt.nva.nvi.index.model.search.CandidateSearchParameters;
 import no.sikt.nva.nvi.index.model.search.OrderByFields;
 import no.sikt.nva.nvi.index.model.search.SearchResultParameters;
-import no.sikt.nva.nvi.index.query.CandidateQuery.QueryFilterType;
+import no.sikt.nva.nvi.index.query.QueryFilterType;
 import no.sikt.nva.nvi.index.query.SearchAggregation;
 import nva.commons.core.ioutils.IoUtils;
 import nva.commons.core.paths.UriWrapper;


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49371

This is incidental refactoring to remove linter warnings and make the structure easier to parse.

Changes:

- refactor: Convert `CandidateQuery` to a record and remove the duplicate inner class for parameters
- refactor: Extract the enum `QueryFilterType` to a separate file
- refactor: Combine relevant parameters into a single `ApprovalQuery` record in the builder instead of passing them through one by one