### PR TITLE
fix: Clean up unnecessary PMD exclusions

### DIFF
--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -66,7 +66,6 @@
     <exclude name="LawOfDemeter"/>
     <exclude name="DataClass"/>
     <exclude name="ExcessiveImports"/>
-    <exclude name="UseUtilityClass"/>
     <exclude name="UseObjectForClearerAPI"/>
     <exclude name="TooManyMethods"/>
 

--- a/config/pmd/ruleset.xml
+++ b/config/pmd/ruleset.xml
@@ -24,7 +24,6 @@
 
   <rule ref="category/java/bestpractices.xml">
     <exclude name="GuardLogStatement"/>
-    <exclude name="AvoidPrintStackTrace"/>
     <exclude name="UnitTestAssertionsShouldIncludeMessage"/>
     <exclude name="UnitTestContainsTooManyAsserts"/>
 
@@ -33,10 +32,6 @@
 
     <!-- In TableManager we map ResourceNotFoundException to TableNotFoundException -->
     <exclude name="PreserveStackTrace"/>
-
-    <!-- //TODO: This is complaining on private methods that are used?  -->
-    <exclude name="UnusedPrivateMethod"/>
-
   </rule>
 
   <rule ref="category/java/codestyle.xml">
@@ -51,17 +46,12 @@
     <exclude name="MethodArgumentCouldBeFinal"/>
     <exclude name="TooManyStaticImports"/>
     <exclude name="UseExplicitTypes"/>
-    <exclude name="ClassNamingConventions"/>
     <exclude name="UnnecessaryConstructor"/>
     <!-- Conflicts with the rule category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending -->
     <exclude name="CommentDefaultAccessModifier"/>
     <!-- Conflicts with the rule category/java/codestyle.xml/AvoidProtectedMethodInFinalClassNotExtending -->
 
-    <exclude name="ConfusingTernary"/>
     <exclude name="FieldNamingConventions"/>
-
-    <!-- Sometimes it is useful in debugging to assign the return value to a local variable  -->
-    <exclude name="UnnecessaryLocalBeforeReturn"/>
   </rule>
 
 
@@ -76,12 +66,9 @@
     <exclude name="LawOfDemeter"/>
     <exclude name="DataClass"/>
     <exclude name="ExcessiveImports"/>
-    <exclude name="AvoidCatchingGenericException"/>
-    <exclude name="SignatureDeclareThrowsException"/>
     <exclude name="UseUtilityClass"/>
     <exclude name="UseObjectForClearerAPI"/>
     <exclude name="TooManyMethods"/>
