### PR TITLE
feat: Use shared version catalog

### DIFF
--- a/build-logic/build.gradle
+++ b/build-logic/build.gradle
@@ -5,9 +5,3 @@ plugins {
 repositories {
     gradlePluginPortal()
 }
-
-dependencies {
-    implementation libs.errorprone.plugin
-    implementation libs.gradle.versions.plugin
-    implementation libs.spotless
-}

--- a/build-logic/settings.gradle
+++ b/build-logic/settings.gradle
@@ -1,7 +1,1 @@
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs", { from(files("../gradle/libs.versions.toml")) })
-    }
-}
-
 rootProject.name = 'build-logic'

--- a/build-logic/src/main/groovy/nva.nvi.java-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.nvi.java-conventions.gradle
@@ -8,14 +8,6 @@ plugins {
 
 group = 'com.github.bibsysdev'
 
-dependencies {
-    testImplementation libs.bundles.testing
-
-    // Add ErrorProne for static analysis during compilation
-    annotationProcessor libs.errorprone
-    testAnnotationProcessor libs.errorprone
-}
-
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(21)

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,17 @@
 plugins {
     id 'nva.nvi.root-module-conventions'
+    alias(nvaCatalog.plugins.errorprone)
+    alias(nvaCatalog.plugins.gradle.versions)
+    alias(nvaCatalog.plugins.spotless)
+}
+
+allprojects {
+    plugins.withId('java') {
+        plugins.withId('net.ltgt.errorprone') {
+            dependencies {
+                annotationProcessor nvaCatalog.errorprone
+                testAnnotationProcessor nvaCatalog.errorprone
+            }
+        }
+    }
 }

--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -23,7 +23,6 @@ dependencies {
     implementation nvaCatalog.jackson.databind
     implementation nvaLibs.auth
     implementation nvaLibs.core
-    implementation nvaLibs.core
     implementation nvaLibs.eventhandlers
     implementation nvaLibs.json
     implementation nvaLibs.s3

--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -21,13 +21,13 @@ dependencies {
     implementation libs.bundles.jena
     implementation libs.com.auth0.jwt
     implementation libs.jackson.csv
-    implementation libs.nva.commons.auth
-    implementation libs.nva.commons.core
-    implementation libs.nva.commons.secrets
-    implementation libs.nva.core
-    implementation libs.nva.eventhandlers
-    implementation libs.nva.json
-    implementation libs.nva.s3
+    implementation nvaLibs.auth
+    implementation nvaLibs.core
+    implementation nvaLibs.secrets
+    implementation nvaLibs.core
+    implementation nvaLibs.eventhandlers
+    implementation nvaLibs.json
+    implementation nvaLibs.s3
     implementation project(':nvi-commons')
 
     testFixturesAnnotationProcessor libs.errorprone
@@ -38,8 +38,8 @@ dependencies {
     testFixturesImplementation libs.bundles.cucumber
     testFixturesImplementation libs.bundles.testing
     testFixturesImplementation libs.com.auth0.jwt
-    testFixturesImplementation libs.nva.commons.core
-    testFixturesImplementation libs.nva.testutils
+    testFixturesImplementation nvaLibs.core
+    testFixturesImplementation nvaLibs.testutils
     testFixturesImplementation project(':nvi-test')
     testFixturesImplementation(testFixtures(project(":nvi-commons")))
 
@@ -48,7 +48,8 @@ dependencies {
     testImplementation libs.bundles.cucumber
     testImplementation libs.bundles.testing
     testImplementation libs.dynamodDbLocal
-    testImplementation libs.nva.testutils
+    testImplementation nvaLibs.logutils
+    testImplementation nvaLibs.testutils
     testImplementation project(':nvi-test')
     testImplementation(testFixtures(project(":nvi-commons")))
 }

--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -4,6 +4,9 @@ plugins {
 }
 
 dependencies {
+    implementation libs.aws.sdk2.sns
+    implementation libs.aws.sdk2.sqs
+    implementation libs.jackson.csv
     implementation nvaCatalog.aws.java.sdk.core
     implementation nvaCatalog.aws.lambda.core
     implementation nvaCatalog.aws.lambda.events
@@ -13,41 +16,39 @@ dependencies {
     implementation nvaCatalog.aws.sdk2.s3
     implementation nvaCatalog.aws.sdk2.secrets
     implementation nvaCatalog.aws.sdk2.urlconnection
+    implementation nvaCatalog.bundles.jena
     implementation nvaCatalog.bundles.logging
+    implementation nvaCatalog.com.auth0.jwt
     implementation nvaCatalog.jackson.core
     implementation nvaCatalog.jackson.databind
-    implementation libs.aws.sdk2.sns
-    implementation libs.aws.sdk2.sqs
-    implementation libs.bundles.jena
-    implementation libs.com.auth0.jwt
-    implementation libs.jackson.csv
     implementation nvaLibs.auth
     implementation nvaLibs.core
-    implementation nvaLibs.secrets
     implementation nvaLibs.core
     implementation nvaLibs.eventhandlers
     implementation nvaLibs.json
     implementation nvaLibs.s3
+    implementation nvaLibs.secrets
     implementation project(':nvi-commons')
-
-    testFixturesAnnotationProcessor libs.errorprone
+    testFixturesAnnotationProcessor nvaCatalog.errorprone
+    testFixturesImplementation libs.aws.sdk2.sns
     testFixturesImplementation nvaCatalog.aws.lambda.core
     testFixturesImplementation nvaCatalog.aws.lambda.events
+    testFixturesImplementation nvaCatalog.bundles.testing.cucumber
+    testFixturesImplementation nvaCatalog.bundles.testing.junit
+    testFixturesImplementation nvaCatalog.com.auth0.jwt
     testFixturesImplementation nvaCatalog.hamcrest
-    testFixturesImplementation libs.aws.sdk2.sns
-    testFixturesImplementation libs.bundles.cucumber
-    testFixturesImplementation libs.bundles.testing
-    testFixturesImplementation libs.com.auth0.jwt
+    testFixturesImplementation nvaCatalog.mockito.core
     testFixturesImplementation nvaLibs.core
     testFixturesImplementation nvaLibs.testutils
     testFixturesImplementation project(':nvi-test')
     testFixturesImplementation(testFixtures(project(":nvi-commons")))
-
+    testImplementation libs.dynamodDbLocal
+    testImplementation nvaCatalog.assertj.core
+    testImplementation nvaCatalog.bundles.testing.cucumber
+    testImplementation nvaCatalog.bundles.testing.junit
     testImplementation nvaCatalog.hamcrest
     testImplementation nvaCatalog.jackson.datatype.jsr310
-    testImplementation libs.bundles.cucumber
-    testImplementation libs.bundles.testing
-    testImplementation libs.dynamodDbLocal
+    testImplementation nvaCatalog.mockito.core
     testImplementation nvaLibs.logutils
     testImplementation nvaLibs.testutils
     testImplementation project(':nvi-test')

--- a/event-handlers/build.gradle
+++ b/event-handlers/build.gradle
@@ -4,18 +4,18 @@ plugins {
 }
 
 dependencies {
-    implementation commons.aws.java.sdk.core
-    implementation commons.aws.lambda.core
-    implementation commons.aws.lambda.events
-    implementation commons.aws.sdk2.core
-    implementation commons.aws.sdk2.dynamo
-    implementation commons.aws.sdk2.eventbridge
-    implementation commons.aws.sdk2.s3
-    implementation commons.aws.sdk2.secrets
-    implementation commons.aws.sdk2.urlconnection
-    implementation commons.bundles.logging
-    implementation commons.jackson.core
-    implementation commons.jackson.databind
+    implementation nvaCatalog.aws.java.sdk.core
+    implementation nvaCatalog.aws.lambda.core
+    implementation nvaCatalog.aws.lambda.events
+    implementation nvaCatalog.aws.sdk2.core
+    implementation nvaCatalog.aws.sdk2.dynamo
+    implementation nvaCatalog.aws.sdk2.eventbridge
+    implementation nvaCatalog.aws.sdk2.s3
+    implementation nvaCatalog.aws.sdk2.secrets
+    implementation nvaCatalog.aws.sdk2.urlconnection
+    implementation nvaCatalog.bundles.logging
+    implementation nvaCatalog.jackson.core
+    implementation nvaCatalog.jackson.databind
     implementation libs.aws.sdk2.sns
     implementation libs.aws.sdk2.sqs
     implementation libs.bundles.jena
@@ -31,9 +31,9 @@ dependencies {
     implementation project(':nvi-commons')
 
     testFixturesAnnotationProcessor libs.errorprone
-    testFixturesImplementation commons.aws.lambda.core
-    testFixturesImplementation commons.aws.lambda.events
-    testFixturesImplementation commons.hamcrest
+    testFixturesImplementation nvaCatalog.aws.lambda.core
+    testFixturesImplementation nvaCatalog.aws.lambda.events
+    testFixturesImplementation nvaCatalog.hamcrest
     testFixturesImplementation libs.aws.sdk2.sns
     testFixturesImplementation libs.bundles.cucumber
     testFixturesImplementation libs.bundles.testing
@@ -43,9 +43,10 @@ dependencies {
     testFixturesImplementation project(':nvi-test')
     testFixturesImplementation(testFixtures(project(":nvi-commons")))
 
-    testImplementation commons.hamcrest
-    testImplementation commons.jackson.datatype.jsr310
+    testImplementation nvaCatalog.hamcrest
+    testImplementation nvaCatalog.jackson.datatype.jsr310
     testImplementation libs.bundles.cucumber
+    testImplementation libs.bundles.testing
     testImplementation libs.dynamodDbLocal
     testImplementation libs.nva.testutils
     testImplementation project(':nvi-test')

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,6 @@ org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.console=verbose
 org.gradle.warning.mode=all
+
+# Version of `nva-commons` used for version catalog and dependencies
+nvaCommonsVersion=2.3.5

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 apache-poi = { strictly = '5.4.1' }
 assertj = { strictly = '3.27.3' }
-awsSdk2 = { strictly = '2.31.77' }
+awsSdk2 = { strictly = '2.31.78' }
 com-auth0-jwt = { strictly = '4.5.0' }
 cucumber = { strictly = '7.23.0' }
 dynamoDbLocal = { strictly = '2.6.1' }
@@ -12,7 +12,7 @@ jena = { strictly = '5.4.0' }
 junit = { strictly = '5.13.3' }
 junitPlatform = { strictly = '1.13.3' } # May need to sync minor&patch version with 'junit' version
 mockito = { strictly = '5.18.0' }
-nva = { strictly = '2.3.1' }
+nva = { strictly = '2.3.5' }
 nvaLanguage = { strictly = '1.2.1' }
 openCsv = { strictly = '5.11.2' }
 openSearchJava = { strictly = '3.1.0' }
@@ -51,7 +51,7 @@ mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mo
 nva-commons-apigateway = { group = 'com.github.bibsysdev', name = 'apigateway', version.ref = 'nva' }
 nva-commons-auth = { group = 'com.github.bibsysdev', name = 'auth', version.ref = 'nva' }
 nva-commons-clients = { group = 'com.github.bibsysdev', name = 'clients', version.ref = 'nva' }
-nva-commons-core = { group = 'com.github.bibsysdev', name = 'core', version.ref = 'nva' }
+nva-commons-core = { group = 'com.github.bibsysdev', name = 'core', version.ref = 'nva' } # FIXME: Duplicate
 nva-commons-pagination = { group = 'com.github.bibsysdev', name = 'pagination', version.ref = 'nva' }
 nva-commons-secrets = { group = 'com.github.bibsysdev', name = 'secrets', version.ref = 'nva' }
 nva-core = { group = 'com.github.bibsysdev', name = 'core', version.ref = 'nva' }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,65 +1,16 @@
 [versions]
-apache-poi = { strictly = '5.4.1' }
-assertj = { strictly = '3.27.3' }
 awsSdk2 = { strictly = '2.31.78' }
-com-auth0-jwt = { strictly = '4.5.0' }
-cucumber = { strictly = '7.23.0' }
 dynamoDbLocal = { strictly = '2.6.1' }
-errorprone = { strictly = '2.39.0' }
-errorpronePlugin = { strictly = '4.3.0' }
 jackson = { strictly = '2.19.1' }
-jena = { strictly = '5.4.0' }
-junit = { strictly = '5.13.3' }
 junitPlatform = { strictly = '1.13.3' } # May need to sync minor&patch version with 'junit' version
-mockito = { strictly = '5.18.0' }
 nvaLanguage = { strictly = '1.2.1' }
-openCsv = { strictly = '5.11.2' }
-openSearchJava = { strictly = '3.1.0' }
-openSearchRestClient = { strictly = '3.1.0' }
-openSearchTestContainer = { strictly = '3.0.1' }
-spotless = { strictly = '7.1.0' }
-testContainers = { strictly = '1.21.3' }
-versions = { strictly = '0.52.0' }
 
 [libraries]
-apache-poi = { group = 'org.apache.poi', name = 'poi', version.ref = 'apache-poi' }
-apache-poi-ooxml = { group = 'org.apache.poi', name = 'poi-ooxml', version.ref = 'apache-poi' }
-assertj-core = { group = 'org.assertj', name = 'assertj-core', version.ref = 'assertj' }
 aws-sdk2-dynamodbenhanced = { group = 'software.amazon.awssdk', name = 'dynamodb-enhanced', version.ref = 'awsSdk2' }
 aws-sdk2-regions = { group = 'software.amazon.awssdk', name = 'regions', version.ref = 'awsSdk2' }
 aws-sdk2-sns = { group = 'software.amazon.awssdk', name = 'sns', version.ref = 'awsSdk2' }
 aws-sdk2-sqs = { group = 'software.amazon.awssdk', name = 'sqs', version.ref = 'awsSdk2' }
-com-auth0-jwt = { group = 'com.auth0', name = 'java-jwt', version.ref = 'com-auth0-jwt' }
-cucumber-java = { group = 'io.cucumber', name = 'cucumber-java', version.ref = 'cucumber' }
-cucumber-junit-platform-engine = { group = 'io.cucumber', name = 'cucumber-junit-platform-engine', version.ref = 'cucumber' }
-cucumber-picocontainer = { group = 'io.cucumber', name = 'cucumber-picocontainer', version.ref = 'cucumber' }
 dynamodDbLocal = { group = 'com.amazonaws', name = 'DynamoDBLocal', version.ref = 'dynamoDbLocal' }
-errorprone = { group = 'com.google.errorprone', name = 'error_prone_core', version.ref = 'errorprone' }
-errorprone-plugin = { group = 'net.ltgt.errorprone', name = 'net.ltgt.errorprone.gradle.plugin', version.ref = 'errorpronePlugin' }
-gradle-versions-plugin = { group = 'com.github.ben-manes', name = 'gradle-versions-plugin', version.ref = 'versions' }
 jackson-csv = { group = 'com.fasterxml.jackson.dataformat', name = 'jackson-dataformat-csv', version.ref = 'jackson' }
-jackson-jr-annotations = { group = 'com.fasterxml.jackson.jr', name = 'jackson-jr-annotation-support', version.ref = 'jackson' }
-jackson-jr-objects = { group = 'com.fasterxml.jackson.jr', name = 'jackson-jr-objects', version.ref = 'jackson' }
-jena-arq = { group = 'org.apache.jena', name = 'jena-arq', version.ref = 'jena' }
-jena-core = { group = 'org.apache.jena', name = 'jena-core', version.ref = 'jena' }
-junit-jupiter-api = { group = 'org.junit.jupiter', name = 'junit-jupiter-api', version.ref = 'junit' }
-junit-jupiter-engine = { group = 'org.junit.jupiter', name = 'junit-jupiter-engine', version.ref = 'junit' }
-junit-jupiter-params = { group = 'org.junit.jupiter', name = 'junit-jupiter-params', version.ref = 'junit' }
 junit-platform-suite = { group = 'org.junit.platform', name = 'junit-platform-suite', version.ref = 'junitPlatform' }
-mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mockito' }
 nva-language = { group = 'com.github.bibsysdev', name = 'nva-language', version.ref = 'nvaLanguage' }
-openCsv = { group = 'com.opencsv', name = 'opencsv', version.ref = 'openCsv' }
-opensearch-java = { group = 'org.opensearch.client', name = 'opensearch-java', version.ref = 'openSearchJava' }
-opensearch-rest-client = { group = 'org.opensearch.client', name = 'opensearch-rest-client', version.ref = 'openSearchRestClient' }
-spotless = { group = 'com.diffplug.spotless', name = 'spotless-plugin-gradle', version.ref = 'spotless' }
-testContainers = { group = 'org.testcontainers', name = 'testcontainers', version.ref = 'testContainers' }
-testContainersJunit = { group = 'org.testcontainers', name = 'junit-jupiter', version.ref = 'testContainers' }
-testContainersOpenSearch = { group = 'org.opensearch', name = 'opensearch-testcontainers', version.ref = 'openSearchTestContainer' }
-
-[bundles]
-apachePoi = ['apache-poi', 'apache-poi-ooxml']
-jacksonjr = ['jackson-jr-objects', 'jackson-jr-annotations']
-jena = ['jena-core', 'jena-arq']
-testContainers = ['testContainers', 'testContainersJunit', 'testContainersOpenSearch']
-testing = ['assertj-core', 'junit-jupiter-api', 'junit-jupiter-params', 'junit-jupiter-engine', 'junit-platform-suite', 'mockito-core']
-cucumber = ['cucumber-java', 'cucumber-junit-platform-engine', 'cucumber-picocontainer']

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,7 +12,6 @@ jena = { strictly = '5.4.0' }
 junit = { strictly = '5.13.3' }
 junitPlatform = { strictly = '1.13.3' } # May need to sync minor&patch version with 'junit' version
 mockito = { strictly = '5.18.0' }
-nva = { strictly = '2.3.5' }
 nvaLanguage = { strictly = '1.2.1' }
 openCsv = { strictly = '5.11.2' }
 openSearchJava = { strictly = '3.1.0' }
@@ -48,20 +47,7 @@ junit-jupiter-engine = { group = 'org.junit.jupiter', name = 'junit-jupiter-engi
 junit-jupiter-params = { group = 'org.junit.jupiter', name = 'junit-jupiter-params', version.ref = 'junit' }
 junit-platform-suite = { group = 'org.junit.platform', name = 'junit-platform-suite', version.ref = 'junitPlatform' }
 mockito-core = { group = 'org.mockito', name = 'mockito-core', version.ref = 'mockito' }
-nva-commons-apigateway = { group = 'com.github.bibsysdev', name = 'apigateway', version.ref = 'nva' }
-nva-commons-auth = { group = 'com.github.bibsysdev', name = 'auth', version.ref = 'nva' }
-nva-commons-clients = { group = 'com.github.bibsysdev', name = 'clients', version.ref = 'nva' }
-nva-commons-core = { group = 'com.github.bibsysdev', name = 'core', version.ref = 'nva' } # FIXME: Duplicate
-nva-commons-pagination = { group = 'com.github.bibsysdev', name = 'pagination', version.ref = 'nva' }
-nva-commons-secrets = { group = 'com.github.bibsysdev', name = 'secrets', version.ref = 'nva' }
-nva-core = { group = 'com.github.bibsysdev', name = 'core', version.ref = 'nva' }
-nva-eventhandlers = { group = 'com.github.bibsysdev', name = 'eventhandlers', version.ref = 'nva' }
-nva-identifiers = { group = 'com.github.bibsysdev', name = 'identifiers', version.ref = 'nva' }
-nva-json = { group = 'com.github.bibsysdev', name = 'json', version.ref = 'nva' }
 nva-language = { group = 'com.github.bibsysdev', name = 'nva-language', version.ref = 'nvaLanguage' }
-nva-logutils = { group = 'com.github.bibsysdev', name = 'logutils', version.ref = 'nva' }
-nva-s3 = { group = 'com.github.bibsysdev', name = 's3', version.ref = 'nva' }
-nva-testutils = { group = 'com.github.bibsysdev', name = 'nvatestutils', version.ref = 'nva' }
 openCsv = { group = 'com.opencsv', name = 'opencsv', version.ref = 'openCsv' }
 opensearch-java = { group = 'org.opensearch.client', name = 'opensearch-java', version.ref = 'openSearchJava' }
 opensearch-rest-client = { group = 'org.opensearch.client', name = 'opensearch-rest-client', version.ref = 'openSearchRestClient' }
@@ -75,5 +61,5 @@ apachePoi = ['apache-poi', 'apache-poi-ooxml']
 jacksonjr = ['jackson-jr-objects', 'jackson-jr-annotations']
 jena = ['jena-core', 'jena-arq']
 testContainers = ['testContainers', 'testContainersJunit', 'testContainersOpenSearch']
-testing = ['assertj-core', 'junit-jupiter-api', 'junit-jupiter-params', 'junit-jupiter-engine', 'junit-platform-suite', 'mockito-core', 'nva-testutils', 'nva-logutils']
+testing = ['assertj-core', 'junit-jupiter-api', 'junit-jupiter-params', 'junit-jupiter-engine', 'junit-platform-suite', 'mockito-core']
 cucumber = ['cucumber-java', 'cucumber-junit-platform-engine', 'cucumber-picocontainer']

--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -2,45 +2,46 @@ plugins {
     id 'nva.nvi.java-conventions'
 }
 dependencies {
+    implementation libs.aws.sdk2.regions
+    implementation libs.aws.sdk2.sqs
+    implementation libs.nva.language
     implementation nvaCatalog.aws.apache.client
     implementation nvaCatalog.aws.java.sdk.core
     implementation nvaCatalog.aws.lambda.core
     implementation nvaCatalog.aws.lambda.events
     implementation nvaCatalog.aws.sdk2.dynamo
     implementation nvaCatalog.aws.sdk2.s3
+    implementation nvaCatalog.bundles.apache.poi
+    implementation nvaCatalog.bundles.jacksonjr
     implementation nvaCatalog.bundles.logging
+    implementation nvaCatalog.com.auth0.jwt
     implementation nvaCatalog.guava
     implementation nvaCatalog.jackson.core
     implementation nvaCatalog.jackson.databind
-    implementation libs.aws.sdk2.regions
-    implementation libs.aws.sdk2.sqs
-    implementation libs.bundles.apachePoi
-    implementation libs.bundles.jacksonjr
-    implementation libs.com.auth0.jwt
-    implementation libs.jena.core
+    implementation nvaCatalog.jena.core
+    implementation nvaCatalog.opensearch.java
+    implementation nvaCatalog.opensearch.rest.client
     implementation nvaLibs.apigateway
     implementation nvaLibs.auth
     implementation nvaLibs.clients
-    implementation nvaLibs.pagination
-    implementation nvaLibs.secrets
     implementation nvaLibs.core
     implementation nvaLibs.json
-    implementation libs.nva.language
+    implementation nvaLibs.pagination
     implementation nvaLibs.s3
-    implementation libs.opensearch.java
-    implementation libs.opensearch.rest.client
+    implementation nvaLibs.secrets
     implementation project(':nvi-commons')
-
+    testImplementation libs.dynamodDbLocal
+    testImplementation nvaCatalog.assertj.core
+    testImplementation nvaCatalog.bundles.testing.cucumber
+    testImplementation nvaCatalog.bundles.testing.junit
+    testImplementation nvaCatalog.bundles.testing.testcontainers
     testImplementation nvaCatalog.hamcrest
+    testImplementation nvaCatalog.mockito.core
+    testImplementation nvaCatalog.opencsv
     testImplementation nvaCatalog.zalando
-    testImplementation libs.bundles.cucumber
-    testImplementation libs.bundles.testContainers
-    testImplementation libs.bundles.testing
+    testImplementation nvaLibs.identifiers
     testImplementation nvaLibs.logutils
     testImplementation nvaLibs.testutils
-    testImplementation libs.dynamodDbLocal
-    testImplementation nvaLibs.identifiers
-    testImplementation libs.openCsv
     testImplementation project(':nvi-test')
     testImplementation(testFixtures(project(":nvi-commons")))
 }

--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -18,15 +18,15 @@ dependencies {
     implementation libs.bundles.jacksonjr
     implementation libs.com.auth0.jwt
     implementation libs.jena.core
-    implementation libs.nva.commons.apigateway
-    implementation libs.nva.commons.auth
-    implementation libs.nva.commons.clients
-    implementation libs.nva.commons.pagination
-    implementation libs.nva.commons.secrets
-    implementation libs.nva.core
-    implementation libs.nva.json
+    implementation nvaLibs.apigateway
+    implementation nvaLibs.auth
+    implementation nvaLibs.clients
+    implementation nvaLibs.pagination
+    implementation nvaLibs.secrets
+    implementation nvaLibs.core
+    implementation nvaLibs.json
     implementation libs.nva.language
-    implementation libs.nva.s3
+    implementation nvaLibs.s3
     implementation libs.opensearch.java
     implementation libs.opensearch.rest.client
     implementation project(':nvi-commons')
@@ -36,8 +36,10 @@ dependencies {
     testImplementation libs.bundles.cucumber
     testImplementation libs.bundles.testContainers
     testImplementation libs.bundles.testing
+    testImplementation nvaLibs.logutils
+    testImplementation nvaLibs.testutils
     testImplementation libs.dynamodDbLocal
-    testImplementation libs.nva.identifiers
+    testImplementation nvaLibs.identifiers
     testImplementation libs.openCsv
     testImplementation project(':nvi-test')
     testImplementation(testFixtures(project(":nvi-commons")))

--- a/index-handlers/build.gradle
+++ b/index-handlers/build.gradle
@@ -2,16 +2,16 @@ plugins {
     id 'nva.nvi.java-conventions'
 }
 dependencies {
-    implementation commons.aws.apache.client
-    implementation commons.aws.java.sdk.core
-    implementation commons.aws.lambda.core
-    implementation commons.aws.lambda.events
-    implementation commons.aws.sdk2.dynamo
-    implementation commons.aws.sdk2.s3
-    implementation commons.bundles.logging
-    implementation commons.guava
-    implementation commons.jackson.core
-    implementation commons.jackson.databind
+    implementation nvaCatalog.aws.apache.client
+    implementation nvaCatalog.aws.java.sdk.core
+    implementation nvaCatalog.aws.lambda.core
+    implementation nvaCatalog.aws.lambda.events
+    implementation nvaCatalog.aws.sdk2.dynamo
+    implementation nvaCatalog.aws.sdk2.s3
+    implementation nvaCatalog.bundles.logging
+    implementation nvaCatalog.guava
+    implementation nvaCatalog.jackson.core
+    implementation nvaCatalog.jackson.databind
     implementation libs.aws.sdk2.regions
     implementation libs.aws.sdk2.sqs
     implementation libs.bundles.apachePoi
@@ -31,10 +31,11 @@ dependencies {
     implementation libs.opensearch.rest.client
     implementation project(':nvi-commons')
 
-    testImplementation commons.hamcrest
-    testImplementation commons.zalando
+    testImplementation nvaCatalog.hamcrest
+    testImplementation nvaCatalog.zalando
     testImplementation libs.bundles.cucumber
     testImplementation libs.bundles.testContainers
+    testImplementation libs.bundles.testing
     testImplementation libs.dynamodDbLocal
     testImplementation libs.nva.identifiers
     testImplementation libs.openCsv

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -3,23 +3,25 @@ plugins {
 }
 
 dependencies {
+    testImplementation libs.aws.sdk2.sns
+    testImplementation libs.aws.sdk2.sqs
+    testImplementation libs.junit.platform.suite
+    testImplementation nvaCatalog.assertj.core
     testImplementation nvaCatalog.aws.java.sdk.core
     testImplementation nvaCatalog.aws.lambda.core
     testImplementation nvaCatalog.aws.lambda.events
     testImplementation nvaCatalog.aws.sdk2.core
     testImplementation nvaCatalog.aws.sdk2.dynamo
     testImplementation nvaCatalog.aws.sdk2.s3
-    testImplementation libs.aws.sdk2.sns
-    testImplementation libs.aws.sdk2.sqs
-    testImplementation libs.bundles.cucumber
-    testImplementation libs.bundles.testing
-    testImplementation libs.com.auth0.jwt
+    testImplementation nvaCatalog.bundles.testing.cucumber
+    testImplementation nvaCatalog.bundles.testing.junit
+    testImplementation nvaCatalog.com.auth0.jwt
+    testImplementation nvaCatalog.mockito.core
     testImplementation nvaLibs.auth
     testImplementation nvaLibs.core
     testImplementation nvaLibs.json
     testImplementation nvaLibs.s3
     testImplementation nvaLibs.testutils
-
     testImplementation project(":event-handlers")
     testImplementation project(":index-handlers")
     testImplementation project(":nvi-commons")

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -14,11 +14,11 @@ dependencies {
     testImplementation libs.bundles.cucumber
     testImplementation libs.bundles.testing
     testImplementation libs.com.auth0.jwt
-    testImplementation libs.nva.commons.auth
-    testImplementation libs.nva.commons.core
-    testImplementation libs.nva.json
-    testImplementation libs.nva.s3
-    testImplementation libs.nva.testutils
+    testImplementation nvaLibs.auth
+    testImplementation nvaLibs.core
+    testImplementation nvaLibs.json
+    testImplementation nvaLibs.s3
+    testImplementation nvaLibs.testutils
 
     testImplementation project(":event-handlers")
     testImplementation project(":index-handlers")

--- a/integration-tests/build.gradle
+++ b/integration-tests/build.gradle
@@ -3,15 +3,16 @@ plugins {
 }
 
 dependencies {
-    testImplementation commons.aws.java.sdk.core
-    testImplementation commons.aws.lambda.core
-    testImplementation commons.aws.lambda.events
-    testImplementation commons.aws.sdk2.core
-    testImplementation commons.aws.sdk2.dynamo
-    testImplementation commons.aws.sdk2.s3
+    testImplementation nvaCatalog.aws.java.sdk.core
+    testImplementation nvaCatalog.aws.lambda.core
+    testImplementation nvaCatalog.aws.lambda.events
+    testImplementation nvaCatalog.aws.sdk2.core
+    testImplementation nvaCatalog.aws.sdk2.dynamo
+    testImplementation nvaCatalog.aws.sdk2.s3
     testImplementation libs.aws.sdk2.sns
     testImplementation libs.aws.sdk2.sqs
     testImplementation libs.bundles.cucumber
+    testImplementation libs.bundles.testing
     testImplementation libs.com.auth0.jwt
     testImplementation libs.nva.commons.auth
     testImplementation libs.nva.commons.core

--- a/nvi-commons/build.gradle
+++ b/nvi-commons/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 dependencies {
-    implementation commons.aws.apache.client
-    implementation commons.aws.lambda.events
-    implementation commons.aws.sdk2.dynamo
-    implementation commons.aws.sdk2.s3
-    implementation commons.aws.sdk2.urlconnection
-    implementation commons.jackson.databind
+    implementation nvaCatalog.aws.apache.client
+    implementation nvaCatalog.aws.lambda.events
+    implementation nvaCatalog.aws.sdk2.dynamo
+    implementation nvaCatalog.aws.sdk2.s3
+    implementation nvaCatalog.aws.sdk2.urlconnection
+    implementation nvaCatalog.jackson.databind
     implementation libs.aws.sdk2.dynamodbenhanced
     implementation libs.aws.sdk2.sns
     implementation libs.aws.sdk2.sqs
@@ -24,9 +24,9 @@ dependencies {
     implementation libs.nva.s3
 
     testFixturesAnnotationProcessor libs.errorprone
-    testFixturesImplementation commons.aws.lambda.events
-    testFixturesImplementation commons.aws.sdk2.s3
-    testFixturesImplementation commons.hamcrest
+    testFixturesImplementation nvaCatalog.aws.lambda.events
+    testFixturesImplementation nvaCatalog.aws.sdk2.s3
+    testFixturesImplementation nvaCatalog.hamcrest
     testFixturesImplementation libs.aws.sdk2.sqs
     testFixturesImplementation libs.bundles.cucumber
     testFixturesImplementation libs.bundles.testing
@@ -38,8 +38,9 @@ dependencies {
     testFixturesImplementation libs.nva.s3
     testFixturesImplementation project(':nvi-test')
 
-    testImplementation commons.hamcrest
+    testImplementation nvaCatalog.hamcrest
     testImplementation libs.bundles.cucumber
+    testImplementation libs.bundles.testing
     testImplementation libs.dynamodDbLocal
     testImplementation project(':nvi-test')
 }

--- a/nvi-commons/build.gradle
+++ b/nvi-commons/build.gradle
@@ -5,16 +5,16 @@ plugins {
 }
 
 dependencies {
+    implementation libs.aws.sdk2.dynamodbenhanced
+    implementation libs.aws.sdk2.sns
+    implementation libs.aws.sdk2.sqs
     implementation nvaCatalog.aws.apache.client
     implementation nvaCatalog.aws.lambda.events
     implementation nvaCatalog.aws.sdk2.dynamo
     implementation nvaCatalog.aws.sdk2.s3
     implementation nvaCatalog.aws.sdk2.urlconnection
+    implementation nvaCatalog.bundles.jena
     implementation nvaCatalog.jackson.databind
-    implementation libs.aws.sdk2.dynamodbenhanced
-    implementation libs.aws.sdk2.sns
-    implementation libs.aws.sdk2.sqs
-    implementation libs.bundles.jena
     implementation nvaLibs.apigateway
     implementation nvaLibs.auth
     implementation nvaLibs.clients
@@ -22,15 +22,15 @@ dependencies {
     implementation nvaLibs.identifiers
     implementation nvaLibs.json
     implementation nvaLibs.s3
-
-    testFixturesAnnotationProcessor libs.errorprone
+    testFixturesAnnotationProcessor nvaCatalog.errorprone
+    testFixturesImplementation libs.aws.sdk2.sqs
+    testFixturesImplementation libs.dynamodDbLocal
     testFixturesImplementation nvaCatalog.aws.lambda.events
     testFixturesImplementation nvaCatalog.aws.sdk2.s3
+    testFixturesImplementation nvaCatalog.bundles.testing.cucumber
+    testFixturesImplementation nvaCatalog.bundles.testing.junit
     testFixturesImplementation nvaCatalog.hamcrest
-    testFixturesImplementation libs.aws.sdk2.sqs
-    testFixturesImplementation libs.bundles.cucumber
-    testFixturesImplementation libs.bundles.testing
-    testFixturesImplementation libs.dynamodDbLocal
+    testFixturesImplementation nvaCatalog.mockito.core
     testFixturesImplementation nvaLibs.apigateway
     testFixturesImplementation nvaLibs.auth
     testFixturesImplementation nvaLibs.core
@@ -38,13 +38,15 @@ dependencies {
     testFixturesImplementation nvaLibs.s3
     testFixturesImplementation nvaLibs.testutils
     testFixturesImplementation project(':nvi-test')
-
+    testImplementation libs.dynamodDbLocal
+    testImplementation libs.junit.platform.suite
+    testImplementation nvaCatalog.assertj.core
+    testImplementation nvaCatalog.bundles.testing.cucumber
+    testImplementation nvaCatalog.bundles.testing.junit
     testImplementation nvaCatalog.hamcrest
+    testImplementation nvaCatalog.mockito.core
     testImplementation nvaLibs.logutils
     testImplementation nvaLibs.testutils
-    testImplementation libs.bundles.cucumber
-    testImplementation libs.bundles.testing
-    testImplementation libs.dynamodDbLocal
     testImplementation project(':nvi-test')
 }
 

--- a/nvi-commons/build.gradle
+++ b/nvi-commons/build.gradle
@@ -15,13 +15,13 @@ dependencies {
     implementation libs.aws.sdk2.sns
     implementation libs.aws.sdk2.sqs
     implementation libs.bundles.jena
-    implementation libs.nva.commons.apigateway
-    implementation libs.nva.commons.auth
-    implementation libs.nva.commons.clients
-    implementation libs.nva.core
-    implementation libs.nva.identifiers
-    implementation libs.nva.json
-    implementation libs.nva.s3
+    implementation nvaLibs.apigateway
+    implementation nvaLibs.auth
+    implementation nvaLibs.clients
+    implementation nvaLibs.core
+    implementation nvaLibs.identifiers
+    implementation nvaLibs.json
+    implementation nvaLibs.s3
 
     testFixturesAnnotationProcessor libs.errorprone
     testFixturesImplementation nvaCatalog.aws.lambda.events
@@ -31,14 +31,17 @@ dependencies {
     testFixturesImplementation libs.bundles.cucumber
     testFixturesImplementation libs.bundles.testing
     testFixturesImplementation libs.dynamodDbLocal
-    testFixturesImplementation libs.nva.commons.apigateway
-    testFixturesImplementation libs.nva.commons.auth
-    testFixturesImplementation libs.nva.core
-    testFixturesImplementation libs.nva.json
-    testFixturesImplementation libs.nva.s3
+    testFixturesImplementation nvaLibs.apigateway
+    testFixturesImplementation nvaLibs.auth
+    testFixturesImplementation nvaLibs.core
+    testFixturesImplementation nvaLibs.json
+    testFixturesImplementation nvaLibs.s3
+    testFixturesImplementation nvaLibs.testutils
     testFixturesImplementation project(':nvi-test')
 
     testImplementation nvaCatalog.hamcrest
+    testImplementation nvaLibs.logutils
+    testImplementation nvaLibs.testutils
     testImplementation libs.bundles.cucumber
     testImplementation libs.bundles.testing
     testImplementation libs.dynamodDbLocal

--- a/nvi-rest/build.gradle
+++ b/nvi-rest/build.gradle
@@ -2,10 +2,10 @@ plugins {
     id 'nva.nvi.java-conventions'
 }
 dependencies {
-    implementation commons.aws.sdk2.dynamo
-    implementation commons.guava
-    implementation commons.httpclient5
-    implementation commons.jackson.databind
+    implementation nvaCatalog.aws.sdk2.dynamo
+    implementation nvaCatalog.guava
+    implementation nvaCatalog.httpclient5
+    implementation nvaCatalog.jackson.databind
     implementation libs.aws.sdk2.dynamodbenhanced
     implementation libs.nva.commons.apigateway
     implementation libs.nva.commons.auth
@@ -14,8 +14,8 @@ dependencies {
     implementation libs.nva.json
     implementation project(':nvi-commons')
 
-    testImplementation commons.hamcrest
-    testImplementation commons.zalando
+    testImplementation nvaCatalog.hamcrest
+    testImplementation nvaCatalog.zalando
     testImplementation libs.bundles.cucumber
     testImplementation libs.bundles.testing
     testImplementation libs.dynamodDbLocal

--- a/nvi-rest/build.gradle
+++ b/nvi-rest/build.gradle
@@ -7,11 +7,11 @@ dependencies {
     implementation nvaCatalog.httpclient5
     implementation nvaCatalog.jackson.databind
     implementation libs.aws.sdk2.dynamodbenhanced
-    implementation libs.nva.commons.apigateway
-    implementation libs.nva.commons.auth
-    implementation libs.nva.commons.clients
-    implementation libs.nva.commons.core
-    implementation libs.nva.json
+    implementation nvaLibs.apigateway
+    implementation nvaLibs.auth
+    implementation nvaLibs.clients
+    implementation nvaLibs.core
+    implementation nvaLibs.json
     implementation project(':nvi-commons')
 
     testImplementation nvaCatalog.hamcrest
@@ -19,7 +19,7 @@ dependencies {
     testImplementation libs.bundles.cucumber
     testImplementation libs.bundles.testing
     testImplementation libs.dynamodDbLocal
-    testImplementation libs.nva.testutils
+    testImplementation nvaLibs.testutils
     testImplementation project(':nvi-test')
     testImplementation(testFixtures(project(":nvi-commons")))
 }

--- a/nvi-rest/build.gradle
+++ b/nvi-rest/build.gradle
@@ -2,23 +2,24 @@ plugins {
     id 'nva.nvi.java-conventions'
 }
 dependencies {
+    implementation libs.aws.sdk2.dynamodbenhanced
     implementation nvaCatalog.aws.sdk2.dynamo
     implementation nvaCatalog.guava
     implementation nvaCatalog.httpclient5
     implementation nvaCatalog.jackson.databind
-    implementation libs.aws.sdk2.dynamodbenhanced
     implementation nvaLibs.apigateway
     implementation nvaLibs.auth
     implementation nvaLibs.clients
     implementation nvaLibs.core
     implementation nvaLibs.json
     implementation project(':nvi-commons')
-
-    testImplementation nvaCatalog.hamcrest
-    testImplementation nvaCatalog.zalando
-    testImplementation libs.bundles.cucumber
-    testImplementation libs.bundles.testing
     testImplementation libs.dynamodDbLocal
+    testImplementation nvaCatalog.assertj.core
+    testImplementation nvaCatalog.bundles.testing.cucumber
+    testImplementation nvaCatalog.bundles.testing.junit
+    testImplementation nvaCatalog.hamcrest
+    testImplementation nvaCatalog.mockito.core
+    testImplementation nvaCatalog.zalando
     testImplementation nvaLibs.testutils
     testImplementation project(':nvi-test')
     testImplementation(testFixtures(project(":nvi-commons")))

--- a/nvi-test/build.gradle
+++ b/nvi-test/build.gradle
@@ -5,8 +5,8 @@ plugins {
 dependencies {
     implementation nvaCatalog.jackson.databind
     implementation libs.bundles.testing
-    implementation libs.nva.commons.core
-    implementation libs.nva.testutils
+    implementation nvaLibs.core
+    implementation nvaLibs.testutils
 }
 
 test {

--- a/nvi-test/build.gradle
+++ b/nvi-test/build.gradle
@@ -3,8 +3,9 @@ plugins {
 }
 
 dependencies {
+    implementation nvaCatalog.bundles.testing.junit
     implementation nvaCatalog.jackson.databind
-    implementation libs.bundles.testing
+    implementation nvaCatalog.mockito.core
     implementation nvaLibs.core
     implementation nvaLibs.testutils
 }

--- a/nvi-test/build.gradle
+++ b/nvi-test/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation commons.jackson.databind
+    implementation nvaCatalog.jackson.databind
     implementation libs.bundles.testing
     implementation libs.nva.commons.core
     implementation libs.nva.testutils

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,8 +8,16 @@ dependencyResolutionManagement {
     }
     versionCatalogs {
         // Version catalog imported from nva-commons
-        create("commons") {
-            from("com.github.bibsysdev:versions:2.3.1")
+        create("nvaCatalog") {
+            from("com.github.bibsysdev:versions:${nvaCommonsVersion}")
+        }
+
+        // Local version catalog for libraries in nva-commons
+        // This is defined programmatically to reference the version from gradle.properties
+        create("nvaLibs") {
+            version('nva', "${nvaCommonsVersion}")
+            library("core", "com.github.bibsysdev", "core").versionRef("nva")
+            library("testutils", "com.github.bibsysdev", "nvatestutils").versionRef("nva")
         }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,17 @@ dependencyResolutionManagement {
         // This is defined programmatically to reference the version from gradle.properties
         create("nvaLibs") {
             version('nva', "${nvaCommonsVersion}")
+            library("apigateway", "com.github.bibsysdev", "apigateway").versionRef("nva")
+            library("auth", "com.github.bibsysdev", "auth").versionRef("nva")
+            library("clients", "com.github.bibsysdev", "clients").versionRef("nva")
             library("core", "com.github.bibsysdev", "core").versionRef("nva")
+            library("eventhandlers", "com.github.bibsysdev", "eventhandlers").versionRef("nva")
+            library("identifiers", "com.github.bibsysdev", "identifiers").versionRef("nva")
+            library("json", "com.github.bibsysdev", "json").versionRef("nva")
+            library("logutils", "com.github.bibsysdev", "logutils").versionRef("nva")
+            library("pagination", "com.github.bibsysdev", "pagination").versionRef("nva")
+            library("s3", "com.github.bibsysdev", "s3").versionRef("nva")
+            library("secrets", "com.github.bibsysdev", "secrets").versionRef("nva")
             library("testutils", "com.github.bibsysdev", "nvatestutils").versionRef("nva")
         }
     }


### PR DESCRIPTION
Changes:

- refactor: Move version number for `nva-commons` to `gradle.properties` in order to reference it during build
- feat: Use version catalog from `nva-commons` for most dependencies
- build: Bump `nva-commons` to `2.3.5`

Note that more of the remaining dependencies and plugins can be taken from `nva-commons` when recent changes there are published. Because of this, I'm not cleaning up the mixed casing in `libs.versions.toml` here.