### PR TITLE
fix: Prevent automated deletion of DynamoDB table

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1470,7 +1470,7 @@ Resources:
   NvaNviTable:
     Type: AWS::DynamoDB::Table
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Delete
+    DeletionPolicy: Retain
     Properties:
       TableName: !Sub "nva-nvi-${AWS::StackName}"
       PointInTimeRecoverySpecification:


### PR DESCRIPTION
Prevents the DynamoDB table from being deleted automatically (e.g. if stack deleted or resource modified). See https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-deletionpolicy.html for details.