### PR TITLE
fix(evaluator): preserve closed-but-not-reported candidates from stripping

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -174,25 +174,26 @@ public class EvaluatorService {
     if (optionalCandidate.isEmpty() || !isInClosedPeriod(optionalCandidate.get())) {
       return false;
     }
-    if (movesToOpenPeriod(candidateAndPeriods, publicationDate)) {
-      logger.info(
-          "Candidate {} moves from a closed period to open period {}",
-          optionalCandidate.get().identifier(),
-          publicationDate.year());
-      return false;
+    var candidate = optionalCandidate.get();
+    if (remainsInSamePeriod(candidate, publicationDate)) {
+      return true;
     }
-    return true;
+    logger.info(
+        "Candidate {} in a closed period is being moved to year {}",
+        candidate.identifier(),
+        publicationDate.year());
+    return false;
   }
 
   private static boolean isInClosedPeriod(Candidate candidate) {
     return candidate.getPeriod().map(NviPeriod::isClosed).orElse(false);
   }
 
-  private boolean movesToOpenPeriod(
-      CandidateAndPeriods candidateAndPeriods, PublicationDateDto publicationDate) {
-    return candidateAndPeriods
-        .getPeriod(publicationDate.year())
-        .map(NviPeriod::isOpen)
+  private static boolean remainsInSamePeriod(
+      Candidate candidate, PublicationDateDto publicationDate) {
+    return candidate
+        .getPeriod()
+        .map(period -> period.hasPublishingYear(publicationDate.year()))
         .orElse(false);
   }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -97,6 +97,14 @@ public class EvaluatorService {
       return Optional.empty();
     }
 
+    // Preserve an existing candidate whose period is closed before any non-candidate decision
+    // below, so a publication edit cannot strip a closed-but-not-yet-reported candidate.
+    if (shouldPreserveExistingCandidateInClosedPeriod(
+        candidateAndPeriods, publication.publicationDate())) {
+      logger.info(SKIPPED_EVALUATION_MESSAGE, publication.id());
+      return Optional.empty();
+    }
+
     // Check that the publication meets the basic requirements to be a candidate
     if (isNonCandidate(publication)) {
       return createNonNviCandidateMessage(publication.id());
@@ -108,12 +116,6 @@ public class EvaluatorService {
     if (creators.isEmpty()) {
       logger.info("Publication has no NVI creators");
       return createNonNviCandidateMessage(publication.id());
-    }
-
-    // Skip update if the period is closed and the candidate is still applicable
-    if (isApplicableCandidateInClosedPeriod(candidateAndPeriods, publication.publicationDate())) {
-      logger.info(SKIPPED_EVALUATION_MESSAGE, publication.id());
-      return Optional.empty();
     }
 
     // Check that the publication can be a candidate in the target period
@@ -166,16 +168,31 @@ public class EvaluatorService {
     return nonNull(publication.status()) && "published".equalsIgnoreCase(publication.status());
   }
 
-  private boolean isApplicableCandidateInClosedPeriod(
+  private boolean shouldPreserveExistingCandidateInClosedPeriod(
       CandidateAndPeriods candidateAndPeriods, PublicationDateDto publicationDate) {
-    var optionalPeriod = candidateAndPeriods.getPeriod(publicationDate.year());
-    if (optionalPeriod.isEmpty() || !optionalPeriod.get().isClosed()) {
+    var optionalCandidate = candidateAndPeriods.getCandidate();
+    if (optionalCandidate.isEmpty() || !isInClosedPeriod(optionalCandidate.get())) {
       return false;
     }
-    var period = optionalPeriod.get();
+    if (movesToOpenPeriod(candidateAndPeriods, publicationDate)) {
+      logger.info(
+          "Candidate {} moves from a closed period to open period {}",
+          optionalCandidate.get().identifier(),
+          publicationDate.year());
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean isInClosedPeriod(Candidate candidate) {
+    return candidate.getPeriod().map(NviPeriod::isClosed).orElse(false);
+  }
+
+  private boolean movesToOpenPeriod(
+      CandidateAndPeriods candidateAndPeriods, PublicationDateDto publicationDate) {
     return candidateAndPeriods
-        .getCandidate()
-        .map(candidate -> isApplicableInPeriod(period, candidate))
+        .getPeriod(publicationDate.year())
+        .map(NviPeriod::isOpen)
         .orElse(false);
   }
 
@@ -183,12 +200,6 @@ public class EvaluatorService {
       CandidateAndPeriods candidateAndPeriods, PublicationDateDto publicationDate) {
     var optionalPeriod = candidateAndPeriods.getPeriod(publicationDate.year());
     return optionalPeriod.isPresent() && !optionalPeriod.get().isClosed();
-  }
-
-  private boolean isApplicableInPeriod(NviPeriod targetPeriod, Candidate candidate) {
-    var hasSamePeriod =
-        candidate.getPeriod().filter(period -> targetPeriod.id().equals(period.id())).isPresent();
-    return candidate.isApplicable() && hasSamePeriod;
   }
 
   private UpsertNviCandidateRequest constructNviCandidate(

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -52,6 +52,8 @@ public class EvaluatorService {
       "Skipping evaluation due to invalid year format {}.";
   private static final String REPORTED_CANDIDATE_MESSAGE =
       "Publication is already reported and cannot be updated.";
+  private static final String CLOSED_PERIOD_CANDIDATE_MESSAGE =
+      "Candidate is in a closed period and cannot be updated.";
   private final Logger logger = LoggerFactory.getLogger(EvaluatorService.class);
   private final CandidateService candidateService;
   private final IdentityServiceClient identityServiceClient;
@@ -97,14 +99,6 @@ public class EvaluatorService {
       return Optional.empty();
     }
 
-    // Preserve any existing candidate whose period is closed, before the non-candidate and
-    // move decisions below, so closed-period numbers can never change: a closed-period
-    // candidate is neither stripped in place nor moved out by a publication edit.
-    if (isExistingCandidateInClosedPeriod(candidateAndPeriods)) {
-      logger.info(SKIPPED_EVALUATION_MESSAGE, publication.id());
-      return Optional.empty();
-    }
-
     // Check that the publication meets the basic requirements to be a candidate
     if (isNonCandidate(publication)) {
       return createNonNviCandidateMessage(publication.id());
@@ -138,6 +132,13 @@ public class EvaluatorService {
 
     if (candidateAndPeriods.getCandidate().map(Candidate::isReported).orElse(false)) {
       logger.warn(REPORTED_CANDIDATE_MESSAGE);
+      return true;
+    }
+
+    // Freeze any existing candidate in a closed period: closed-period numbers must never change,
+    // so it is neither stripped in place nor moved out by a publication edit.
+    if (isExistingCandidateInClosedPeriod(candidateAndPeriods)) {
+      logger.info(CLOSED_PERIOD_CANDIDATE_MESSAGE);
       return true;
     }
     return false;

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -97,10 +97,10 @@ public class EvaluatorService {
       return Optional.empty();
     }
 
-    // Preserve an existing candidate whose period is closed before any non-candidate decision
-    // below, so a publication edit cannot strip a closed-but-not-yet-reported candidate.
-    if (shouldPreserveExistingCandidateInClosedPeriod(
-        candidateAndPeriods, publication.publicationDate())) {
+    // Preserve any existing candidate whose period is closed, before the non-candidate and
+    // move decisions below, so closed-period numbers can never change: a closed-period
+    // candidate is neither stripped in place nor moved out by a publication edit.
+    if (isExistingCandidateInClosedPeriod(candidateAndPeriods)) {
       logger.info(SKIPPED_EVALUATION_MESSAGE, publication.id());
       return Optional.empty();
     }
@@ -168,33 +168,13 @@ public class EvaluatorService {
     return nonNull(publication.status()) && "published".equalsIgnoreCase(publication.status());
   }
 
-  private boolean shouldPreserveExistingCandidateInClosedPeriod(
-      CandidateAndPeriods candidateAndPeriods, PublicationDateDto publicationDate) {
-    var optionalCandidate = candidateAndPeriods.getCandidate();
-    if (optionalCandidate.isEmpty() || !isInClosedPeriod(optionalCandidate.get())) {
-      return false;
-    }
-    var candidate = optionalCandidate.get();
-    if (remainsInSamePeriod(candidate, publicationDate)) {
-      return true;
-    }
-    logger.info(
-        "Candidate {} in a closed period is being moved to year {}",
-        candidate.identifier(),
-        publicationDate.year());
-    return false;
+  private static boolean isExistingCandidateInClosedPeriod(
+      CandidateAndPeriods candidateAndPeriods) {
+    return candidateAndPeriods.getCandidate().map(EvaluatorService::isInClosedPeriod).orElse(false);
   }
 
   private static boolean isInClosedPeriod(Candidate candidate) {
     return candidate.getPeriod().map(NviPeriod::isClosed).orElse(false);
-  }
-
-  private static boolean remainsInSamePeriod(
-      Candidate candidate, PublicationDateDto publicationDate) {
-    return candidate
-        .getPeriod()
-        .map(period -> period.hasPublishingYear(publicationDate.year()))
-        .orElse(false);
   }
 
   private boolean canEvaluateInPeriod(

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -27,7 +27,6 @@ import no.sikt.nva.nvi.common.model.Customer;
 import no.sikt.nva.nvi.common.service.CandidateService;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.service.model.CandidateAndPeriods;
-import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.events.evaluator.model.NviCreator;
 import no.sikt.nva.nvi.events.evaluator.model.NviOrganization;
 import no.sikt.nva.nvi.events.model.CandidateEvaluatedMessage;
@@ -171,11 +170,7 @@ public class EvaluatorService {
 
   private static boolean isExistingCandidateInClosedPeriod(
       CandidateAndPeriods candidateAndPeriods) {
-    return candidateAndPeriods.getCandidate().map(EvaluatorService::isInClosedPeriod).orElse(false);
-  }
-
-  private static boolean isInClosedPeriod(Candidate candidate) {
-    return candidate.getPeriod().map(NviPeriod::isClosed).orElse(false);
+    return candidateAndPeriods.getCandidate().map(Candidate::isInClosedPeriod).orElse(false);
   }
 
   private boolean canEvaluateInPeriod(

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/EvaluatorService.java
@@ -129,7 +129,7 @@ public class EvaluatorService {
       return true;
     }
 
-    if (candidateAndPeriods.getCandidate().map(Candidate::isReported).orElse(false)) {
+    if (isReportedCandidate(candidateAndPeriods)) {
       logger.warn(REPORTED_CANDIDATE_MESSAGE);
       return true;
     }
@@ -166,6 +166,10 @@ public class EvaluatorService {
 
   private boolean isPublished(PublicationDto publication) {
     return nonNull(publication.status()) && "published".equalsIgnoreCase(publication.status());
+  }
+
+  private static boolean isReportedCandidate(CandidateAndPeriods candidateAndPeriods) {
+    return candidateAndPeriods.getCandidate().map(Candidate::isReported).orElse(false);
   }
 
   private static boolean isExistingCandidateInClosedPeriod(

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -669,21 +669,50 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     }
 
     @Test
-    void shouldEvaluateExistingCandidateInClosedPeriodThatIsNoLongerApplicable() {
-      // Given a publication that has been evaluated as an applicable Candidate
-      // And the publication is published in a closed period
-      // When the publication is updated to be no longer applicable
-      // Then it should be re-evaluated as a NonCandidate
+    void shouldPreserveExistingCandidateInClosedPeriodWhenEditedToNonApplicable() {
+      // Given an applicable Candidate in a closed but not yet reported period
+      // When the publication is edited so that it would no longer be applicable
+      // Then the Candidate must be preserved, not stripped, to protect closed-period numbers
       setupOpenPeriod(scenario, publicationDate.year());
       var publicationFactory = factory.withContributor(verifiedCreatorFrom(nviOrganization));
       setupCandidateMatchingPublication(publicationFactory.getExpandedPublication());
       setupClosedPeriod(scenario, publicationDate.year());
+      var candidateBeforeUpdate =
+          candidateService.getCandidateByPublicationId(publicationFactory.getPublicationId());
 
       var publication = publicationFactory.withPublicationType("ComicBook");
       handleEvaluation(publication);
 
-      var candidate = candidateService.getCandidateByPublicationId(publication.getPublicationId());
-      assertThat(candidate.isApplicable()).isFalse();
+      var candidateAfterUpdate =
+          candidateService.getCandidateByPublicationId(publication.getPublicationId());
+      assertThat(candidateAfterUpdate.isApplicable()).isTrue();
+      assertThat(candidateAfterUpdate.approvals()).isEqualTo(candidateBeforeUpdate.approvals());
+      assertThat(candidateAfterUpdate.revision()).isEqualTo(candidateBeforeUpdate.revision());
+    }
+
+    @Test
+    void shouldMoveExistingClosedPeriodCandidateWhenYearCorrectedToOpenPeriod() {
+      // Given an applicable Candidate in a closed period
+      // When the publication year is corrected to a different, open period
+      // Then the Candidate must be moved and re-evaluated, not frozen
+      var closedYearDate = randomPublicationDateInYear(CURRENT_YEAR);
+      var openYearDate = randomPublicationDateInYear(CURRENT_YEAR + 1);
+      setupOpenPeriod(scenario, closedYearDate.year());
+      setupOpenPeriod(scenario, openYearDate.year());
+      var publicationFactory =
+          factory
+              .withContributor(verifiedCreatorFrom(nviOrganization))
+              .withPublicationDate(closedYearDate);
+      setupCandidateMatchingPublication(publicationFactory.getExpandedPublication());
+      setupClosedPeriod(scenario, closedYearDate.year());
+
+      var movedPublication = publicationFactory.withPublicationDate(openYearDate);
+      handleEvaluation(movedPublication);
+
+      var candidate =
+          candidateService.getCandidateByPublicationId(movedPublication.getPublicationId());
+      assertThat(candidate.isApplicable()).isTrue();
+      assertThat(candidate.publicationDetails().publicationDate()).isEqualTo(openYearDate);
     }
 
     @Test

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -691,10 +691,10 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     }
 
     @Test
-    void shouldMoveExistingClosedPeriodCandidateWhenYearCorrectedToOpenPeriod() {
+    void shouldPreserveExistingClosedPeriodCandidateWhenYearCorrectedToOpenPeriod() {
       // Given an applicable Candidate in a closed period
       // When the publication year is corrected to a different, open period
-      // Then the Candidate must be moved and re-evaluated, not frozen
+      // Then the Candidate must be preserved, not moved out, so closed-period numbers do not change
       var closedYearDate = randomPublicationDateInYear(CURRENT_YEAR);
       var openYearDate = randomPublicationDateInYear(CURRENT_YEAR + 1);
       setupOpenPeriod(scenario, closedYearDate.year());
@@ -705,14 +705,18 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
               .withPublicationDate(closedYearDate);
       setupCandidateMatchingPublication(publicationFactory.getExpandedPublication());
       setupClosedPeriod(scenario, closedYearDate.year());
+      var candidateBeforeUpdate =
+          candidateService.getCandidateByPublicationId(publicationFactory.getPublicationId());
 
       var movedPublication = publicationFactory.withPublicationDate(openYearDate);
       handleEvaluation(movedPublication);
 
-      var candidate =
+      var candidateAfterUpdate =
           candidateService.getCandidateByPublicationId(movedPublication.getPublicationId());
-      assertThat(candidate.isApplicable()).isTrue();
-      assertThat(candidate.publicationDetails().publicationDate()).isEqualTo(openYearDate);
+      assertThat(candidateAfterUpdate.isApplicable()).isTrue();
+      assertThat(candidateAfterUpdate.publicationDetails().publicationDate())
+          .isEqualTo(closedYearDate);
+      assertThat(candidateAfterUpdate.revision()).isEqualTo(candidateBeforeUpdate.revision());
     }
 
     @Test

--- a/integration-tests/src/test/resources/features/Evaluation.feature
+++ b/integration-tests/src/test/resources/features/Evaluation.feature
@@ -69,7 +69,7 @@ Feature: Evaluation of Publications as NVI Candidates
       When the Publication title is changed
       Then the Candidate is not updated
 
-  Rule: Unreported Candidates can be demoted in any period
+  Rule: Unreported Candidates can be demoted in pending or open periods
 
     Background:
       Given an applicable Publication published "this" year
@@ -84,7 +84,11 @@ Feature: Evaluation of Publications as NVI Candidates
         | period_state |
         | OPEN         |
         | PENDING      |
-        | CLOSED       |
+
+    Scenario: Candidate in closed period is not demoted
+      Given the reporting period for "this" year is "CLOSED"
+      When the Publication is updated to be non-applicable
+      Then the Candidate is applicable
 
   Rule: Year transitions follow the target period's rules
 

--- a/integration-tests/src/test/resources/features/Evaluation.feature
+++ b/integration-tests/src/test/resources/features/Evaluation.feature
@@ -107,7 +107,6 @@ Feature: Evaluation of Publications as NVI Candidates
         | period_state |
         | OPEN         |
         | PENDING      |
-        | CLOSED       |
 
     Scenario Outline: Candidate is moved to open period
       Given the reporting period for "this" year is "<period_state>"
@@ -120,7 +119,18 @@ Feature: Evaluation of Publications as NVI Candidates
         | period_state |
         | OPEN         |
         | PENDING      |
-        | CLOSED       |
+
+    Scenario Outline: Candidate in closed period is not moved when year is corrected
+      Given the reporting period for "this" year is "CLOSED"
+      And the reporting period for "next" year is "<target_state>"
+      When the Publication date is changed to "next" year
+      Then the Candidate is not updated
+      And the reporting period for the Candidate is "this" year
+
+      Examples:
+        | target_state |
+        | OPEN         |
+        | PENDING      |
 
     Scenario: Candidate is demoted when moved to closed period
       Given the reporting period for "this" year is "OPEN"

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/exception/IllegalCandidateUpdateException.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/exception/IllegalCandidateUpdateException.java
@@ -2,6 +2,8 @@ package no.sikt.nva.nvi.common.service.exception;
 
 public class IllegalCandidateUpdateException extends RuntimeException {
   public static final String CANDIDATE_IS_REPORTED = "Cannot update reported candidate";
+  public static final String CANDIDATE_IN_CLOSED_PERIOD =
+      "Cannot downgrade candidate in closed period";
   public static final String CANNOT_MOVE_CANDIDATE_TO_CLOSED_PERIOD =
       "Cannot move candidate to closed period";
   public static final String PERIOD_IS_CLOSED = "Target period is closed";

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -5,6 +5,7 @@ import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 import static java.util.function.Predicate.not;
 import static no.sikt.nva.nvi.common.db.ReportStatus.REPORTED;
+import static no.sikt.nva.nvi.common.service.exception.IllegalCandidateUpdateException.CANDIDATE_IN_CLOSED_PERIOD;
 import static no.sikt.nva.nvi.common.service.exception.IllegalCandidateUpdateException.CANDIDATE_IS_REPORTED;
 import static no.sikt.nva.nvi.common.service.exception.IllegalCandidateUpdateException.CANNOT_MOVE_CANDIDATE_TO_CLOSED_PERIOD;
 import static no.sikt.nva.nvi.common.service.exception.IllegalCandidateUpdateException.NO_APPROVAL_FOUND;
@@ -157,6 +158,9 @@ public record Candidate(
   public Candidate updateToNonCandidate() {
     if (isReported()) {
       throw new IllegalCandidateUpdateException(CANDIDATE_IS_REPORTED);
+    }
+    if (isInClosedPeriod()) {
+      throw new IllegalCandidateUpdateException(CANDIDATE_IN_CLOSED_PERIOD);
     }
     return copy()
         .withPeriod(null)

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/model/Candidate.java
@@ -312,7 +312,7 @@ public record Candidate(
     return getPeriod().map(NviPeriod::isOpen).orElse(false);
   }
 
-  private boolean isInClosedPeriod() {
+  public boolean isInClosedPeriod() {
     return getPeriod().map(NviPeriod::isClosed).orElse(false);
   }
 

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/service/CandidateTest.java
@@ -473,6 +473,16 @@ class CandidateTest extends CandidateTestSetup {
   }
 
   @Test
+  void shouldNotAllowDowngradingCandidateInClosedPeriod() {
+    var candidate = setupRandomApplicableCandidate(scenario, CURRENT_YEAR);
+    setupClosedPeriod(scenario, CURRENT_YEAR);
+    var candidateInClosedPeriod = candidateService.getCandidateByIdentifier(candidate.identifier());
+
+    assertThrows(
+        IllegalCandidateUpdateException.class, candidateInClosedPeriod::updateToNonCandidate);
+  }
+
+  @Test
   @Disabled
   void shouldBeAbleToRoundTripWithNoLossOfData() {
     var candidate = setupRandomApplicableCandidate(scenario);


### PR DESCRIPTION
Prevents an approved but not-yet-reported candidate in a closed period from having its approvals changed by a publication edit, so closed-period numbers can never change. Previously the non-candidate decision ran before the closed-period guard, so a publication edit could strip the candidate in place; a year correction could also move it out of the closed period.

- Reorder `EvaluatorService.evaluateCandidacy` so the closed-period guard for an existing candidate runs before the non-candidate and move decisions
- Freeze any existing candidate in a closed period: it is neither stripped in place nor moved out, regardless of how the publication is edited or which year it gets. Correcting the year for such a candidate requires reopening the period
- Add a backstop period guard in `Candidate.updateToNonCandidate()` so the invariant holds even if a caller bypasses the evaluator
- Update `Evaluation.feature`: closed-period candidates are not demoted and not moved; demotion/move apply only in pending or open periods
- Add reproducing tests for the closed-but-not-reported window and the year-correction case

Note: NP-51363 originally allowed moving a closed-period candidate to a new open period. This was intentionally tightened to a full freeze, since such a move also changes the closed period's numbers.

https://sikt.atlassian.net/browse/NP-51363

Changes previous implementation done here https://sikt.atlassian.net/browse/NP-48355