### PR TITLE
[np-49232] feat: Update search aggregation

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionStatusAggregationHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionStatusAggregationHandler.java
@@ -47,8 +47,7 @@ public class FetchInstitutionStatusAggregationHandler extends ApiGatewayHandler<
   }
 
   @Override
-  protected String processInput(Void input, RequestInfo requestInfo, Context context)
-      throws ApiGatewayException {
+  protected String processInput(Void input, RequestInfo requestInfo, Context context) {
     var topLevelOrg = requestInfo.getTopLevelOrgCristinId().orElseThrow();
     var year = requestInfo.getPathParameter(PATH_PARAM_YEAR);
     var result = getAggregate(year, topLevelOrg);

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandler.java
@@ -13,7 +13,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 import no.sikt.nva.nvi.common.client.OrganizationRetriever;
 import no.sikt.nva.nvi.common.utils.RequestUtil;
 import no.sikt.nva.nvi.common.validator.ViewingScopeValidator;
@@ -123,7 +122,7 @@ public class SearchNviCandidatesHandler
     return fetchViewingScope(requestInfo.getUserName()).stream()
         .map(UriWrapper::fromUri)
         .map(UriWrapper::getLastPathElement)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   private Set<URI> fetchViewingScope(String userName) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -87,7 +87,7 @@ public final class Aggregations {
   public static Aggregation totalCountAggregation(String topLevelCristinOrg) {
     final var fieldValueQuery = approvalInstitutionIdQuery(topLevelCristinOrg);
     final var query = mustMatch(fieldValueQuery);
-    return filterAggregation(mustMatch(nestedQuery(APPROVALS, query)));
+    return filterAggregation(nestedQuery(APPROVALS, query));
   }
 
   public static Aggregation statusAggregation(String topLevelCristinOrg, ApprovalStatus status) {
@@ -102,11 +102,11 @@ public final class Aggregations {
           mustNotMatch(NEW.getValue(), APPROVAL_STATUS_PATH)
         };
     var notPendingQuery = nestedQuery(APPROVALS, mustMatch(queries));
-    return filterAggregation(mustMatch(notPendingQuery));
+    return filterAggregation(notPendingQuery);
   }
 
   public static Aggregation assignmentsAggregation(String username, String topLevelCristinOrg) {
-    return filterAggregation(mustMatch(assignmentsQuery(username, topLevelCristinOrg)));
+    return filterAggregation(assignmentsQuery(username, topLevelCristinOrg));
   }
 
   public static Aggregation finalizedCollaborationAggregation(

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/Aggregations.java
@@ -2,8 +2,12 @@ package no.sikt.nva.nvi.index.query;
 
 import static java.util.Objects.isNull;
 import static no.sikt.nva.nvi.common.utils.JsonUtils.jsonPathOf;
+import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.APPROVED;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.NEW;
 import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.PENDING;
+import static no.sikt.nva.nvi.index.model.document.ApprovalStatus.REJECTED;
+import static no.sikt.nva.nvi.index.query.ApprovalQuery.approvalBelongsTo;
+import static no.sikt.nva.nvi.index.query.ApprovalQuery.approvalStatusIs;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.filterAggregation;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.nestedAggregation;
 import static no.sikt.nva.nvi.index.utils.AggregationFunctions.sumAggregation;
@@ -11,6 +15,7 @@ import static no.sikt.nva.nvi.index.utils.AggregationFunctions.termsAggregation;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.assignmentsQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.containsNonFinalizedStatusQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.fieldValueQuery;
+import static no.sikt.nva.nvi.index.utils.QueryFunctions.matchAtLeastOne;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.multipleApprovalsQuery;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.mustMatch;
 import static no.sikt.nva.nvi.index.utils.QueryFunctions.mustNotMatch;
@@ -36,7 +41,6 @@ import org.opensearch.client.opensearch._types.query_dsl.Query;
 public final class Aggregations {
 
   public static final String APPROVAL_ORGANIZATIONS_AGGREGATION = "organizations";
-  private static final String APPROVAL_STATUS_PATH = jsonPathOf(APPROVALS, APPROVAL_STATUS);
   private static final String INSTITUTION_ID_PATH = jsonPathOf(APPROVALS, INSTITUTION_ID);
   private static final String DISPUTE_AGGREGATION = "dispute";
   private static final String POINTS_AGGREGATION = "points";
@@ -57,7 +61,7 @@ public final class Aggregations {
 
   public static Aggregation organizationApprovalStatusAggregations(String topLevelCristinOrg) {
     var statusAggregation = termsAggregation(APPROVALS, APPROVAL_STATUS)._toAggregation();
-    var pointAggregation = filterNotRegectedPointsAggregation();
+    var pointAggregation = filterNotRejectedPointsAggregation();
     var disputeAggregation = filterStatusDisputeAggregation();
     var organizationAggregation =
         new Aggregation.Builder()
@@ -94,15 +98,22 @@ public final class Aggregations {
     return filterAggregation(mustMatch(statusQuery(topLevelCristinOrg, status), notDisputeQuery()));
   }
 
-  public static Aggregation completedAggregation(String topLevelCristinOrg) {
-    final var queries =
-        new Query[] {
-          approvalInstitutionIdQuery(topLevelCristinOrg),
-          mustNotMatch(PENDING.getValue(), APPROVAL_STATUS_PATH),
-          mustNotMatch(NEW.getValue(), APPROVAL_STATUS_PATH)
-        };
-    var notPendingQuery = nestedQuery(APPROVALS, mustMatch(queries));
-    return filterAggregation(notPendingQuery);
+  public static Aggregation pendingAggregation(String topLevelOrganization) {
+    return filterAggregation(
+        mustMatch(
+            notDisputeQuery(),
+            nestedQuery(
+                APPROVALS,
+                approvalBelongsTo(topLevelOrganization),
+                matchAtLeastOne(approvalStatusIs(NEW), approvalStatusIs(PENDING)))));
+  }
+
+  public static Aggregation completedAggregation(String topLevelOrganization) {
+    return filterAggregation(
+        nestedQuery(
+            APPROVALS,
+            approvalBelongsTo(topLevelOrganization),
+            matchAtLeastOne(approvalStatusIs(APPROVED), approvalStatusIs(REJECTED))));
   }
 
   public static Aggregation assignmentsAggregation(String username, String topLevelCristinOrg) {
@@ -129,9 +140,9 @@ public final class Aggregations {
     return filterAggregation(mustMatch(globalStatusDisputeForInstitution(topLevelCristinOrg)));
   }
 
-  private static Aggregation filterNotRegectedPointsAggregation() {
+  private static Aggregation filterNotRejectedPointsAggregation() {
     return filterAggregation(
-        mustNotMatch(ApprovalStatus.REJECTED.getValue(), jsonPathOf(APPROVALS, APPROVAL_STATUS)),
+        mustNotMatch(REJECTED.getValue(), jsonPathOf(APPROVALS, APPROVAL_STATUS)),
         Map.of(
             TOTAL_POINTS_SUM_AGGREGATION, sumAggregation(APPROVALS, POINTS, INSTITUTION_POINTS)));
   }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/ApprovalQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/ApprovalQuery.java
@@ -41,9 +41,8 @@ public record ApprovalQuery(
     return Optional.of(
         nestedQuery(
             APPROVALS,
-            mustMatch(
-                approvalBelongsTo(topLevelOrganization),
-                mustMatch(subQueries.toArray(Query[]::new)))));
+            approvalBelongsTo(topLevelOrganization),
+            mustMatch(subQueries.toArray(Query[]::new))));
   }
 
   public static Query approvalBelongsTo(String organization) {
@@ -101,9 +100,6 @@ public record ApprovalQuery(
   }
 
   private static Query approvalIsUnassigned() {
-    return QueryBuilders.bool()
-        .mustNot(existsQuery(jsonPathOf(APPROVALS, ASSIGNEE)))
-        .build()
-        .toQuery();
+    return mustNotMatch(existsQuery(jsonPathOf(APPROVALS, ASSIGNEE)));
   }
 }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -168,12 +168,12 @@ public record CandidateQuery(
           case NEW_COLLABORATION_AGG ->
               mustMatch(statusQuery(topLevelCristinOrg, NEW), multipleApprovalsQuery());
 
-          case PENDING_AGG -> mustMatch(statusQuery(topLevelCristinOrg, PENDING));
+          case PENDING_AGG -> statusQuery(topLevelCristinOrg, PENDING);
 
           case PENDING_COLLABORATION_AGG ->
               mustMatch(statusQuery(topLevelCristinOrg, PENDING), multipleApprovalsQuery());
 
-          case APPROVED_AGG -> mustMatch(statusQuery(topLevelCristinOrg, APPROVED));
+          case APPROVED_AGG -> statusQuery(topLevelCristinOrg, APPROVED);
 
           case APPROVED_COLLABORATION_AGG ->
               mustMatch(
@@ -181,7 +181,7 @@ public record CandidateQuery(
                   containsNonFinalizedStatusQuery(),
                   multipleApprovalsQuery());
 
-          case REJECTED_AGG -> mustMatch(statusQuery(topLevelCristinOrg, REJECTED));
+          case REJECTED_AGG -> statusQuery(topLevelCristinOrg, REJECTED);
 
           case REJECTED_COLLABORATION_AGG ->
               mustMatch(
@@ -190,7 +190,7 @@ public record CandidateQuery(
                   multipleApprovalsQuery());
 
           case DISPUTED_AGG -> mustMatch(disputeQuery(), institutionQuery(topLevelCristinOrg));
-          case ASSIGNMENTS_AGG -> mustMatch(assignmentsQuery(username, topLevelCristinOrg));
+          case ASSIGNMENTS_AGG -> assignmentsQuery(username, topLevelCristinOrg);
         };
 
     return Optional.ofNullable(aggregation);
@@ -199,9 +199,7 @@ public record CandidateQuery(
   private static Query otherOrganizationStatusQuery(
       String userOrganization, ApprovalStatus status) {
     return nestedQuery(
-        APPROVALS,
-        mustNotMatch(approvalBelongsTo(userOrganization)),
-        mustMatch(approvalStatusIs(status)));
+        APPROVALS, mustNotMatch(approvalBelongsTo(userOrganization)), approvalStatusIs(status));
   }
 
   private Query institutionQuery(String topLevelCristinOrg) {

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/SearchAggregation.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/SearchAggregation.java
@@ -9,6 +9,7 @@ import static no.sikt.nva.nvi.index.query.Aggregations.completedAggregation;
 import static no.sikt.nva.nvi.index.query.Aggregations.disputeAggregation;
 import static no.sikt.nva.nvi.index.query.Aggregations.finalizedCollaborationAggregation;
 import static no.sikt.nva.nvi.index.query.Aggregations.organizationApprovalStatusAggregations;
+import static no.sikt.nva.nvi.index.query.Aggregations.pendingAggregation;
 import static no.sikt.nva.nvi.index.query.Aggregations.statusAggregation;
 import static no.sikt.nva.nvi.index.query.Aggregations.totalCountAggregation;
 
@@ -19,7 +20,7 @@ import java.util.stream.Stream;
 import org.opensearch.client.opensearch._types.aggregations.Aggregation;
 
 public enum SearchAggregation {
-  NEW_AGG("pending", (username, topLevelCristinOrg) -> statusAggregation(topLevelCristinOrg, NEW)),
+  NEW_AGG("pending", (username, topLevelCristinOrg) -> pendingAggregation(topLevelCristinOrg)),
   NEW_COLLABORATION_AGG(
       "pendingCollaboration",
       (username, topLevelCristinOrg) -> collaborationAggregation(topLevelCristinOrg, NEW)),
@@ -62,9 +63,9 @@ public enum SearchAggregation {
     this.aggregationFunction = aggregationFunction;
   }
 
-  public static SearchAggregation parse(String candidate) {
+  public static SearchAggregation parse(String candidateString) {
     return Arrays.stream(values())
-        .filter(type -> type.getAggregationName().equalsIgnoreCase(candidate))
+        .filter(type -> type.getAggregationName().equalsIgnoreCase(candidateString))
         .findFirst()
         .orElse(null);
   }

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/QueryFunctions.java
@@ -120,7 +120,7 @@ public final class QueryFunctions {
   }
 
   public static Query multipleApprovalsQuery() {
-    return mustMatch(rangeFromQuery(NUMBER_OF_APPROVALS, MULTIPLE));
+    return rangeFromQuery(NUMBER_OF_APPROVALS, MULTIPLE);
   }
 
   public static Query assignmentsQuery(String username, String customer) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionStatusAggregationHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/FetchInstitutionStatusAggregationHandlerTest.java
@@ -46,7 +46,7 @@ class FetchInstitutionStatusAggregationHandlerTest {
   private OpenSearchClient openSearchClient;
 
   @BeforeEach
-  public void setUp() {
+  void setUp() {
     output = new ByteArrayOutputStream();
     openSearchClient = mock(OpenSearchClient.class);
     handler = new FetchInstitutionStatusAggregationHandler(openSearchClient, ENVIRONMENT);


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49430

The core change here is that `ApprovalStatus.NEW` and `ApprovalStatus.PENDING` are merged in the search aggregation, matching the new query parameter changing.

refactor: Simplify query building by removing unnecessary nesting
- Removed redundant mustMatch() calls in ApprovalQuery, CandidateQuery, and QueryFunctions
- Streamlined nested query structures in key methods

feat: Improve aggregation logic and performance
- Updated pendingAggregation() and completedAggregation() to use matchAtLeastOne() for cleaner status
matching
- Fixed typo: filterNotRegectedPointsAggregation() → filterNotRejectedPointsAggregation()

refactor: Clean up approval status handling
- Removed exception throwing from FetchInstitutionStatusAggregationHandler.processInput()
- Updated SearchAggregation.NEW_AGG to use new pending aggregation method

test: Enhance test coverage with parameterized status combination tests
- Added comprehensive aggregation counting scenarios
- Improved test data creation for all approval status combinations