### PR TITLE
feat: Add backfill migration for reportedDate

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ProcessBatchJobHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ProcessBatchJobHandler.java
@@ -7,7 +7,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.ArrayList;
 import no.sikt.nva.nvi.common.MigrationService;
-import no.sikt.nva.nvi.common.RboInstitutionMigrationService;
+import no.sikt.nva.nvi.common.ReportedDateMigrationService;
 import no.sikt.nva.nvi.common.service.CandidateService;
 import no.sikt.nva.nvi.common.service.NviPeriodService;
 import no.sikt.nva.nvi.common.service.exception.CandidateNotFoundException;
@@ -30,7 +30,7 @@ public class ProcessBatchJobHandler implements RequestHandler<SQSEvent, SQSBatch
   public ProcessBatchJobHandler() {
     this(
         CandidateService.defaultCandidateService(),
-        RboInstitutionMigrationService.defaultService(),
+        ReportedDateMigrationService.defaultService(),
         NviPeriodService.defaultNviPeriodService());
   }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/RboInstitutionMigrationService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/RboInstitutionMigrationService.java
@@ -22,6 +22,10 @@ import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated Inactive migration code that should be removed.
+ */
+@Deprecated(forRemoval = true)
 public class RboInstitutionMigrationService implements MigrationService {
 
   private static final Logger LOGGER =

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/ReportedDateMigrationService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/ReportedDateMigrationService.java
@@ -1,0 +1,53 @@
+package no.sikt.nva.nvi.common;
+
+import static java.util.Objects.isNull;
+import static no.sikt.nva.nvi.common.service.CandidateService.defaultCandidateService;
+
+import java.time.Instant;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.service.CandidateService;
+import no.sikt.nva.nvi.common.service.model.Candidate;
+import nva.commons.core.JacocoGenerated;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReportedDateMigrationService implements MigrationService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ReportedDateMigrationService.class);
+  private final CandidateService candidateService;
+
+  public ReportedDateMigrationService(CandidateService candidateService) {
+    this.candidateService = candidateService;
+  }
+
+  @JacocoGenerated
+  public static ReportedDateMigrationService defaultService() {
+    return new ReportedDateMigrationService(defaultCandidateService());
+  }
+
+  @Override
+  public void migrateCandidate(UUID identifier) {
+    var candidate = candidateService.getCandidateByIdentifier(identifier);
+    if (shouldMigrate(candidate)) {
+      LOGGER.info(
+          "Setting reportedDate for candidate {} (year={}) to {}",
+          identifier,
+          candidate.period().publishingYear(),
+          candidate.period().reportingDate());
+      var updatedCandidate = backfillReportedDate(candidate);
+      candidateService.updateCandidate(updatedCandidate);
+    }
+  }
+
+  private static boolean shouldMigrate(Candidate candidate) {
+    return candidate.isReported() && isNull(candidate.reportedDate());
+  }
+
+  private static Candidate backfillReportedDate(Candidate candidate) {
+    return candidate
+        .copy()
+        .withReportedDate(candidate.period().reportingDate())
+        .withModifiedDate(Instant.now())
+        .build();
+  }
+}

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/ReportedDateMigrationServiceTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/ReportedDateMigrationServiceTest.java
@@ -1,0 +1,96 @@
+package no.sikt.nva.nvi.common;
+
+import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createCandidateInRepository;
+import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidateBuilder;
+import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
+import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Instant;
+import java.util.UUID;
+import no.sikt.nva.nvi.common.db.CandidateRepository;
+import no.sikt.nva.nvi.common.db.ReportStatus;
+import no.sikt.nva.nvi.common.service.CandidateService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ReportedDateMigrationServiceTest {
+
+  private CandidateService candidateService;
+  private CandidateRepository candidateRepository;
+  private ReportedDateMigrationService migrationService;
+
+  @BeforeEach
+  void setUp() {
+    var scenario = new TestScenario();
+    candidateService = scenario.getCandidateService();
+    candidateRepository = scenario.getCandidateRepository();
+    migrationService = new ReportedDateMigrationService(candidateService);
+    setupOpenPeriod(scenario, CURRENT_YEAR);
+  }
+
+  @Test
+  void shouldSetReportedDateBasedOnPeriodIfMissingFromReportedCandidate() {
+    var candidateId = createReportedCandidateWithoutReportedDate();
+
+    migrationService.migrateCandidate(candidateId);
+
+    var updatedCandidate = candidateService.getCandidateByIdentifier(candidateId);
+    assertThat(updatedCandidate.reportedDate())
+        .isEqualTo(updatedCandidate.period().reportingDate());
+  }
+
+  @Test
+  void shouldNotModifyCandidateAlreadyHavingReportedDate() {
+    var existingReportedDate = Instant.parse("2024-01-15T10:00:00Z");
+    var candidateId = createReportedCandidateWithReportedDate(existingReportedDate);
+
+    migrationService.migrateCandidate(candidateId);
+
+    var candidate = candidateService.getCandidateByIdentifier(candidateId);
+    assertThat(candidate.reportedDate()).isEqualTo(existingReportedDate);
+  }
+
+  @Test
+  void shouldNotModifyNonReportedCandidate() {
+    var candidateId = createNonReportedCandidate();
+
+    migrationService.migrateCandidate(candidateId);
+
+    var candidate = candidateService.getCandidateByIdentifier(candidateId);
+    assertThat(candidate.reportedDate()).isNull();
+    assertThat(candidate.reportStatus()).isNull();
+  }
+
+  @Test
+  void shouldUpdateModifiedDateWhenMigrating() {
+    var candidateId = createReportedCandidateWithoutReportedDate();
+    var candidateBeforeMigration = candidateService.getCandidateByIdentifier(candidateId);
+
+    migrationService.migrateCandidate(candidateId);
+
+    var updatedCandidate = candidateService.getCandidateByIdentifier(candidateId);
+    assertThat(updatedCandidate.modifiedDate())
+        .isAfterOrEqualTo(candidateBeforeMigration.modifiedDate());
+  }
+
+  private UUID createReportedCandidateWithoutReportedDate() {
+    var dbCandidate =
+        randomCandidateBuilder(true).reportStatus(ReportStatus.REPORTED).reportedDate(null).build();
+    return createCandidateInRepository(candidateRepository, dbCandidate);
+  }
+
+  private UUID createReportedCandidateWithReportedDate(Instant reportedDate) {
+    var dbCandidate =
+        randomCandidateBuilder(true)
+            .reportStatus(ReportStatus.REPORTED)
+            .reportedDate(reportedDate)
+            .build();
+    return createCandidateInRepository(candidateRepository, dbCandidate);
+  }
+
+  private UUID createNonReportedCandidate() {
+    var dbCandidate = randomCandidateBuilder(true).reportStatus(null).reportedDate(null).build();
+    return createCandidateInRepository(candidateRepository, dbCandidate);
+  }
+}


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51080

Adds a backfill migration that sets `reportedDate` for historical candidates based on when the period closed. Also switches the currently active migration to this new one, on the assumption that the previous migration is complete.