-    <exclude name="CyclomaticComplexity"/>
 
     <!-- This rule does not allow the Lambda Handler to cast  the ContainerInitializationException
         to a RuntimeException.

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/StartBatchJobHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/StartBatchJobHandler.java
@@ -79,14 +79,14 @@ public class StartBatchJobHandler implements RequestStreamHandler {
 
   @Override
   public void handleRequest(InputStream input, OutputStream output, Context context) {
-    if (!processingEnabled) {
-      LOGGER.warn("Processing disabled, aborting batch job");
-    } else {
+    if (processingEnabled) {
       var request = parseRequest(input);
       LOGGER.info("Processing batch job: {}", request);
       var batchJobResult = batchJobFactory.from(request).execute();
       sendMessagesToQueue(batchJobResult.messages());
       sendContinuationEvents(batchJobResult.continuationEvents());
+    } else {
+      LOGGER.warn("Processing disabled, aborting batch job");
     }
   }
 

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -449,7 +449,7 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
 
   @Nested
   @DisplayName("Test cases with dynamic test data")
-  class evaluateNviCandidatesWithDynamicTestData {
+  class EvaluateNviCandidatesWithDynamicTestData {
     private SampleExpandedPublicationFactory factory;
     private Organization nviOrganization;
     private PublicationDate publicationDate;

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/PointCalculationTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/PointCalculationTest.java
@@ -4,8 +4,18 @@ import static java.util.Objects.nonNull;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.dto.CustomerDtoFixtures.getDefaultCustomers;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDate;
+import static no.sikt.nva.nvi.test.TestConstants.ACADEMIC_ARTICLE;
+import static no.sikt.nva.nvi.test.TestConstants.ACADEMIC_CHAPTER;
+import static no.sikt.nva.nvi.test.TestConstants.ACADEMIC_COMMENTARY;
+import static no.sikt.nva.nvi.test.TestConstants.ACADEMIC_LITERATURE_REVIEW;
+import static no.sikt.nva.nvi.test.TestConstants.ACADEMIC_MONOGRAPH;
 import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_NORWAY;
 import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_SWEDEN;
+import static no.sikt.nva.nvi.test.TestConstants.JOURNAL_TYPE;
+import static no.sikt.nva.nvi.test.TestConstants.LEVEL_ONE;
+import static no.sikt.nva.nvi.test.TestConstants.LEVEL_TWO;
+import static no.sikt.nva.nvi.test.TestConstants.PUBLISHER_TYPE;
+import static no.sikt.nva.nvi.test.TestConstants.SERIES_TYPE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.tuple;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -28,10 +38,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-// FIXME: Suppressing AvoidDuplicateLiterals because I don't want to touch the test data now.
-// We should consider moving the test data to a separate CSV file or something later.
-@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 class PointCalculationTest extends EvaluationTest {
+  private static final String SQUARE_ROOT_OF_ONE_HALF = "0.7071";
   private SampleExpandedPublicationFactory factory;
   private URI publicationId;
   private Organization nviOrganization1;
@@ -166,7 +174,7 @@ class PointCalculationTest extends EvaluationTest {
 
     handleEvaluation(publication);
 
-    var expectedPoints = asBigDecimal("0.7071");
+    var expectedPoints = asBigDecimal(SQUARE_ROOT_OF_ONE_HALF);
     assertCandidateHasPointsFromSingleInstitution(nviOrganization1.id(), expectedPoints);
   }
 
@@ -200,7 +208,7 @@ class PointCalculationTest extends EvaluationTest {
 
     handleEvaluation(publication);
 
-    var expectedPoints = asBigDecimal("0.7071");
+    var expectedPoints = asBigDecimal(SQUARE_ROOT_OF_ONE_HALF);
     assertCandidateHasPointsFromSingleInstitution(nviOrganization1.id(), expectedPoints);
     assertCandidateHasTotalPointsAndCreatorShares(expectedPoints, 2);
   }
@@ -283,7 +291,7 @@ class PointCalculationTest extends EvaluationTest {
             .withCreatorAffiliatedWith(nviOrganization1.hasPart().getFirst())
             .withCreatorAffiliatedWith(nonNviOrganization)
             .withCreatorAffiliatedWith(nviOrganization1.getTopLevelOrg(), nonNviOrganization)
-            .withPublicationChannel("Journal", "LevelOne");
+            .withPublicationChannel(JOURNAL_TYPE, LEVEL_ONE);
 
     handleEvaluation(publication);
 
@@ -328,121 +336,121 @@ class PointCalculationTest extends EvaluationTest {
     return Stream.of(
         // example from cristin calculations, publicationYear 2022
         new PointParameters(
-            "AcademicArticle",
-            "Journal",
-            "LevelOne",
+            ACADEMIC_ARTICLE,
+            JOURNAL_TYPE,
+            LEVEL_ONE,
             false,
             2,
-            asBigDecimal("0.7071"),
-            asBigDecimal("0.7071"),
+            asBigDecimal(SQUARE_ROOT_OF_ONE_HALF),
+            asBigDecimal(SQUARE_ROOT_OF_ONE_HALF),
             asBigDecimal("1.4142")));
   }
 
   private static Stream<PointParameters> twoCreatorsAffiliatedWithOneInstitutionPointProvider() {
     return Stream.of(
         new PointParameters(
-            "AcademicCommentary",
-            "Series",
-            "LevelOne",
+            ACADEMIC_COMMENTARY,
+            SERIES_TYPE,
+            LEVEL_ONE,
             false,
             3,
             asBigDecimal("4.0825"),
             asBigDecimal("2.8868"),
             asBigDecimal("6.9693")),
         new PointParameters(
-            "AcademicCommentary",
-            "Series",
-            "LevelTwo",
+            ACADEMIC_COMMENTARY,
+            SERIES_TYPE,
+            LEVEL_TWO,
             true,
             4,
             asBigDecimal("7.3539"),
             asBigDecimal("5.2000"),
             asBigDecimal("12.5539")),
         new PointParameters(
-            "AcademicCommentary",
-            "Series",
-            "LevelTwo",
+            ACADEMIC_COMMENTARY,
+            SERIES_TYPE,
+            LEVEL_TWO,
             false,
             4,
             asBigDecimal("5.6569"),
             asBigDecimal("4.0000"),
             asBigDecimal("9.6569")),
         new PointParameters(
-            "AcademicMonograph",
-            "Series",
-            "LevelOne",
+            ACADEMIC_MONOGRAPH,
+            SERIES_TYPE,
+            LEVEL_ONE,
             false,
             3,
             asBigDecimal("4.0825"),
             asBigDecimal("2.8868"),
             asBigDecimal("6.9693")),
         new PointParameters(
-            "AcademicMonograph",
-            "Series",
-            "LevelTwo",
+            ACADEMIC_MONOGRAPH,
+            SERIES_TYPE,
+            LEVEL_TWO,
             true,
             4,
             asBigDecimal("7.3539"),
             asBigDecimal("5.2000"),
             asBigDecimal("12.5539")),
         new PointParameters(
-            "AcademicMonograph",
-            "Series",
-            "LevelTwo",
+            ACADEMIC_MONOGRAPH,
+            SERIES_TYPE,
+            LEVEL_TWO,
             false,
             4,
             asBigDecimal("5.6569"),
             asBigDecimal("4.0000"),
             asBigDecimal("9.6569")),
         new PointParameters(
-            "AcademicChapter",
-            "Series",
-            "LevelOne",
+            ACADEMIC_CHAPTER,
+            SERIES_TYPE,
+            LEVEL_ONE,
             true,
             5,
             asBigDecimal("0.8222"),
             asBigDecimal("0.5814"),
             asBigDecimal("1.4036")),
         new PointParameters(
-            "AcademicChapter",
-            "Series",
-            "LevelTwo",
+            ACADEMIC_CHAPTER,
+            SERIES_TYPE,
+            LEVEL_TWO,
             false,
             5,
             asBigDecimal("1.8974"),
             asBigDecimal("1.3416"),
             asBigDecimal("3.2390")),
         new PointParameters(
-            "AcademicArticle",
-            "Journal",
-            "LevelOne",
+            ACADEMIC_ARTICLE,
+            JOURNAL_TYPE,
+            LEVEL_ONE,
             false,
             7,
             asBigDecimal("0.5345"),
             asBigDecimal("0.3780"),
             asBigDecimal("0.9125")),
         new PointParameters(
-            "AcademicArticle",
-            "Journal",
-            "LevelTwo",
+            ACADEMIC_ARTICLE,
+            JOURNAL_TYPE,
+            LEVEL_TWO,
             false,
             7,
             asBigDecimal("1.6036"),
             asBigDecimal("1.1339"),
             asBigDecimal("2.7375")),
         new PointParameters(
-            "AcademicLiteratureReview",
-            "Journal",
-            "LevelOne",
+            ACADEMIC_LITERATURE_REVIEW,
+            JOURNAL_TYPE,
+            LEVEL_ONE,
             true,
             8,
             asBigDecimal("0.6500"),
             asBigDecimal("0.4596"),
             asBigDecimal("1.1096")),
         new PointParameters(
-            "AcademicLiteratureReview",
-            "Journal",
-            "LevelTwo",
+            ACADEMIC_LITERATURE_REVIEW,
+            JOURNAL_TYPE,
+            LEVEL_TWO,
             true,
             8,
             asBigDecimal("1.9500"),
@@ -453,144 +461,144 @@ class PointCalculationTest extends EvaluationTest {
   private static Stream<PointParameters> singleCreatorSingleInstitutionPointProvider() {
     return Stream.of(
         new PointParameters(
-            "AcademicCommentary",
-            "Series",
-            "LevelOne",
+            ACADEMIC_COMMENTARY,
+            SERIES_TYPE,
+            LEVEL_ONE,
             false,
             1,
             asBigDecimal("5"),
             null,
             asBigDecimal("5")),
         new PointParameters(
-            "AcademicCommentary",
-            "Series",
-            "LevelTwo",
+            ACADEMIC_COMMENTARY,
+            SERIES_TYPE,
+            LEVEL_TWO,
             false,
             1,
             asBigDecimal("8"),
             null,
             asBigDecimal("8")),
         new PointParameters(
-            "AcademicCommentary",
-            "Publisher",
-            "LevelOne",
+            ACADEMIC_COMMENTARY,
+            PUBLISHER_TYPE,
+            LEVEL_ONE,
             false,
             1,
             asBigDecimal("5"),
             null,
             asBigDecimal("5")),
         new PointParameters(
-            "AcademicCommentary",
-            "Publisher",
-            "LevelTwo",
+            ACADEMIC_COMMENTARY,
+            PUBLISHER_TYPE,
+            LEVEL_TWO,
             false,
             1,
             asBigDecimal("8"),
             null,
             asBigDecimal("8")),
         new PointParameters(
-            "AcademicMonograph",
-            "Series",
-            "LevelOne",
+            ACADEMIC_MONOGRAPH,
+            SERIES_TYPE,
+            LEVEL_ONE,
             false,
             1,
             asBigDecimal("5"),
             null,
             asBigDecimal("5")),
         new PointParameters(
-            "AcademicMonograph",
-            "Series",
-            "LevelTwo",
+            ACADEMIC_MONOGRAPH,
+            SERIES_TYPE,
+            LEVEL_TWO,
             false,
             1,
             asBigDecimal("8"),
             null,
             asBigDecimal("8")),
         new PointParameters(
-            "AcademicMonograph",
-            "Publisher",
-            "LevelOne",
+            ACADEMIC_MONOGRAPH,
+            PUBLISHER_TYPE,
+            LEVEL_ONE,
             false,
             1,
             asBigDecimal("5"),
             null,
             asBigDecimal("5")),
         new PointParameters(
-            "AcademicMonograph",
-            "Publisher",
-            "LevelTwo",
+            ACADEMIC_MONOGRAPH,
+            PUBLISHER_TYPE,
+            LEVEL_TWO,
             false,
             1,
             asBigDecimal("8"),
             null,
             asBigDecimal("8")),
         new PointParameters(
-            "AcademicChapter",
-            "Series",
-            "LevelOne",
+            ACADEMIC_CHAPTER,
+            SERIES_TYPE,
+            LEVEL_ONE,
             false,
             1,
             asBigDecimal("1"),
             null,
             asBigDecimal("1")),
         new PointParameters(
-            "AcademicChapter",
-            "Series",
-            "LevelTwo",
+            ACADEMIC_CHAPTER,
+            SERIES_TYPE,
+            LEVEL_TWO,
             false,
             1,
             asBigDecimal("3"),
             null,
             asBigDecimal("3")),
         new PointParameters(
-            "AcademicChapter",
-            "Publisher",
-            "LevelOne",
+            ACADEMIC_CHAPTER,
+            PUBLISHER_TYPE,
+            LEVEL_ONE,
             false,
             1,
             asBigDecimal("0.7"),
             null,
             asBigDecimal("0.7")),
         new PointParameters(
-            "AcademicChapter",
-            "Publisher",
-            "LevelTwo",
+            ACADEMIC_CHAPTER,
+            PUBLISHER_TYPE,
+            LEVEL_TWO,
             false,
             1,
             asBigDecimal("1"),
             null,
             asBigDecimal("1")),
         new PointParameters(
-            "AcademicArticle",
-            "Journal",
-            "LevelOne",
+            ACADEMIC_ARTICLE,
+            JOURNAL_TYPE,
+            LEVEL_ONE,
             false,
             1,
             asBigDecimal("1"),
             null,
             asBigDecimal("1")),
         new PointParameters(
-            "AcademicArticle",
-            "Journal",
-            "LevelTwo",
+            ACADEMIC_ARTICLE,
+            JOURNAL_TYPE,
+            LEVEL_TWO,
             false,
             1,
             asBigDecimal("3"),
             null,
             asBigDecimal("3")),
         new PointParameters(
-            "AcademicLiteratureReview",
-            "Journal",
-            "LevelOne",
+            ACADEMIC_LITERATURE_REVIEW,
+            JOURNAL_TYPE,
+            LEVEL_ONE,
             false,
             1,
             asBigDecimal("1"),
             null,
             asBigDecimal("1")),
         new PointParameters(
-            "AcademicLiteratureReview",
-            "Journal",
-            "LevelTwo",
+            ACADEMIC_LITERATURE_REVIEW,
+            JOURNAL_TYPE,
+            LEVEL_TWO,
             false,
             1,
             asBigDecimal("3"),

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/InitHandler.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/InitHandler.java
@@ -23,11 +23,11 @@ public class InitHandler implements RequestHandler<Object, String> {
 
   @Override
   public String handleRequest(Object input, Context context) {
-    if (!this.indexingClient.indexExists()) {
+    if (this.indexingClient.indexExists()) {
+      LOGGER.info("Index already exists");
+    } else {
       LOGGER.info("Creating index");
       this.indexingClient.createIndex();
-    } else {
-      LOGGER.info("Index already exists");
     }
 
     return SUCCESS;

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/CandidateQuery.java
@@ -157,6 +157,7 @@ public record CandidateQuery(
         .toList();
   }
 
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   private Optional<Query> constructQueryWithFilter() {
 
     var aggregation =

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/SearchAggregation.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/query/SearchAggregation.java
@@ -58,6 +58,7 @@ public enum SearchAggregation {
     return searchAggregation != ORGANIZATION_APPROVAL_STATUS_AGGREGATION;
   }
 
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   public Aggregation generateAggregation(String username, String topLevelCristinOrg) {
     return switch (this) {
       case NEW_AGG -> pendingAggregation(topLevelCristinOrg);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/FakeCachedJwtProvider.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/FakeCachedJwtProvider.java
@@ -11,7 +11,7 @@ import java.util.Date;
 import no.unit.nva.auth.CachedJwtProvider;
 import no.unit.nva.auth.CognitoAuthenticator;
 
-public class FakeCachedJwtProvider {
+public final class FakeCachedJwtProvider {
 
   private static final String TEST_TOKEN =
       "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPbmxpbmUgSldUIEJ1"
@@ -20,6 +20,8 @@ public class FakeCachedJwtProvider {
           + "mVuTmFtZSI6IkpvaG5ueSIsIlN1cm5hbWUiOiJSb2NrZXQiLCJFbWFpbCI6Impyb2"
           + "NrZXRAZXhhbXBsZS5jb20iLCJSb2xlIjoiTWFuYWdlciIsInNjb3BlIjoiZXhhbX"
           + "BsZS1zY29wZSJ9.ne8Jb4f2xao1zSJFZxIBRrh4WFNjkaBRV3-Ybp6fHZU";
+
+  private FakeCachedJwtProvider() {}
 
   public static CachedJwtProvider setup() {
     var jwt = mock(DecodedJWT.class);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/IndexDocumentHandlerTest.java
@@ -788,16 +788,6 @@ class IndexDocumentHandlerTest {
         constructPublicationBucketPath(extractResourceIdentifier(candidate)));
   }
 
-  private void setupResourceWithInvalidObjectInS3(JsonNode expandedResource, Candidate candidate) {
-    var invalidObject = objectMapper.createObjectNode();
-    invalidObject.put("invalidKey", "invalidValue");
-    ((ObjectNode) expandedResource).remove("topLevelOrganizations");
-    ((ObjectNode) expandedResource).set("topLevelOrganizations", invalidObject);
-    insertResourceInS3(
-        createResourceIndexDocument(expandedResource),
-        constructPublicationBucketPath(extractResourceIdentifier(candidate)));
-  }
-
   private JsonNode removeTopLevelOrganization(ObjectNode expandedResource) {
     expandedResource.remove("topLevelOrganizations");
     return expandedResource;

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/AggregateResponseTestUtil.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/AggregateResponseTestUtil.java
@@ -12,7 +12,9 @@ import org.opensearch.client.opensearch._types.aggregations.NestedAggregate;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsAggregate;
 import org.opensearch.client.opensearch._types.aggregations.StringTermsBucket;
 
-public class AggregateResponseTestUtil {
+public final class AggregateResponseTestUtil {
+
+  private AggregateResponseTestUtil() {}
 
   public static Aggregate organizationApprovalStatusAggregate(String topLevelOrg) {
     var pendingBucket = getStringTermsBucket("Pending", Map.of(), 2);

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/ExcelWorkbookUtil.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/ExcelWorkbookUtil.java
@@ -16,11 +16,13 @@ import org.apache.poi.xssf.usermodel.XSSFRow;
 import org.apache.poi.xssf.usermodel.XSSFSheet;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
-public class ExcelWorkbookUtil {
+public final class ExcelWorkbookUtil {
 
   private static final int FIRST_SHEET_INDEX = 0;
   private static final int FIRST_ROW_INDEX = 0;
   private static final int FIRST_DATA_ROW_INDEX = 1;
+
+  private ExcelWorkbookUtil() {}
 
   public static ExcelWorkbookGenerator fromInputStream(InputStream inputStream) {
     try (var workbook = new XSSFWorkbook(inputStream)) {

--- a/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
+++ b/index-handlers/src/test/java/no/sikt/nva/nvi/index/apigateway/utils/MockOpenSearchUtil.java
@@ -15,7 +15,9 @@ import org.opensearch.client.opensearch.core.search.HitsMetadata;
 import org.opensearch.client.opensearch.core.search.TotalHits;
 import org.opensearch.client.opensearch.core.search.TotalHitsRelation;
 
-public class MockOpenSearchUtil {
+public final class MockOpenSearchUtil {
+
+  private MockOpenSearchUtil() {}
 
   public static SearchResponse<NviCandidateIndexDocument> createSearchResponse(
       NviCandidateIndexDocument document) {

--- a/libs/publication-service/src/test/java/no/sikt/nva/nvi/publication/NviGraphValidatorTest.java
+++ b/libs/publication-service/src/test/java/no/sikt/nva/nvi/publication/NviGraphValidatorTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("PMD.CyclomaticComplexity")
 class NviGraphValidatorTest {
 
   private static final String NVA_ONTOLOGY = "https://nva.sikt.no/ontology/publication#";

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Approval.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Approval.java
@@ -146,6 +146,7 @@ public record Approval(
     }
   }
 
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   private void validateUpdateStatusRequest(UpdateStatusRequest request) {
     status.validateStateTransition(request.approvalStatus());
     if (isNull(request.institutionId())) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -56,7 +56,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 // Should be refactored, technical debt task: https://sikt.atlassian.net/browse/NP-48093
-@SuppressWarnings({"PMD.CouplingBetweenObjects"})
+@SuppressWarnings({"PMD.CouplingBetweenObjects", "PMD.CyclomaticComplexity"})
 public record Candidate(
     UUID identifier,
     boolean applicable,

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/Validator.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/Validator.java
@@ -59,6 +59,7 @@ public final class Validator {
     }
   }
 
+  @SuppressWarnings("PMD.CyclomaticComplexity")
   public static void doesNotHaveNullValues(UpsertPeriodRequest upsertPeriodRequest) {
     if (isNull(upsertPeriodRequest.publishingYear())) {
       throw new IllegalArgumentException("Publishing year can not be null!");

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/LocalDynamoTestSetup.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/LocalDynamoTestSetup.java
@@ -21,7 +21,7 @@ import software.amazon.awssdk.services.dynamodb.model.ProvisionedThroughput;
 import software.amazon.awssdk.services.dynamodb.model.ScalarAttributeType;
 import software.amazon.dynamodb.services.local.embedded.DynamoDBEmbedded;
 
-public class LocalDynamoTestSetup {
+public final class LocalDynamoTestSetup {
 
   private static final Long CAPACITY_DOES_NOT_MATTER = 1000L;
   private static final ProvisionedThroughput LOCAL_THROUGHPUT =
@@ -29,6 +29,8 @@ public class LocalDynamoTestSetup {
           .readCapacityUnits(CAPACITY_DOES_NOT_MATTER)
           .writeCapacityUnits(CAPACITY_DOES_NOT_MATTER)
           .build();
+
+  private LocalDynamoTestSetup() {}
 
   public static DynamoDbClient initializeTestDatabase(String tableName) {
     var localDynamo = DynamoDBEmbedded.create(null, true).dynamoDbClient();

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/RequestFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/RequestFixtures.java
@@ -8,7 +8,9 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import no.sikt.nva.nvi.common.model.CreateNoteRequest;
 import no.sikt.nva.nvi.common.model.UpdateAssigneeRequest;
 
-public class RequestFixtures {
+public final class RequestFixtures {
+
+  private RequestFixtures() {}
 
   public static CreateNoteRequest createNoteRequest(String text, String username) {
     return new CreateNoteRequest(text, username, randomUri());

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/UpsertRequestFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/UpsertRequestFixtures.java
@@ -22,7 +22,9 @@ import no.sikt.nva.nvi.common.model.UserInstance;
 import no.sikt.nva.nvi.common.service.dto.NviCreatorDto;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 
-public class UpsertRequestFixtures {
+public final class UpsertRequestFixtures {
+
+  private UpsertRequestFixtures() {}
 
   public static UpsertNonNviCandidateRequest createUpsertNonCandidateRequest(URI publicationId) {
     return new UpsertNonNviCandidateRequest(publicationId);

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/CandidateDaoFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/CandidateDaoFixtures.java
@@ -21,8 +21,10 @@ import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import nva.commons.core.paths.UriWrapper;
 
-public class CandidateDaoFixtures {
+public final class CandidateDaoFixtures {
   private static final String UUID_SEPARATOR = "-";
+
+  private CandidateDaoFixtures() {}
 
   public static CandidateDao randomApplicableCandidateDao() {
     return CandidateDao.builder()

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbApprovalStatusFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbApprovalStatusFixtures.java
@@ -11,7 +11,9 @@ import java.util.UUID;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbApprovalStatus;
 import no.sikt.nva.nvi.common.db.ApprovalStatusDao.DbStatus;
 
-public class DbApprovalStatusFixtures {
+public final class DbApprovalStatusFixtures {
+
+  private DbApprovalStatusFixtures() {}
 
   public static DbApprovalStatus randomApproval() {
     return randomApproval(randomUri());

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbCandidateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbCandidateFixtures.java
@@ -21,7 +21,9 @@ import no.sikt.nva.nvi.common.db.model.DbPublicationDetails;
 import no.sikt.nva.nvi.common.dto.UpsertNviCandidateRequest;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 
-public class DbCandidateFixtures {
+public final class DbCandidateFixtures {
+
+  private DbCandidateFixtures() {}
 
   public static DbCandidate randomCandidate() {
     return randomCandidateBuilder(true).build();

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPointCalculationFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPointCalculationFixtures.java
@@ -18,7 +18,9 @@ import no.sikt.nva.nvi.common.dto.UpsertNviCandidateRequest;
 import no.sikt.nva.nvi.common.model.Sector;
 import no.sikt.nva.nvi.test.TestUtils;
 
-public class DbPointCalculationFixtures {
+public final class DbPointCalculationFixtures {
+
+  private DbPointCalculationFixtures() {}
 
   public static DbPointCalculation.Builder randomPointCalculationBuilder(
       URI organizationId, URI creatorId) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPublicationChannelFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPublicationChannelFixtures.java
@@ -7,7 +7,9 @@ import no.sikt.nva.nvi.common.db.model.DbPublicationChannel;
 import no.sikt.nva.nvi.common.dto.UpsertNviCandidateRequest;
 import no.sikt.nva.nvi.common.model.ScientificValue;
 
-public class DbPublicationChannelFixtures {
+public final class DbPublicationChannelFixtures {
+
+  private DbPublicationChannelFixtures() {}
 
   public static DbPublicationChannel.Builder randomDbPublicationChannelBuilder() {
     return DbPublicationChannel.builder()

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPublicationDetailsFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPublicationDetailsFixtures.java
@@ -21,7 +21,9 @@ import no.sikt.nva.nvi.common.db.model.DbPublicationDetails;
 import no.sikt.nva.nvi.common.dto.UpsertNviCandidateRequest;
 import no.sikt.nva.nvi.common.service.model.PageCount;
 
-public class DbPublicationDetailsFixtures {
+public final class DbPublicationDetailsFixtures {
+
+  private DbPublicationDetailsFixtures() {}
 
   public static DbPublicationDetails.Builder randomPublicationBuilder(
       UUID publicationIdentifier, URI organizationId) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/NoteDaoFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/NoteDaoFixtures.java
@@ -8,7 +8,9 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.NoteDao.DbNote;
 
-public class NoteDaoFixtures {
+public final class NoteDaoFixtures {
+
+  private NoteDaoFixtures() {}
 
   public static NoteDao randomNoteDao() {
     return randomNoteDao(randomUUID());

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/PeriodRepositoryFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/PeriodRepositoryFixtures.java
@@ -11,11 +11,13 @@ import no.sikt.nva.nvi.common.service.model.CreatePeriodRequest;
 import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.common.service.model.UpdatePeriodRequest;
 
-public class PeriodRepositoryFixtures {
+public final class PeriodRepositoryFixtures {
   private static final Instant previousMonth = ZonedDateTime.now().minusMonths(1).toInstant();
   private static final Instant previousYear = ZonedDateTime.now().minusMonths(12).toInstant();
   private static final Instant nextMonth = ZonedDateTime.now().plusMonths(1).toInstant();
   private static final Instant nextYear = ZonedDateTime.now().plusMonths(12).toInstant();
+
+  private PeriodRepositoryFixtures() {}
 
   public static NviPeriod setupFuturePeriod(TestScenario scenario, String year) {
     return upsertPeriod(year, nextMonth, nextYear, scenario.getPeriodRepository());

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/UsernameFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/UsernameFixtures.java
@@ -5,7 +5,9 @@ import static no.sikt.nva.nvi.common.model.UsernameFixtures.randomUsername;
 
 import no.sikt.nva.nvi.common.db.model.Username;
 
-public class UsernameFixtures {
+public final class UsernameFixtures {
+
+  private UsernameFixtures() {}
 
   public static Username randomDbUsername() {
     return fromUserName(randomUsername());

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/dto/NviCreatorDtoFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/dto/NviCreatorDtoFixtures.java
@@ -11,7 +11,9 @@ import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.service.dto.UnverifiedNviCreatorDto;
 import no.sikt.nva.nvi.common.service.dto.VerifiedNviCreatorDto;
 
-public class NviCreatorDtoFixtures {
+public final class NviCreatorDtoFixtures {
+
+  private NviCreatorDtoFixtures() {}
 
   public static VerifiedNviCreatorDto verifiedNviCreatorDtoCopiedFrom(
       VerifiedNviCreatorDto originalCreator, Collection<URI> newAffiliations) {

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/CandidateFixtures.java
@@ -16,7 +16,9 @@ import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.service.dto.NviCreatorDto;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 
-public class CandidateFixtures {
+public final class CandidateFixtures {
+
+  private CandidateFixtures() {}
 
   public static Candidate setupRandomApplicableCandidate(TestScenario scenario) {
     var candidateRequest = randomUpsertRequestBuilder().build();

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/ContributorFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/ContributorFixtures.java
@@ -13,11 +13,13 @@ import no.sikt.nva.nvi.common.dto.ContributorRole;
 import no.sikt.nva.nvi.common.dto.VerificationStatus;
 import no.sikt.nva.nvi.common.service.dto.VerifiedNviCreatorDto;
 
-public class ContributorFixtures {
+public final class ContributorFixtures {
   public static final ContributorRole ROLE_CREATOR = new ContributorRole("Creator");
   public static final ContributorRole ROLE_OTHER = new ContributorRole("ContactPerson");
   public static final VerificationStatus STATUS_VERIFIED = new VerificationStatus("Verified");
   public static final VerificationStatus STATUS_UNVERIFIED = new VerificationStatus("NotVerified");
+
+  private ContributorFixtures() {}
 
   public static Builder randomCreator(Organization... affiliations) {
     return randomCreator(List.of(affiliations));

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/EnumFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/EnumFixtures.java
@@ -4,7 +4,9 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomElement;
 
 import java.util.List;
 
-public class EnumFixtures {
+public final class EnumFixtures {
+
+  private EnumFixtures() {}
 
   public static InstanceType randomValidInstanceType() {
     var values =

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/NviCreatorFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/NviCreatorFixtures.java
@@ -14,7 +14,9 @@ import no.sikt.nva.nvi.common.service.dto.NviCreatorDto;
 import no.sikt.nva.nvi.common.service.dto.UnverifiedNviCreatorDto;
 import no.sikt.nva.nvi.common.service.dto.VerifiedNviCreatorDto;
 
-public class NviCreatorFixtures {
+public final class NviCreatorFixtures {
+
+  private NviCreatorFixtures() {}
 
   public static List<DbCreatorType> mapToDbCreators(
       Collection<VerifiedNviCreatorDto> verifiedNviCreators,

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/OrganizationFixtures.java
@@ -20,7 +20,9 @@ import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.client.model.Organization.Builder;
 import nva.commons.core.paths.UriWrapper;
 
-public class OrganizationFixtures {
+public final class OrganizationFixtures {
+
+  private OrganizationFixtures() {}
 
   public static String randomOrganizationIdentifier() {
     return FAKER.numerify("###.###.###.###");

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PointCalculationFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PointCalculationFixtures.java
@@ -43,10 +43,6 @@ public final class PointCalculationFixtures {
         totalPoints);
   }
 
-  private static InstitutionPoints randomInstitutionPoints(int scale, Sector sector) {
-    return randomInstitutionPoints(scale, sector, randomBoolean());
-  }
-
   private static InstitutionPoints randomInstitutionPoints(
       int scale, Sector sector, boolean rboInstitution) {
     var institutionId = randomUri();

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PublicationDateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PublicationDateFixtures.java
@@ -6,7 +6,10 @@ import static no.unit.nva.testutils.RandomDataGenerator.randomLocalDate;
 import no.sikt.nva.nvi.common.db.model.DbPublicationDate;
 import no.sikt.nva.nvi.common.dto.PublicationDateDto;
 
-public class PublicationDateFixtures {
+public final class PublicationDateFixtures {
+
+  private PublicationDateFixtures() {}
+
   public static PublicationDate randomPublicationDateInYear(int year) {
     return randomPublicationDateInYear(String.valueOf(year));
   }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PublicationDetailsFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/PublicationDetailsFixtures.java
@@ -14,7 +14,9 @@ import java.util.List;
 import no.sikt.nva.nvi.common.dto.PublicationChannelDto;
 import no.sikt.nva.nvi.common.dto.PublicationDto;
 
-public class PublicationDetailsFixtures {
+public final class PublicationDetailsFixtures {
+
+  private PublicationDetailsFixtures() {}
 
   public static PublicationDto.Builder randomPublicationDtoBuilder() {
     var channel =

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/UsernameFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/UsernameFixtures.java
@@ -4,7 +4,9 @@ import static no.unit.nva.testutils.RandomDataGenerator.FAKER;
 
 import no.sikt.nva.nvi.common.service.model.Username;
 
-public class UsernameFixtures {
+public final class UsernameFixtures {
+
+  private UsernameFixtures() {}
 
   public static Username randomUsername() {
     var organizationIdentifier = FAKER.numerify("###.###.###.###");

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/ReportStatusDto.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/ReportStatusDto.java
@@ -22,6 +22,7 @@ public record ReportStatusDto(
     return new Builder();
   }
 
+  @SuppressWarnings({"PMD.ConfusingTernary", "PMD.CyclomaticComplexity"})
   private static StatusDto getStatus(Candidate candidate) {
     var isOpenPeriod = candidate.getPeriod().filter(NviPeriod::isOpen).isPresent();
     if (!candidate.isApplicable()) {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestConstants.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestConstants.java
@@ -101,6 +101,7 @@ public final class TestConstants {
   public static final String SERIES_TYPE = "Series";
   public static final String LEVEL_UNASSIGNED = "Unassigned";
   public static final String LEVEL_ONE = "LevelOne";
+  public static final String LEVEL_TWO = "LevelTwo";
 
   public static final String PERSISTED_RESOURCES_BUCKET = "EXPANDED_RESOURCES_BUCKET";
 


### PR DESCRIPTION
Cleans up unnecessary global exclusion of PMD rules. Trivial issues are fixed, while a few are converted to inline suppressions of each violation.

Changes:

- [refactor: Replace string literals with constants](https://github.com/BIBSYSDEV/nva-nvi/pull/771/commits/8d5a7b8ccb5083491fa0da409da9599da45a7960)
- [chore: Delete unused methods](https://github.com/BIBSYSDEV/nva-nvi/pull/771/commits/4e5bafec61ff2b5c5e4cf027d493e9187bb343bf)
- [refactor: Invert condition to make it less confusing](https://github.com/BIBSYSDEV/nva-nvi/pull/771/commits/395a9ae1e27197c6441e750ba79477a99ba633bf)
- [refactor: Rename class to match conventions](https://github.com/BIBSYSDEV/nva-nvi/pull/771/commits/b2e4d6a891bada7f31a4f603aee29802609f6f69)
- [fix: Remove unnecessary global PMD exclusions](https://github.com/BIBSYSDEV/nva-nvi/pull/771/commits/564bef7da64ecd6d3b7fac2fe0a3f4694fc41be5)
- [fix: Make utility classes final with private constructors](https://github.com/BIBSYSDEV/nva-nvi/pull/771/commits/2ca53fb70a631c31c3ec687495b6f48017a07387)
