### PR TITLE
build: Enable Gradle configuration cache for local development

### DIFF
--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -3,6 +3,7 @@ version: 0.2
 env:
   variables:
     GRADLE_USER_HOME: '/root/.gradle'
+    GRADLE_OPTS: "-Dorg:gradle:configuration-cache=false"
     SAM_CLI_TELEMETRY: "0"
   secrets-manager:
     DOCKER_HUB_USERNAME: DockerHubCredentials:DockerHubUsername

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -37,6 +37,7 @@ phases:
 
   build:
     commands:
+      - echo "Gradle options: '$GRADLE_OPTS'"
       - sam build
 
   post_build:

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -37,7 +37,8 @@ phases:
 
   build:
     commands:
-      - echo "Gradle options: '$GRADLE_OPTS'"
+      - echo "Testing stuff"
+      - echo "GRADLE_OPTS=$GRADLE_OPTS"
       - sam build
 
   post_build:

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -37,8 +37,6 @@ phases:
 
   build:
     commands:
-      - echo "Testing stuff"
-      - echo "GRADLE_OPTS=$GRADLE_OPTS"
       - sam build
 
   post_build:

--- a/buildspec.yaml
+++ b/buildspec.yaml
@@ -3,7 +3,7 @@ version: 0.2
 env:
   variables:
     GRADLE_USER_HOME: '/root/.gradle'
-    GRADLE_OPTS: "-Dorg:gradle:configuration-cache=false"
+    GRADLE_OPTS: "-Dorg.gradle.configuration-cache=false"
     SAM_CLI_TELEMETRY: "0"
   secrets-manager:
     DOCKER_HUB_USERNAME: DockerHubCredentials:DockerHubUsername

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,4 @@
-# Disabled because it does not work with `sam build` (should be enabled when this is fixed)
-org.gradle.configuration-cache=false
+org.gradle.configuration-cache=true
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.console=verbose

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/NviCreator.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/NviCreator.java
@@ -144,7 +144,8 @@ public record NviCreator(
       return topLevelOrganization.get();
     }
     LOGGER.error(
-        "Failed to find top-level organization for {}, which indicates incomplete organization tree in persisted data.",
+        "Failed to find top-level organization for {}, which indicates incomplete organization tree"
+            + " in persisted data.",
         affiliationId);
     return null;
   }

--- a/sam-build.sh
+++ b/sam-build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# SAM build wrapper that disables Gradle configuration cache
+export GRADLE_OPTS="-Dorg.gradle.configuration-cache=false"
+sam build "$@"

--- a/sam-build.sh
+++ b/sam-build.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-# SAM build wrapper that disables Gradle configuration cache
+# Wrapper script for running `sam build` locally
 export GRADLE_OPTS="-Dorg.gradle.configuration-cache=false"
-echo "Gradle options: '$GRADLE_OPTS'"
 sam build "$@"

--- a/sam-build.sh
+++ b/sam-build.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 # SAM build wrapper that disables Gradle configuration cache
 export GRADLE_OPTS="-Dorg.gradle.configuration-cache=false"
+echo "Gradle options: '$GRADLE_OPTS'"
 sam build "$@"


### PR DESCRIPTION
Workaround to enable Gradle configuration cache for local development, while keeping it disabled for `sam build` (which does not support it yet).

Changes:
- build: Enable Gradle configuration cache by default
- ci: Disable Gradle configuration cache for CodeBuild
- feat: Add a wrapper script for running `sam build` locally with options