### PR TITLE
build: Set failFast=true for tests

### DIFF
--- a/build-logic/src/main/groovy/nva.nvi.java-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.nvi.java-conventions.gradle
@@ -31,7 +31,7 @@ pmd {
 
 tasks.named('test', Test) {
     useJUnitPlatform()
-    failFast = false
+    failFast = true
     testLogging {
         events = ['skipped', 'passed', 'failed']
         showCauses = true


### PR DESCRIPTION
Make Gradle stop after the first test failure so that we don't need to wait for all the slow integration tests to see what failed.