### PR TITLE
feat: Add logging and test case for query complexity

### DIFF
--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -77,4 +77,5 @@ test {
     environment("TOPIC_APPROVAL_UPDATE", "APPROVAL_UPDATE_TOPIC")
     environment("TOPIC_APPROVAL_REMOVE", "APPROVAL_REMOVE_TOPIC")
     environment("COGNITO_AUTHORIZER_URLS", "http://localhost:3000")
+    environment("LOG_LEVEL", "debug")
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ junit = { strictly = '5.12.2' }
 junitPlatform = { strictly = '1.12.2' } # May need to sync minor&patch version with 'junit' version
 log4j = { strictly = '2.24.3' }
 mockito = { strictly = '5.17.0' }
-nva = { strictly = '2.2.4' }
+nva = { strictly = '2.2.9' }
 nvaLanguage = { strictly = '1.2.1' }
 openCsv = { strictly = '5.10' }
 openSearchJava = { strictly = '2.23.0' }

--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -56,4 +56,5 @@ test {
     environment("INDEX_DLQ", "IndexDlq")
     environment("INSTITUTION_REPORT_SEARCH_PAGE_SIZE", "4")
     environment("COGNITO_AUTHORIZER_URLS", "http://localhost:3000")
+    environment("LOG_LEVEL", "trace")
 }

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerIntegrationTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/SearchNviCandidatesHandlerIntegrationTest.java
@@ -41,16 +41,19 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
 import no.sikt.nva.nvi.index.OpenSearchContainerContext;
+import no.sikt.nva.nvi.index.aws.OpenSearchClient;
 import no.sikt.nva.nvi.index.model.document.Approval;
 import no.sikt.nva.nvi.index.model.document.ApprovalStatus;
 import no.sikt.nva.nvi.index.model.document.NviCandidateIndexDocument;
 import no.sikt.nva.nvi.index.model.document.ReportingPeriod;
 import no.unit.nva.commons.pagination.PaginatedSearchResult;
 import nva.commons.apigateway.AccessRight;
+import nva.commons.logutils.LogUtils;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -93,6 +96,22 @@ class SearchNviCandidatesHandlerIntegrationTest extends SearchNviCandidatesHandl
   @AfterEach
   void afterEach() {
     CONTAINER.deleteIndex();
+  }
+
+  @Nested
+  @DisplayName("Query structure")
+  class QueryStructureTests {
+
+    @Test
+    @Disabled // FIXME: Fix excessive nesting in query builder and enable this test
+    void shouldNotProduceExtremelyNestedQuery() {
+      var logAppender = LogUtils.getTestingAppender(OpenSearchClient.class);
+
+      handleRequest(emptyMap());
+      var messages = logAppender.getMessages();
+
+      assertThat(messages).isNotEmpty().doesNotContain("exceeds recommended limit");
+    }
   }
 
   @Nested

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -37,6 +37,7 @@ test {
     environment("COGNITO_AUTHORIZER_URLS", "http://localhost:3000")
     environment("CUSTOM_DOMAIN_BASE_PATH", "scientific-index")
     environment("EXPANDED_RESOURCES_BUCKET", "testBucket")
+    environment("LOG_LEVEL", "debug")
     environment("NVI_TABLE_NAME", "some-table")
     environment("UPSERT_CANDIDATE_DLQ_QUEUE_URL", "http://localhost:3000/upsert-candidate-DLQ")
 }

--- a/nvi-commons/build.gradle
+++ b/nvi-commons/build.gradle
@@ -52,4 +52,5 @@ test {
     environment("NVI_TABLE_NAME", "some-table")
     environment("BACKEND_CLIENT_AUTH_URL", "example.org/auth")
     environment("COGNITO_AUTHORIZER_URLS", "http://localhost:3000")
+    environment("LOG_LEVEL", "debug")
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/EnvironmentFixtures.java
@@ -11,6 +11,7 @@ public enum EnvironmentFixtures {
   BACKEND_CLIENT_SECRET_NAME("BackendCognitoClientCredentials"),
   COGNITO_AUTHORIZER_URLS("http://localhost:3000,https://localhost:3000"),
   CUSTOM_DOMAIN_BASE_PATH("scientific-index"),
+  LOG_LEVEL("trace"), // Log4j cannot read these, so this must also be set in build.gradle
   NVI_TABLE_NAME("nvi-table-name"),
   SEARCH_INFRASTRUCTURE_API_HOST("https://api.fake.sws.aws.sikt.no"),
   SEARCH_INFRASTRUCTURE_AUTH_URI("https://sws-auth.fake.auth.eu-west-1.amazoncognito.com"),
@@ -57,6 +58,7 @@ public enum EnvironmentFixtures {
         .with(BACKEND_CLIENT_SECRET_NAME)
         .with(COGNITO_AUTHORIZER_URLS)
         .with(CUSTOM_DOMAIN_BASE_PATH)
+        .with(LOG_LEVEL)
         .with(NVI_TABLE_NAME)
         .with(SEARCH_INFRASTRUCTURE_API_HOST)
         .with(SEARCH_INFRASTRUCTURE_AUTH_URI);

--- a/nvi-rest/build.gradle
+++ b/nvi-rest/build.gradle
@@ -37,4 +37,5 @@ test {
     environment("NVI_TABLE_NAME", "some-table")
     environment("COGNITO_AUTHORIZER_URLS", "http://localhost:3000")
     environment("UPSERT_CANDIDATE_DLQ_QUEUE_URL", "http://localhost:3000/upsert-candidate-DLQ")
+    environment("LOG_LEVEL", "debug")
 }

--- a/nvi-test/build.gradle
+++ b/nvi-test/build.gradle
@@ -11,4 +11,5 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    environment("LOG_LEVEL", "debug")
 }


### PR DESCRIPTION
This adds logging and testing to give us insight into the complexity of the OpenSearch queries we generate.

Changes:

- Add `TRACE` level logging of the full query string (JSON)
- Add `DEBUG` level logging of estimated query size
- Add `WARNING` level logging of unexpectedly complex queries. The cut-off here is currently at 150. For comparison, current queries are around ~300 and a "normal" query should probably be in the range 40-80.
- Set the environment variable `LOG_LEVEL` in all Gradle sub-projects. Note that this must be set here to apply during tests, as the logging framework does not read from the fake environment we otherwise use.