### PR TITLE
Enable configuration cache

### DIFF
--- a/build-logic/src/main/groovy/nva.nvi.root-module-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.nvi.root-module-conventions.gradle
@@ -62,10 +62,10 @@ tasks.register('showCoverageReport') {
     description = "Show clickable link to test coverage report"
     dependsOn tasks.named('testCodeCoverageReport', JacocoReport)
     outputs.upToDateWhen { false }
+    def reportDirPath = "reports/jacoco/testCodeCoverageReport/html"
+    def reportDir = layout.buildDirectory.dir(reportDirPath).get().asFile
 
     doLast {
-        def reportDirPath = "reports/jacoco/testCodeCoverageReport/html"
-        def reportDir = layout.buildDirectory.dir(reportDirPath).get().asFile
         logger.quiet("Combined coverage report:")
         logger.quiet("file://${reportDir}/index.html")
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.console=verbose


### PR DESCRIPTION
Enables configuration cache
 - Necessarily moves a few lines of code to avoid calls to gradle scripting from inside closures 