### PR TITLE
fix: Persist creator names in evaluation

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ProcessBatchJobHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ProcessBatchJobHandler.java
@@ -14,8 +14,8 @@ import no.sikt.nva.nvi.events.batch.message.MigrateCandidateMessage;
 import no.sikt.nva.nvi.events.batch.message.RefreshCandidateMessage;
 import no.sikt.nva.nvi.events.batch.message.RefreshPeriodMessage;
 import no.sikt.nva.nvi.events.batch.message.ReportCandidateMessage;
+import no.sikt.nva.nvi.migration.CandidateMigrationService;
 import no.sikt.nva.nvi.migration.MigrationService;
-import no.sikt.nva.nvi.migration.ReportedDateMigrationService;
 import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,7 +31,7 @@ public class ProcessBatchJobHandler implements RequestHandler<SQSEvent, SQSBatch
   public ProcessBatchJobHandler() {
     this(
         CandidateService.defaultCandidateService(),
-        ReportedDateMigrationService.defaultService(),
+        CandidateMigrationService.defaultCandidateMigrationService(),
         NviPeriodService.defaultNviPeriodService());
   }
 

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/CreatorVerificationUtil.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/CreatorVerificationUtil.java
@@ -70,6 +70,7 @@ public final class CreatorVerificationUtil {
       ContributorDto contributor, List<NviOrganization> nviAffiliations) {
     return VerifiedNviCreator.builder()
         .withId(contributor.id())
+        .withName(contributor.name())
         .withNviAffiliations(nviAffiliations)
         .build();
   }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/model/VerifiedNviCreator.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.function.Predicate;
 import no.sikt.nva.nvi.common.service.dto.VerifiedNviCreatorDto;
 
-public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations)
+public record VerifiedNviCreator(URI id, String name, List<NviOrganization> nviAffiliations)
     implements NviCreator {
 
   public static Builder builder() {
@@ -38,6 +38,7 @@ public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations)
   public VerifiedNviCreatorDto toDto() {
     return VerifiedNviCreatorDto.builder()
         .withId(id)
+        .withName(name)
         .withAffiliations(nviAffiliationsIds())
         .build();
   }
@@ -45,6 +46,8 @@ public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations)
   public static final class Builder {
 
     private URI id;
+
+    private String name;
 
     private List<NviOrganization> nviAffiliations;
 
@@ -55,13 +58,18 @@ public record VerifiedNviCreator(URI id, List<NviOrganization> nviAffiliations)
       return this;
     }
 
+    public Builder withName(String name) {
+      this.name = name;
+      return this;
+    }
+
     public Builder withNviAffiliations(List<NviOrganization> nviAffiliations) {
       this.nviAffiliations = nviAffiliations;
       return this;
     }
 
     public VerifiedNviCreator build() {
-      return new VerifiedNviCreator(id, nviAffiliations);
+      return new VerifiedNviCreator(id, name, nviAffiliations);
     }
   }
 }

--- a/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
+++ b/event-handlers/src/test/java/no/sikt/nva/nvi/events/evaluator/EvaluateNviCandidateHandlerTest.java
@@ -482,6 +482,20 @@ class EvaluateNviCandidateHandlerTest extends EvaluationTest {
     }
 
     @Test
+    void shouldPersistNameOfVerifiedNviCreator() {
+      setupOpenPeriod(scenario, publicationDate.year());
+      var verifiedContributor = verifiedCreatorFrom(nviOrganization);
+      var publication = factory.withContributor(verifiedContributor);
+
+      handleEvaluation(publication);
+
+      var candidate = candidateService.getCandidateByPublicationId(publication.getPublicationId());
+      assertThat(candidate.publicationDetails().verifiedCreators())
+          .extracting(VerifiedNviCreatorDto::name)
+          .containsExactly(verifiedContributor.name());
+    }
+
+    @Test
     void shouldIdentifyCandidateWithOnlyUnverifiedNviCreators() {
       setupOpenPeriod(scenario, publicationDate.year());
       var publication = factory.withContributor(unverifiedCreatorFrom(nviOrganization));

--- a/libs/migration-service/src/main/java/no/sikt/nva/nvi/migration/CandidateMigrationService.java
+++ b/libs/migration-service/src/main/java/no/sikt/nva/nvi/migration/CandidateMigrationService.java
@@ -27,10 +27,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Service intended for updating persisted candidates with data from external sources, such as
  * expanded publications stored in S3. This can be used in batch migrations to add missing fields to
- * reported candidates.
+ * reported candidates. Currently, backfills missing verified creator names (NP-51445).
  */
-// TODO: Remove service
-@Deprecated(forRemoval = true)
 public final class CandidateMigrationService implements MigrationService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(CandidateMigrationService.class);

--- a/libs/migration-service/src/main/java/no/sikt/nva/nvi/migration/ReportedDateMigrationService.java
+++ b/libs/migration-service/src/main/java/no/sikt/nva/nvi/migration/ReportedDateMigrationService.java
@@ -11,6 +11,10 @@ import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * @deprecated This backfill migration has been run in prod and can be removed.
+ */
+@Deprecated(forRemoval = true, since = "2026-05-01")
 public class ReportedDateMigrationService implements MigrationService {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ReportedDateMigrationService.class);

--- a/libs/migration-service/src/test/java/no/sikt/nva/nvi/migration/CandidateMigrationServiceTest.java
+++ b/libs/migration-service/src/test/java/no/sikt/nva/nvi/migration/CandidateMigrationServiceTest.java
@@ -28,7 +28,6 @@ import no.sikt.nva.nvi.test.SampleExpandedPublication;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-@Deprecated(forRemoval = true)
 class CandidateMigrationServiceTest {
 
   private TestScenario scenario;

--- a/libs/migration-service/src/test/java/no/sikt/nva/nvi/migration/ReportedDateMigrationServiceTest.java
+++ b/libs/migration-service/src/test/java/no/sikt/nva/nvi/migration/ReportedDateMigrationServiceTest.java
@@ -15,6 +15,7 @@ import no.sikt.nva.nvi.common.service.CandidateService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+@Deprecated(forRemoval = true, since = "2026-05-01")
 class ReportedDateMigrationServiceTest {
 
   private CandidateService candidateService;


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51444

Fixes a bug preventing creator names from being persisted after evaluation and enables an existing migration job to backfill missing data.

Changes:

- [fix: Persist creator names in evaluation](https://github.com/BIBSYSDEV/nva-nvi/pull/784/commits/50d0530ba4a83832d082be68d9154d913f31bd79)
- [chore: Swap default migration service](https://github.com/BIBSYSDEV/nva-nvi/pull/784/commits/38430007384c611d271778e62633f9611e95bd9d)
