### PR TITLE
[np-51079] feat Add reported date

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -1329,6 +1329,15 @@ components:
               type: string
             startDate:
               type: string
+        status:
+          type: string
+          description: The report status of the candidate
+          example: "Reported"
+        reportedDate:
+          type: string
+          format: date-time
+          description: Timestamp for when the candidate was marked as reported
+          example: "2026-01-15T12:00:00Z"
         allowedOperations:
           type: array
           description: >

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinMapper.java
@@ -124,6 +124,7 @@ public final class CristinMapper {
         .pointCalculation(pointCalculation)
         .publicationDetails(publicationDetails)
         .reportStatus(ReportStatus.REPORTED)
+        .reportedDate(publicationDetails.modifiedDate())
         .applicable(true)
         .createdDate(publicationDetails.modifiedDate())
         .modifiedDate(publicationDetails.modifiedDate())

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandlerTest.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.events.batch;
 
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createNumberOfCandidatesForYear;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.getYearIndexStartMarker;
-import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.sortByIdentifier;
 import static no.sikt.nva.nvi.common.model.CandidateFixtures.setupNumberOfCandidatesForYear;
 import static no.sikt.nva.nvi.test.TestConstants.THIS_YEAR;
@@ -97,7 +96,7 @@ class ReEvaluateNviCandidatesHandlerTest {
   @Test
   void shouldNotSendMessagesForReportedCandidates() {
     var year = randomYear();
-    setupReportedCandidate(scenario.getCandidateRepository(), year);
+    scenario.setupReportedCandidate(year);
     handler.handleRequest(eventStream(createRequest(year)), outputStream, context);
     var sentBatches = sqsClient.getSentBatches();
     assertEquals(0, sentBatches.size());

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -6,7 +6,6 @@ import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
 import static no.sikt.nva.nvi.common.SampleExpandedPublicationFactory.mapOrganizationToAffiliation;
 import static no.sikt.nva.nvi.common.UpsertRequestBuilder.randomUpsertRequestBuilder;
-import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.dto.CustomerDtoFixtures.getDefaultCustomers;
@@ -731,9 +730,8 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
       // Then the evaluation should be skipped
       // And the Candidate entry in the database should not be updated
       setupClosedPeriod(scenario, publicationDate.year());
-      var existingCandidateDao =
-          setupReportedCandidate(scenario.getCandidateRepository(), publicationDate.year());
-      var publicationId = existingCandidateDao.publicationId();
+      var existingCandidate = scenario.setupReportedCandidate(publicationDate.year());
+      var publicationId = existingCandidate.getPublicationId();
       var publication =
           factory
               .withContributor(verifiedCreatorFrom(nviOrganization))
@@ -747,8 +745,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
 
       var candidate = candidateService.getCandidateByPublicationId(publicationId);
       assertThat(candidate.isReported()).isTrue();
-      assertThat(candidate.modifiedDate())
-          .isEqualTo(existingCandidateDao.candidate().modifiedDate());
+      assertThat(candidate.modifiedDate()).isEqualTo(existingCandidate.modifiedDate());
     }
 
     @Test

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/model/document/NviCandidateIndexDocument.java
@@ -75,6 +75,7 @@ public record NviCandidateIndexDocument(
     BigDecimal internationalCollaborationFactor,
     ReportingPeriod reportingPeriod,
     boolean reported,
+    String reportedDate,
     String createdDate,
     String modifiedDate,
     String indexDocumentCreatedAt)
@@ -261,6 +262,7 @@ public record NviCandidateIndexDocument(
     private BigDecimal internationalCollaborationFactor;
     private ReportingPeriod reportingPeriod;
     private boolean reported;
+    private String reportedDate;
     private String createdDate;
     private String modifiedDate;
 
@@ -338,6 +340,11 @@ public record NviCandidateIndexDocument(
       return this;
     }
 
+    public Builder withReportedDate(Instant reportedDate) {
+      this.reportedDate = Optional.ofNullable(reportedDate).map(Instant::toString).orElse(null);
+      return this;
+    }
+
     public Builder withCreatedDate(Instant createdDate) {
       this.createdDate = createdDate.toString();
       return this;
@@ -365,6 +372,7 @@ public record NviCandidateIndexDocument(
           internationalCollaborationFactor,
           reportingPeriod,
           reported,
+          reportedDate,
           createdDate,
           modifiedDate,
           Instant.now().toString());

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/utils/NviCandidateIndexDocumentGenerator.java
@@ -163,6 +163,7 @@ public final class NviCandidateIndexDocumentGenerator {
         .withIdentifier(candidate.identifier())
         .withReportingPeriod(ReportingPeriod.fromCandidate(candidate))
         .withReported(candidate.isReported())
+        .withReportedDate(candidate.reportedDate())
         .withApprovals(approvals)
         .withPublicationDetails(expandedPublicationDetails)
         .withNumberOfApprovals(approvals.size())

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -11,7 +11,6 @@ import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidate
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequestWithSingleAffiliation;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandidateRequest;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createCandidateDao;
-import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.db.DbApprovalStatusFixtures.randomApprovalDao;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidateBuilder;
 import static no.sikt.nva.nvi.common.db.DbPointCalculationFixtures.randomPointCalculationBuilder;
@@ -292,11 +291,7 @@ class IndexDocumentHandlerTest {
 
   @Test
   void shouldBuildIndexDocumentWithReportedPeriodWhenCandidateIsReported() {
-    // Using repository to create reported candidate because setting Candidate as reported is not
-    // implemented yet
-    // TODO: Use Candidate.setReported when implemented
-    var dao = setupReportedCandidate(candidateRepository, String.valueOf(CURRENT_YEAR));
-    var candidate = candidateService.getCandidateByIdentifier(dao.identifier());
+    var candidate = scenario.setupReportedCandidate(String.valueOf(CURRENT_YEAR));
     var expectedIndexDocument =
         setupExistingResourceInS3AndGenerateExpectedDocument(candidate).indexDocument();
     var event = createEvent(candidate.identifier());

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -61,6 +61,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpResponse;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -632,6 +633,7 @@ class IndexDocumentHandlerTest {
         randomCandidateBuilder(true)
             .pointCalculation(pointCalculation)
             .reportStatus(ReportStatus.REPORTED)
+            .reportedDate(Instant.now())
             .build();
     var candidateDao = createCandidateDao(dbCandidate);
     candidateRepository.create(candidateDao, emptyList());
@@ -902,6 +904,7 @@ class IndexDocumentHandlerTest {
         .withNumberOfApprovals(candidate.approvals().size())
         .withCreatorShareCount(candidate.getCreatorShareCount())
         .withReported(candidate.isReported())
+        .withReportedDate(candidate.reportedDate())
         .withGlobalApprovalStatus(candidate.getGlobalApprovalStatus())
         .withPublicationTypeChannelLevelPoints(candidate.getBasePoints())
         .withInternationalCollaborationFactor(candidate.getCollaborationFactor())

--- a/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
+++ b/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
@@ -240,14 +240,6 @@ public class EvaluationSteps {
     for (var institutionId : candidate.approvals().keySet()) {
       scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institutionId);
     }
-    //    candidate
-    //        .approvals()
-    //        .keySet()
-    //        .forEach(
-    //            institutionId ->
-    //                scenario.updateApprovalStatus(
-    //                    candidate.identifier(), ApprovalStatus.APPROVED, institutionId));
-    //    var refreshedCandidate = scenario.getCandidateByIdentifier(candidate.identifier());
     scenario.getCandidateService().reportCandidate(candidate.identifier(), Instant.now());
   }
 }

--- a/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
+++ b/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
@@ -237,14 +237,17 @@ public class EvaluationSteps {
   }
 
   private void setCandidateToReported(Candidate candidate) {
-    candidate
-        .approvals()
-        .keySet()
-        .forEach(
-            institutionId ->
-                scenario.updateApprovalStatus(
-                    candidate.identifier(), ApprovalStatus.APPROVED, institutionId));
-    var refreshedCandidate = scenario.getCandidateByIdentifier(candidate.identifier());
-    scenario.getCandidateService().reportCandidate(refreshedCandidate.identifier(), Instant.now());
+    for (var institutionId : candidate.approvals().keySet()) {
+      scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institutionId);
+    }
+    //    candidate
+    //        .approvals()
+    //        .keySet()
+    //        .forEach(
+    //            institutionId ->
+    //                scenario.updateApprovalStatus(
+    //                    candidate.identifier(), ApprovalStatus.APPROVED, institutionId));
+    //    var refreshedCandidate = scenario.getCandidateByIdentifier(candidate.identifier());
+    scenario.getCandidateService().reportCandidate(candidate.identifier(), Instant.now());
   }
 }

--- a/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
+++ b/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
@@ -240,7 +240,13 @@ public class EvaluationSteps {
 
   private void setCandidateToReported(Candidate candidate) {
     var candidateDao = candidate.toDao();
-    var dbCandidate = candidateDao.candidate().copy().reportStatus(ReportStatus.REPORTED).build();
+    var dbCandidate =
+        candidateDao
+            .candidate()
+            .copy()
+            .reportStatus(ReportStatus.REPORTED)
+            .reportedDate(Instant.now())
+            .build();
     var updatedCandidateDao = candidateDao.copy().candidate(dbCandidate).build();
 
     scenario

--- a/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
+++ b/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
@@ -58,7 +58,13 @@ public class EvaluationSteps {
   public void aReportedCandidateForThePublicationExists() {
     setupCandidate(publicationBuilder);
     var candidate = assertPublicationIsCandidate();
-    setCandidateToReported(candidate);
+
+    for (var institutionId : candidate.approvals().keySet()) {
+      scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institutionId);
+    }
+
+    setupClosedPeriod(scenario, candidate.period().publishingYear());
+    scenario.getCandidateService().reportCandidate(candidate.identifier(), Instant.now());
 
     var updatedCandidate = assertPublicationIsCandidate();
     assertThat(updatedCandidate.isReported()).isTrue();
@@ -234,12 +240,5 @@ public class EvaluationSteps {
       evaluationContext.evaluatePublicationAndPersistResult(publication);
       scenario.getPeriodRepository().update(period.toDao());
     }
-  }
-
-  private void setCandidateToReported(Candidate candidate) {
-    for (var institutionId : candidate.approvals().keySet()) {
-      scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institutionId);
-    }
-    scenario.getCandidateService().reportCandidate(candidate.identifier(), Instant.now());
   }
 }

--- a/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
+++ b/integration-tests/src/test/java/cucumber/steps/EvaluationSteps.java
@@ -1,10 +1,8 @@
 package cucumber.steps;
 
-import static java.util.Collections.emptyList;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupFuturePeriod;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
-import static no.sikt.nva.nvi.common.model.ContributorFixtures.unverifiedCreatorFrom;
 import static no.sikt.nva.nvi.common.model.ContributorFixtures.verifiedCreatorFrom;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDateInYear;
 import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_NORWAY;
@@ -21,9 +19,9 @@ import java.net.URI;
 import java.time.Instant;
 import no.sikt.nva.nvi.common.SampleExpandedPublicationFactory;
 import no.sikt.nva.nvi.common.TestScenario;
-import no.sikt.nva.nvi.common.db.ReportStatus;
 import no.sikt.nva.nvi.common.model.PublicationDate;
 import no.sikt.nva.nvi.common.service.exception.CandidateNotFoundException;
+import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 
 public class EvaluationSteps {
@@ -172,7 +170,7 @@ public class EvaluationSteps {
         publicationBuilder
             .withPublicationDate(publicationDate)
             .withContributor(verifiedCreatorFrom(nviOrganization))
-            .withContributor(unverifiedCreatorFrom(nviOrganization));
+            .withContributor(verifiedCreatorFrom(nviOrganization));
     evaluationContext.mockGetAllCustomersResponse(publicationBuilder.getCustomerOrganizations());
   }
 
@@ -239,18 +237,14 @@ public class EvaluationSteps {
   }
 
   private void setCandidateToReported(Candidate candidate) {
-    var candidateDao = candidate.toDao();
-    var dbCandidate =
-        candidateDao
-            .candidate()
-            .copy()
-            .reportStatus(ReportStatus.REPORTED)
-            .reportedDate(Instant.now())
-            .build();
-    var updatedCandidateDao = candidateDao.copy().candidate(dbCandidate).build();
-
-    scenario
-        .getCandidateRepository()
-        .updateCandidateAggregate(updatedCandidateDao, emptyList(), emptyList(), emptyList());
+    candidate
+        .approvals()
+        .keySet()
+        .forEach(
+            institutionId ->
+                scenario.updateApprovalStatus(
+                    candidate.identifier(), ApprovalStatus.APPROVED, institutionId));
+    var refreshedCandidate = scenario.getCandidateByIdentifier(candidate.identifier());
+    scenario.getCandidateService().reportCandidate(refreshedCandidate.identifier(), Instant.now());
   }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -385,7 +385,8 @@ public final class CandidateDao extends Dao {
       @DynamoDbConvertedBy(DbCreatorTypeListConverter.class) List<DbCreatorType> creators,
       Instant createdDate,
       Instant modifiedDate,
-      ReportStatus reportStatus) {
+      ReportStatus reportStatus,
+      Instant reportedDate) {
 
     public static Builder builder() {
       return new Builder();
@@ -400,7 +401,8 @@ public final class CandidateDao extends Dao {
           .creators(creators.stream().map(DbCreatorType::copy).toList())
           .createdDate(createdDate)
           .modifiedDate(modifiedDate)
-          .reportStatus(reportStatus);
+          .reportStatus(reportStatus)
+          .reportedDate(reportedDate);
     }
 
     @DynamoDbIgnore
@@ -417,6 +419,7 @@ public final class CandidateDao extends Dao {
       private Instant builderCreatedDate;
       private Instant builderModifiedDate;
       private ReportStatus builderReportStatus;
+      private Instant builderReportedDate;
 
       private Builder() {}
 
@@ -455,6 +458,11 @@ public final class CandidateDao extends Dao {
         return this;
       }
 
+      public Builder reportedDate(Instant reportedDate) {
+        this.builderReportedDate = reportedDate;
+        return this;
+      }
+
       public DbCandidate build() {
         return new DbCandidate(
             builderPointCalculation,
@@ -463,7 +471,8 @@ public final class CandidateDao extends Dao {
             builderCreators,
             builderCreatedDate,
             builderModifiedDate,
-            builderReportStatus);
+            builderReportStatus,
+            builderReportedDate);
       }
     }
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateResponseFactory.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateResponseFactory.java
@@ -42,6 +42,7 @@ public final class CandidateResponseFactory {
         .withPeriod(toPeriodStatusDto(candidate.period()))
         .withTotalPoints(candidate.getTotalPoints())
         .withReportStatus(getReportStatus(candidate))
+        .withReportedDate(candidate.reportedDate())
         .build();
   }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
@@ -148,12 +148,11 @@ public class CandidateService {
    * Marks a Candidate as `reported`, which means it is included in the final report for the
    * corresponding reporting period and is now immutable.
    */
-  public Candidate reportCandidate(UUID candidateIdentifier, Instant reportedDate) {
+  public void reportCandidate(UUID candidateIdentifier, Instant reportedDate) {
     LOGGER.info("Updating candidate with identifier={} to reported", candidateIdentifier);
     var candidate = getCandidateByIdentifier(candidateIdentifier);
     var reportedCandidate = candidate.updateToReportedCandidate(reportedDate);
     updateCandidate(reportedCandidate);
-    return reportedCandidate;
   }
 
   public Candidate getCandidateByIdentifier(UUID candidateIdentifier) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
@@ -9,6 +9,7 @@ import static no.sikt.nva.nvi.common.service.model.Candidate.getUpdatedInstituti
 import static no.sikt.nva.nvi.common.service.model.Candidate.shouldResetCandidate;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -141,6 +142,18 @@ public class CandidateService {
           updatedCandidate.toDao(), emptyList(), approvalsToDelete, emptyList());
       LOGGER.info("Successfully updated publicationId={} to non-candidate", publicationId);
     }
+  }
+
+  /**
+   * Marks a Candidate as `reported`, which means it is included in the final report for the
+   * corresponding reporting period and is now immutable.
+   */
+  public Candidate reportCandidate(UUID candidateIdentifier, Instant reportedDate) {
+    LOGGER.info("Updating candidate with identifier={} to reported", candidateIdentifier);
+    var candidate = getCandidateByIdentifier(candidateIdentifier);
+    var reportedCandidate = candidate.updateToReportedCandidate(reportedDate);
+    updateCandidate(reportedCandidate);
+    return reportedCandidate;
   }
 
   public Candidate getCandidateByIdentifier(UUID candidateIdentifier) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/dto/CandidateDto.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/dto/CandidateDto.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import java.math.BigDecimal;
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
@@ -26,6 +27,7 @@ public record CandidateDto(
     List<NoteDto> notes,
     PeriodStatusDto period,
     String status,
+    Instant reportedDate,
     Set<CandidateOperation> allowedOperations,
     Set<CandidateProblem> problems)
     implements JsonSerializable {
@@ -47,6 +49,7 @@ public record CandidateDto(
     private List<NoteDto> notes;
     private PeriodStatusDto periodStatus;
     private String reportStatus;
+    private Instant reportedDate;
     private Set<CandidateOperation> allowedOperations;
     private Set<CandidateProblem> problems;
 
@@ -97,6 +100,11 @@ public record CandidateDto(
       return this;
     }
 
+    public Builder withReportedDate(Instant reportedDate) {
+      this.reportedDate = reportedDate;
+      return this;
+    }
+
     public Builder withAllowedOperations(Set<CandidateOperation> allowedOperations) {
       this.allowedOperations = allowedOperations;
       return this;
@@ -118,6 +126,7 @@ public record CandidateDto(
           notes,
           periodStatus,
           reportStatus,
+          reportedDate,
           allowedOperations,
           problems);
     }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -183,6 +183,9 @@ public record Candidate(
     if (getGlobalApprovalStatus() != GlobalApprovalStatus.APPROVED) {
       throw new IllegalCandidateUpdateException("Cannot report non-approved candidate");
     }
+    if (!period().isClosed()) {
+      throw new IllegalCandidateUpdateException("Cannot report candidate if period is not closed");
+    }
     return copy()
         .withReportStatus(REPORTED)
         .withReportedDate(reportedDate)

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -68,6 +68,7 @@ public record Candidate(
     Instant createdDate,
     Instant modifiedDate,
     ReportStatus reportStatus,
+    Instant reportedDate,
     Long revision,
     UUID version,
     // TODO: Remove environment from this record
@@ -107,6 +108,7 @@ public record Candidate(
         .withCreatedDate(dbCandidate.createdDate())
         .withModifiedDate(dbCandidate.modifiedDate())
         .withReportStatus(dbCandidate.reportStatus())
+        .withReportedDate(dbCandidate.reportedDate())
         .withRevision(candidateDao.revision())
         .withVersion(version)
         .withEnvironment(environment)
@@ -185,6 +187,7 @@ public record Candidate(
             .createdDate(createdDate)
             .modifiedDate(modifiedDate)
             .reportStatus(reportStatus)
+            .reportedDate(reportedDate)
             .build();
     var periodYear = getPeriod().map(NviPeriod::publishingYear).map(Object::toString).orElse(null);
     var daoVersion = getVersion().map(Object::toString).orElse(null);
@@ -516,6 +519,7 @@ public record Candidate(
         .withNotes(notes())
         .withPeriod(period())
         .withReportStatus(reportStatus())
+        .withReportedDate(reportedDate())
         .withModifiedDate(modifiedDate())
         .withCreatedDate(createdDate())
         .withPointCalculation(pointCalculation())
@@ -583,6 +587,7 @@ public record Candidate(
     private Instant createdDate;
     private Instant modifiedDate;
     private ReportStatus reportStatus;
+    private Instant reportedDate;
     private Long revision;
     private UUID version;
     private Environment environment;
@@ -639,6 +644,11 @@ public record Candidate(
       return this;
     }
 
+    public Builder withReportedDate(Instant reportedDate) {
+      this.reportedDate = reportedDate;
+      return this;
+    }
+
     public Builder withRevision(Long revision) {
       this.revision = revision;
       return this;
@@ -666,6 +676,7 @@ public record Candidate(
           createdDate,
           modifiedDate,
           reportStatus,
+          reportedDate,
           revision,
           version,
           environment);

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -176,6 +176,20 @@ public record Candidate(
         .build();
   }
 
+  public Candidate updateToReportedCandidate(Instant reportedDate) {
+    if (isReported()) {
+      throw new IllegalCandidateUpdateException(CANDIDATE_IS_REPORTED);
+    }
+    if (getGlobalApprovalStatus() != GlobalApprovalStatus.APPROVED) {
+      throw new IllegalCandidateUpdateException("Cannot report non-approved candidate");
+    }
+    return copy()
+        .withReportStatus(REPORTED)
+        .withReportedDate(reportedDate)
+        .withModifiedDate(Instant.now())
+        .build();
+  }
+
   public CandidateDao toDao() {
     var dbPublication = publicationDetails.toDbPublication();
     var dbCandidate =

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/CandidateMigrationServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/CandidateMigrationServiceTest.java
@@ -12,6 +12,7 @@ import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import java.util.function.Function;
@@ -90,7 +91,8 @@ class CandidateMigrationServiceTest {
     var dbDetails = randomPublicationBuilder(publication.identifier(), topLevelInstitution);
     var builder =
         randomCandidateBuilder(topLevelInstitution, dbDetails.build())
-            .reportStatus(ReportStatus.REPORTED);
+            .reportStatus(ReportStatus.REPORTED)
+            .reportedDate(Instant.now());
     var dbCandidate = customizer.apply(builder).build();
     return createCandidateInRepository(candidateRepository, dbCandidate);
   }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/HandlesMigrationServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/HandlesMigrationServiceTest.java
@@ -10,6 +10,7 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -94,6 +95,7 @@ class HandlesMigrationServiceTest {
     var dbCandidate =
         randomCandidateBuilder(topLevelInstitution, dbDetails)
             .reportStatus(ReportStatus.REPORTED)
+            .reportedDate(Instant.now())
             .build();
     return createCandidateInRepository(candidateRepository, dbCandidate);
   }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -530,7 +530,8 @@ class CandidateTest extends CandidateTestSetup {
     scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institution);
 
     var reportedDate = Instant.parse("2026-01-15T12:00:00Z");
-    var reportedCandidate = candidateService.reportCandidate(candidate.identifier(), reportedDate);
+    candidateService.reportCandidate(candidate.identifier(), reportedDate);
+    var reportedCandidate = candidateService.getCandidateByIdentifier(candidate.identifier());
 
     Assertions.assertThat(reportedCandidate.isReported()).isTrue();
     Assertions.assertThat(reportedCandidate.reportedDate()).isEqualTo(reportedDate);

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -27,8 +27,6 @@ import static nva.commons.core.ioutils.IoUtils.stringFromResources;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -58,7 +56,6 @@ import no.sikt.nva.nvi.common.service.exception.IllegalCandidateUpdateException;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.GlobalApprovalStatus;
-import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
@@ -367,25 +364,23 @@ class CandidateTest extends CandidateTestSetup {
   @Test
   void shouldReturnCandidateWithPeriodStatusContainingPeriodId() {
     var year = randomYear();
-    var candidate = scenario.setupReportedCandidate(year);
+    var candidateIdentifier = scenario.setupReportedCandidate(year).identifier();
     var period = setupClosedPeriod(scenario, year);
 
-    var refetchedCandidate = candidateService.getCandidateByIdentifier(candidate.identifier());
+    var candidate = candidateService.getCandidateByIdentifier(candidateIdentifier);
 
-    assertEquals(period.id(), refetchedCandidate.period().id());
+    assertEquals(period.id(), candidate.period().id());
   }
 
   @Test
   void shouldReturnCandidateWithPeriodStatusContainingPeriodIdWhenFetchingByPublicationId() {
     var year = randomYear();
-    var candidate = scenario.setupReportedCandidate(year);
-    setupClosedPeriod(scenario, year);
+    var publicationId = scenario.setupReportedCandidate(year).getPublicationId();
+    var period = setupClosedPeriod(scenario, year);
 
-    var refetchedCandidate =
-        candidateService.getCandidateByPublicationId(candidate.getPublicationId());
-    var id = refetchedCandidate.getPeriod().map(NviPeriod::id).orElseThrow();
+    var candidate = candidateService.getCandidateByPublicationId(publicationId);
 
-    assertThat(id, is(not(nullValue())));
+    assertEquals(period.id(), candidate.period().id());
   }
 
   @Test

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -368,12 +368,11 @@ class CandidateTest extends CandidateTestSetup {
   void shouldReturnCandidateWithPeriodStatusContainingPeriodId() {
     var year = randomYear();
     var candidate = scenario.setupReportedCandidate(year);
-    setupClosedPeriod(scenario, year);
+    var period = setupClosedPeriod(scenario, year);
 
     var refetchedCandidate = candidateService.getCandidateByIdentifier(candidate.identifier());
-    var id = refetchedCandidate.getPeriod().map(NviPeriod::id).orElseThrow();
 
-    assertThat(id, is(not(nullValue())));
+    assertEquals(period.id(), refetchedCandidate.period().id());
   }
 
   @Test

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -8,7 +8,6 @@ import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidate
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequestWithSingleAffiliation;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandidateRequest;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createCandidateInRepository;
-import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.getExpectedUpdatedDbCandidate;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidate;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
@@ -39,6 +38,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.stream.Stream;
 import no.sikt.nva.nvi.common.UpsertRequestBuilder;
@@ -185,10 +185,10 @@ class CandidateTest extends CandidateTestSetup {
   @Test
   void shouldNotUpdateReportedCandidate() {
     var year = randomYear();
-    var candidate = setupReportedCandidate(candidateRepository, year);
+    var candidate = scenario.setupReportedCandidate(year);
 
     var updateRequest =
-        randomUpsertRequestBuilder().withPublicationId(candidate.publicationId()).build();
+        randomUpsertRequestBuilder().withPublicationId(candidate.getPublicationId()).build();
     assertThrows(
         IllegalCandidateUpdateException.class,
         () -> candidateService.upsertCandidate(updateRequest));
@@ -351,8 +351,7 @@ class CandidateTest extends CandidateTestSetup {
 
   @Test
   void shouldReturnCandidateWithReportStatus() {
-    var dao = setupReportedCandidate(candidateRepository, randomYear());
-    var candidate = candidateService.getCandidateByIdentifier(dao.identifier());
+    var candidate = scenario.setupReportedCandidate(randomYear());
 
     var actualStatus = candidate.reportStatus().getValue();
     var expectedStatus = ReportStatus.REPORTED.getValue();
@@ -361,19 +360,18 @@ class CandidateTest extends CandidateTestSetup {
 
   @Test
   void shouldReturnTrueIfReportStatusIsReported() {
-    var dao = setupReportedCandidate(candidateRepository, randomYear());
-    var candidate = candidateService.getCandidateByIdentifier(dao.identifier());
+    var candidate = scenario.setupReportedCandidate(randomYear());
     assertTrue(candidate.isReported());
   }
 
   @Test
   void shouldReturnCandidateWithPeriodStatusContainingPeriodId() {
     var year = randomYear();
+    var candidate = scenario.setupReportedCandidate(year);
     setupClosedPeriod(scenario, year);
-    var dao = setupReportedCandidate(candidateRepository, year);
 
-    var candidate = candidateService.getCandidateByIdentifier(dao.identifier());
-    var id = candidate.getPeriod().map(NviPeriod::id).orElseThrow();
+    var refetchedCandidate = candidateService.getCandidateByIdentifier(candidate.identifier());
+    var id = refetchedCandidate.getPeriod().map(NviPeriod::id).orElseThrow();
 
     assertThat(id, is(not(nullValue())));
   }
@@ -381,11 +379,12 @@ class CandidateTest extends CandidateTestSetup {
   @Test
   void shouldReturnCandidateWithPeriodStatusContainingPeriodIdWhenFetchingByPublicationId() {
     var year = randomYear();
+    var candidate = scenario.setupReportedCandidate(year);
     setupClosedPeriod(scenario, year);
-    var dao = setupReportedCandidate(candidateRepository, year);
 
-    var candidate = candidateService.getCandidateByPublicationId(dao.publicationId());
-    var id = candidate.getPeriod().map(NviPeriod::id).orElseThrow();
+    var refetchedCandidate =
+        candidateService.getCandidateByPublicationId(candidate.getPublicationId());
+    var id = refetchedCandidate.getPeriod().map(NviPeriod::id).orElseThrow();
 
     assertThat(id, is(not(nullValue())));
   }
@@ -482,10 +481,10 @@ class CandidateTest extends CandidateTestSetup {
 
   @Test
   void shouldReturnFalseWhenCandidateIsReportedInClosedPeriod() {
-    var dao = setupReportedCandidate(candidateRepository, String.valueOf(CURRENT_YEAR));
+    var candidate = scenario.setupReportedCandidate(String.valueOf(CURRENT_YEAR));
     setupClosedPeriod(scenario, CURRENT_YEAR);
-    var candidate = candidateService.getCandidateByIdentifier(dao.identifier());
-    assertFalse(candidate.isNotReportedInClosedPeriod());
+    var refetchedCandidate = candidateService.getCandidateByIdentifier(candidate.identifier());
+    assertFalse(refetchedCandidate.isNotReportedInClosedPeriod());
   }
 
   @Test
@@ -527,6 +526,45 @@ class CandidateTest extends CandidateTestSetup {
                     .withAssignee(approval.getAssigneeUsername())
                     .build())
         .toList();
+  }
+
+  @Test
+  void shouldReportCandidateWithGivenTimestamp() {
+    var institution = randomUri();
+    var request = createUpsertCandidateRequestWithSingleAffiliation(institution, institution);
+    var candidate = scenario.upsertCandidate(request);
+    scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institution);
+
+    var reportedDate = Instant.parse("2026-01-15T12:00:00Z");
+    var reportedCandidate = candidateService.reportCandidate(candidate.identifier(), reportedDate);
+
+    Assertions.assertThat(reportedCandidate.isReported()).isTrue();
+    Assertions.assertThat(reportedCandidate.reportedDate()).isEqualTo(reportedDate);
+  }
+
+  @Test
+  void shouldThrowWhenReportingAlreadyReportedCandidate() {
+    var institution = randomUri();
+    var request = createUpsertCandidateRequestWithSingleAffiliation(institution, institution);
+    var candidate = scenario.upsertCandidate(request);
+    scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institution);
+    candidateService.reportCandidate(candidate.identifier(), Instant.now());
+
+    var identifier = candidate.identifier();
+    var now = Instant.now();
+    Assertions.assertThatThrownBy(() -> candidateService.reportCandidate(identifier, now))
+        .isInstanceOf(IllegalCandidateUpdateException.class);
+  }
+
+  @Test
+  void shouldThrowWhenReportingNonApprovedCandidate() {
+    var request = randomUpsertRequestBuilder().build();
+    var candidate = scenario.upsertCandidate(request);
+
+    var identifier = candidate.identifier();
+    var now = Instant.now();
+    Assertions.assertThatThrownBy(() -> candidateService.reportCandidate(identifier, now))
+        .isInstanceOf(IllegalCandidateUpdateException.class);
   }
 
   private UpsertNviCandidateRequest getUpdateRequestForExistingCandidate() {

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -528,6 +528,7 @@ class CandidateTest extends CandidateTestSetup {
     var request = createUpsertCandidateRequestWithSingleAffiliation(institution, institution);
     var candidate = scenario.upsertCandidate(request);
     scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institution);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
 
     var reportedDate = Instant.parse("2026-01-15T12:00:00Z");
     candidateService.reportCandidate(candidate.identifier(), reportedDate);
@@ -543,6 +544,7 @@ class CandidateTest extends CandidateTestSetup {
     var request = createUpsertCandidateRequestWithSingleAffiliation(institution, institution);
     var candidate = scenario.upsertCandidate(request);
     scenario.updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, institution);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
     candidateService.reportCandidate(candidate.identifier(), Instant.now());
 
     var identifier = candidate.identifier();
@@ -555,6 +557,7 @@ class CandidateTest extends CandidateTestSetup {
   void shouldThrowWhenReportingNonApprovedCandidate() {
     var request = randomUpsertRequestBuilder().build();
     var candidate = scenario.upsertCandidate(request);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
 
     var identifier = candidate.identifier();
     var now = Instant.now();

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -3,16 +3,21 @@ package no.sikt.nva.nvi.common;
 import static no.sikt.nva.nvi.common.EnvironmentFixtures.getGlobalEnvironment;
 import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
+import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequestWithSingleAffiliation;
+import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationId;
 import static no.sikt.nva.nvi.common.model.UserInstanceFixtures.createCuratorUserInstance;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 
 import java.io.IOException;
 import java.net.URI;
+import java.time.Instant;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
+import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
 import no.sikt.nva.nvi.common.db.model.CandidateAggregate;
+import no.sikt.nva.nvi.common.dto.PublicationDateDto;
 import no.sikt.nva.nvi.common.dto.UpsertNviCandidateRequest;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
@@ -23,6 +28,7 @@ import no.sikt.nva.nvi.common.service.NoteService;
 import no.sikt.nva.nvi.common.service.NviPeriodService;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.test.SampleExpandedPublication;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
@@ -107,6 +113,30 @@ public class TestScenario {
     return candidateService.getCandidateByPublicationId(publicationId);
   }
 
+  public Candidate setupReportedCandidate(String year) {
+    return setupReportedCandidate(year, randomOrganizationId());
+  }
+
+  public Candidate setupReportedCandidate(String year, URI organizationId) {
+    var previousPeriodWasClosed =
+        periodService.findByPublishingYear(year).map(NviPeriod::isClosed).orElse(false);
+    PeriodRepositoryFixtures.setupOpenPeriod(this, year);
+
+    var request = createUpsertCandidateRequestWithSingleAffiliation(organizationId, organizationId);
+    var requestWithYear =
+        UpsertRequestBuilder.fromRequest(request)
+            .withPublicationDate(new PublicationDateDto(year, null, null))
+            .build();
+    var candidate = upsertCandidate(requestWithYear);
+    updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, organizationId);
+    var reportedCandidate = candidateService.reportCandidate(candidate.identifier(), Instant.now());
+
+    if (previousPeriodWasClosed) {
+      PeriodRepositoryFixtures.setupClosedPeriod(this, year);
+    }
+    return reportedCandidate;
+  }
+
   public Candidate upsertCandidate(UpsertNviCandidateRequest request) {
     candidateService.upsertCandidate(request);
     return getCandidateByPublicationId(request.publicationId());
@@ -123,8 +153,10 @@ public class TestScenario {
   public Candidate updateApprovalStatus(
       UUID candidateIdentifier, ApprovalStatus status, URI topLevelOrganizationId) {
     var candidate = getCandidateByIdentifier(candidateIdentifier);
-    var updateRequest = createUpdateStatusRequest(status, topLevelOrganizationId, randomString());
     var userInstance = createCuratorUserInstance(topLevelOrganizationId);
+    var updateRequest =
+        createUpdateStatusRequest(
+            status, topLevelOrganizationId, userInstance.userName().toString());
     var approvalService = new ApprovalService(candidateRepository);
     approvalService.updateApproval(candidate, updateRequest, userInstance);
     return getCandidateByIdentifier(candidate.identifier());

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -4,6 +4,8 @@ import static no.sikt.nva.nvi.common.EnvironmentFixtures.getGlobalEnvironment;
 import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequestWithSingleAffiliation;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationId;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDateDtoInYear;
 import static no.sikt.nva.nvi.common.model.UserInstanceFixtures.createCuratorUserInstance;
@@ -16,7 +18,6 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
 import no.sikt.nva.nvi.common.db.model.CandidateAggregate;
 import no.sikt.nva.nvi.common.dto.UpsertNviCandidateRequest;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
@@ -28,7 +29,6 @@ import no.sikt.nva.nvi.common.service.NoteService;
 import no.sikt.nva.nvi.common.service.NviPeriodService;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
-import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.test.SampleExpandedPublication;
 import no.unit.nva.s3.S3Driver;
 import no.unit.nva.stubs.FakeS3Client;
@@ -118,10 +118,7 @@ public class TestScenario {
   }
 
   public Candidate setupReportedCandidate(String year, URI organizationId) {
-    var previousPeriodWasClosed =
-        periodService.findByPublishingYear(year).map(NviPeriod::isClosed).orElse(false);
-    PeriodRepositoryFixtures.setupOpenPeriod(this, year);
-
+    setupOpenPeriod(this, year);
     var request = createUpsertCandidateRequestWithSingleAffiliation(organizationId, organizationId);
     var requestWithYear =
         UpsertRequestBuilder.fromRequest(request)
@@ -129,13 +126,10 @@ public class TestScenario {
             .build();
     var candidate = upsertCandidate(requestWithYear);
     updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, organizationId);
-    candidateService.reportCandidate(candidate.identifier(), Instant.now());
-    var reportedCandidate = candidateService.getCandidateByIdentifier(candidate.identifier());
 
-    if (previousPeriodWasClosed) {
-      PeriodRepositoryFixtures.setupClosedPeriod(this, year);
-    }
-    return reportedCandidate;
+    setupClosedPeriod(this, year);
+    candidateService.reportCandidate(candidate.identifier(), Instant.now());
+    return candidateService.getCandidateByIdentifier(candidate.identifier());
   }
 
   public Candidate upsertCandidate(UpsertNviCandidateRequest request) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -129,7 +129,8 @@ public class TestScenario {
             .build();
     var candidate = upsertCandidate(requestWithYear);
     updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, organizationId);
-    var reportedCandidate = candidateService.reportCandidate(candidate.identifier(), Instant.now());
+    candidateService.reportCandidate(candidate.identifier(), Instant.now());
+    var reportedCandidate = candidateService.getCandidateByIdentifier(candidate.identifier());
 
     if (previousPeriodWasClosed) {
       PeriodRepositoryFixtures.setupClosedPeriod(this, year);

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -5,6 +5,7 @@ import static no.sikt.nva.nvi.common.LocalDynamoTestSetup.initializeTestDatabase
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpdateStatusRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequestWithSingleAffiliation;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationId;
+import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDateDtoInYear;
 import static no.sikt.nva.nvi.common.model.UserInstanceFixtures.createCuratorUserInstance;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 
@@ -17,7 +18,6 @@ import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures;
 import no.sikt.nva.nvi.common.db.model.CandidateAggregate;
-import no.sikt.nva.nvi.common.dto.PublicationDateDto;
 import no.sikt.nva.nvi.common.dto.UpsertNviCandidateRequest;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
 import no.sikt.nva.nvi.common.model.UpdateStatusRequest;
@@ -125,7 +125,7 @@ public class TestScenario {
     var request = createUpsertCandidateRequestWithSingleAffiliation(organizationId, organizationId);
     var requestWithYear =
         UpsertRequestBuilder.fromRequest(request)
-            .withPublicationDate(new PublicationDateDto(year, null, null))
+            .withPublicationDate(randomPublicationDateDtoInYear(year))
             .build();
     var candidate = upsertCandidate(requestWithYear);
     updateApprovalStatus(candidate.identifier(), ApprovalStatus.APPROVED, organizationId);

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/CandidateDaoFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/CandidateDaoFixtures.java
@@ -13,6 +13,7 @@ import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizati
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 
 import java.net.URI;
+import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -109,6 +110,7 @@ public class CandidateDaoFixtures {
         randomCandidateWithYear(organizationId, year)
             .copy()
             .reportStatus(ReportStatus.REPORTED)
+            .reportedDate(Instant.now())
             .build();
     var candidateDao = createCandidateDao(dbCandidate);
     var approvals = List.of(randomApprovalDao(candidateDao.identifier(), organizationId));

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/CandidateDaoFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/CandidateDaoFixtures.java
@@ -5,7 +5,6 @@ import static java.util.Objects.nonNull;
 import static java.util.UUID.randomUUID;
 import static no.sikt.nva.nvi.common.EnvironmentFixtures.EXPANDED_RESOURCES_BUCKET;
 import static no.sikt.nva.nvi.common.SampleExpandedPublicationFactory.defaultExpandedPublicationFactory;
-import static no.sikt.nva.nvi.common.db.DbApprovalStatusFixtures.randomApprovalDao;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidate;
 import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidateWithYear;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
@@ -13,7 +12,6 @@ import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizati
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 
 import java.net.URI;
-import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -90,32 +88,6 @@ public class CandidateDaoFixtures {
 
   private static String getCharacterValues(UUID uuid) {
     return uuid.toString().replaceAll(UUID_SEPARATOR, "");
-  }
-
-  /*
-   * This method is used to set up a reported candidate, but should be removed once Candidate.report is implemented.
-   */
-  @Deprecated
-  public static CandidateDao setupReportedCandidate(CandidateRepository repository, String year) {
-    return setupReportedCandidate(repository, year, randomOrganizationId());
-  }
-
-  /*
-   * This method is used to set up a reported candidate, but should be removed once Candidate.report is implemented.
-   */
-  @Deprecated
-  public static CandidateDao setupReportedCandidate(
-      CandidateRepository repository, String year, URI organizationId) {
-    var dbCandidate =
-        randomCandidateWithYear(organizationId, year)
-            .copy()
-            .reportStatus(ReportStatus.REPORTED)
-            .reportedDate(Instant.now())
-            .build();
-    var candidateDao = createCandidateDao(dbCandidate);
-    var approvals = List.of(randomApprovalDao(candidateDao.identifier(), organizationId));
-    repository.create(candidateDao, approvals);
-    return repository.findCandidateById(candidateDao.identifier()).orElseThrow();
   }
 
   public static Map<String, String> getYearIndexStartMarker(CandidateDao dao) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/SampleCandidateGenerator.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/SampleCandidateGenerator.java
@@ -76,6 +76,7 @@ public final class SampleCandidateGenerator {
         null,
         null,
         null,
+        null,
         new Environment());
   }
 

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
@@ -1,6 +1,5 @@
 package no.sikt.nva.nvi.rest.fetch;
 
-import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.dto.AllowedOperationFixtures.CURATOR_CAN_FINALIZE_APPROVAL;
 import static no.sikt.nva.nvi.rest.fetch.FetchNviCandidateByPublicationIdHandler.CANDIDATE_PUBLICATION_ID;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
@@ -115,10 +114,8 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
 
   @Test
   void shouldReturnCandidateWithReportStatus() throws IOException {
-    var candidate =
-        setupReportedCandidate(
-            scenario.getCandidateRepository(), randomYear(), topLevelOrganizationId);
-    var publicationId = candidate.publicationId();
+    var candidate = scenario.setupReportedCandidate(randomYear(), topLevelOrganizationId);
+    var publicationId = candidate.getPublicationId();
     var request = createRequestWithCuratorAccess(publicationId.toString());
 
     handler.handleRequest(request, output, CONTEXT);

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
@@ -2,7 +2,6 @@ package no.sikt.nva.nvi.rest.fetch;
 
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertNonCandidateRequest;
-import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.setupReportedCandidate;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeriod;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomTopLevelOrganization;
@@ -21,7 +20,6 @@ import java.net.URI;
 import java.util.Map;
 import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.UpsertRequestBuilder;
-import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.dto.PublicationDateDto;
 import no.sikt.nva.nvi.common.service.CandidateService;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
@@ -40,7 +38,6 @@ class FetchReportStatusByPublicationIdHandlerTest {
   private static final String PATH_PARAM_PUBLICATION_ID = "publicationId";
   private Context context;
   private ByteArrayOutputStream output;
-  private CandidateRepository candidateRepository;
   private CandidateService candidateService;
   private TestScenario scenario;
   private FetchReportStatusByPublicationIdHandler handler;
@@ -49,7 +46,6 @@ class FetchReportStatusByPublicationIdHandlerTest {
   void setUp() {
     scenario = new TestScenario();
     setupOpenPeriod(scenario, CURRENT_YEAR);
-    candidateRepository = scenario.getCandidateRepository();
     candidateService = scenario.getCandidateService();
     output = new ByteArrayOutputStream();
     context = new FakeContext();
@@ -59,9 +55,8 @@ class FetchReportStatusByPublicationIdHandlerTest {
 
   @Test
   void shouldReturnReportedYearWhenPublicationIsReportedInClosedPeriod() throws IOException {
-    var dao = setupReportedCandidate(candidateRepository, String.valueOf(CURRENT_YEAR));
+    var reportedCandidate = scenario.setupReportedCandidate(String.valueOf(CURRENT_YEAR));
     setupClosedPeriod(scenario, CURRENT_YEAR);
-    var reportedCandidate = candidateService.getCandidateByIdentifier(dao.identifier());
 
     handler.handleRequest(createRequest(reportedCandidate.getPublicationId()), output, context);
 


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51079

Changes:

- Adds `reportedDate` field to candidate models (domain, database, and index)
- Adds methods to `Candidate` and `CandidateService` to update a candidate to "reported" so that it becomes immutable
- Adds helper method `TestScenario.setupReportedCandidate` to simplify setting up test cases