### PR TITLE
[np-51056] fix: Skip update attempt of valid candidate in closed period

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -110,6 +110,12 @@ public class EvaluatorService {
       return createNonNviCandidateMessage(publication.id());
     }
 
+    // Skip update if the period is closed and the candidate is still applicable
+    if (isApplicableCandidateInClosedPeriod(candidateAndPeriods, publication.publicationDate())) {
+      logger.info(SKIPPED_EVALUATION_MESSAGE, publication.id());
+      return Optional.empty();
+    }
+
     // Check that the publication can be a candidate in the target period
     if (!canEvaluateInPeriod(candidateAndPeriods, publication.publicationDate())) {
       logger.info("Publication is not applicable in the target period");
@@ -160,20 +166,23 @@ public class EvaluatorService {
     return nonNull(publication.status()) && "published".equalsIgnoreCase(publication.status());
   }
 
-  private boolean canEvaluateInPeriod(
+  private boolean isApplicableCandidateInClosedPeriod(
       CandidateAndPeriods candidateAndPeriods, PublicationDateDto publicationDate) {
     var optionalPeriod = candidateAndPeriods.getPeriod(publicationDate.year());
-    if (optionalPeriod.isEmpty()) {
+    if (optionalPeriod.isEmpty() || !optionalPeriod.get().isClosed()) {
       return false;
     }
     var period = optionalPeriod.get();
+    return candidateAndPeriods
+        .getCandidate()
+        .map(candidate -> isApplicableInPeriod(period, candidate))
+        .orElse(false);
+  }
 
-    var candidateExistsInPeriod =
-        candidateAndPeriods
-            .getCandidate()
-            .map(candidate -> isApplicableInPeriod(period, candidate))
-            .orElse(false);
-    return !period.isClosed() || candidateExistsInPeriod;
+  private boolean canEvaluateInPeriod(
+      CandidateAndPeriods candidateAndPeriods, PublicationDateDto publicationDate) {
+    var optionalPeriod = candidateAndPeriods.getPeriod(publicationDate.year());
+    return optionalPeriod.isPresent() && !optionalPeriod.get().isClosed();
   }
 
   private boolean isApplicableInPeriod(NviPeriod targetPeriod, Candidate candidate) {

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -33,6 +33,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -650,6 +651,23 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       assertThat(candidate.getTotalPoints()).isPositive();
       assertThat(candidate.isApplicable()).isTrue();
       assertThat(publicationDetails.publicationDate()).isEqualTo(publicationDate);
+    }
+
+    @Test
+    void shouldNotThrowErrorWhenEvaluatingExistingCandidateInClosedPeriod() {
+      setupOpenPeriod(scenario, publicationDate.year());
+      var publication = factory.withContributor(verifiedCreatorFrom(nviOrganization));
+      setupCandidateMatchingPublication(publication.getExpandedPublication());
+      setupClosedPeriod(scenario, publicationDate.year());
+      var updatedPublication = publication.withContributor(verifiedCreatorFrom(nviOrganization));
+
+      var candidateBeforeUpdate =
+          candidateService.getCandidateByPublicationId(publication.getPublicationId());
+      assertDoesNotThrow(() -> handleEvaluation(updatedPublication));
+
+      var candidateAfterUpdate =
+          candidateService.getCandidateByPublicationId(publication.getPublicationId());
+      assertThat(candidateBeforeUpdate.revision()).isEqualTo(candidateAfterUpdate.revision());
     }
 
     @Test


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51056

Skips attempting to update a candidate in a closed period if the candidate is still valid. This type of update is already prevented by separate validation in the service/domain layer and the attempts fail, sending the event to DLQ.