### PR TITLE
fix(index-handlers): Reduce report scroll page size to avoid 413

### DIFF
--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/report/ReportDocumentClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/report/ReportDocumentClient.java
@@ -19,7 +19,7 @@ import org.opensearch.client.opensearch.core.search.SourceConfig;
 public class ReportDocumentClient {
 
   private static final String SCROLL_TIMEOUT = "1m";
-  private static final int SCROLL_PAGE_SIZE = 25;
+  private static final int SCROLL_PAGE_SIZE = 250;
   static final SourceConfig REPORT_SOURCE_CONFIG =
       SourceConfig.of(
           s ->

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/report/ReportDocumentClient.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/report/ReportDocumentClient.java
@@ -19,7 +19,7 @@ import org.opensearch.client.opensearch.core.search.SourceConfig;
 public class ReportDocumentClient {
 
   private static final String SCROLL_TIMEOUT = "1m";
-  private static final int SCROLL_PAGE_SIZE = 1000;
+  private static final int SCROLL_PAGE_SIZE = 25;
   static final SourceConfig REPORT_SOURCE_CONFIG =
       SourceConfig.of(
           s ->


### PR DESCRIPTION
`GenerateReportHandler` failed with `HTTP 413 Request Too Long` from the OpenSearch proxy (`api.sws.aws.sikt.no`) on the first scroll page, with the message `Search response too large. Try to narrow down the search or use pagination`. The job ended up in `nva-nvi-ReportQueueDLQ`.

- Lower `SCROLL_PAGE_SIZE` in `ReportDocumentClient` from 1000 to 25 so each scroll page stays small enough to fit under the proxy's response size limit.
- Scroll still fetches all pages via `fetchRemainingPages`, so the overall report result is unchanged — just more, smaller round-trips.

https://sikt.atlassian.net/browse/NP-51373