### PR TITLE
fix: Link UpsertCandidateDLQ to UpsertNviCandidateHandler

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -788,6 +788,11 @@ Resources:
           Type: SQS
           Properties:
             Queue: !GetAtt EvaluatedCandidateQueue.Arn
+      EventInvokeConfig:
+        DestinationConfig:
+          OnFailure:
+            Type: SQS
+            Destination: !GetAtt UpsertCandidateDLQ.Arn
 
   DynamoDbEventToQueueHandler:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-49686

This is intended to link the DLQ to the handler, in order to make the "DLQ redrive" button (from console) automatically find the correct destination for events.