### PR TITLE
[np-51491] feat: Persist ORCID for NVI creators

### DIFF
--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/CreatorVerificationUtil.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/evaluator/calculator/CreatorVerificationUtil.java
@@ -64,6 +64,7 @@ public final class CreatorVerificationUtil {
     return new NviCreator(
         contributor.id(),
         contributor.name(),
+        contributor.orcid(),
         contributor.verificationStatus(),
         nviAffiliations.stream().map(Organization::id).toList(),
         creatorOrganizations);

--- a/index-handlers/src/main/java/no/sikt/nva/nvi/index/mapper/ContributorMapper.java
+++ b/index-handlers/src/main/java/no/sikt/nva/nvi/index/mapper/ContributorMapper.java
@@ -26,10 +26,10 @@ import org.slf4j.LoggerFactory;
  * Maps contributors for the index document into two independent lists:
  *
  * <ul>
- *   <li>{@code nviContributors} - one per NVI creator on the frozen Candidate, carrying the
- *       Candidate's affiliations, enriched (name fallback, orcid, role) from the matching
- *       Publication creator when one is found. Indexed even if the Publication no longer has the
- *       creator.
+ *   <li>{@code nviContributors} - one per NVI creator on the frozen Candidate, carrying the name,
+ *       orcid, role and affiliations persisted on the Candidate, with fallback to the matching
+ *       Publication creator for data not yet migrated to the Candidate. Indexed even if the
+ *       Publication no longer has the creator.
  *   <li>{@code contributors} - the full Publication author list as plain {@link Contributor}s
  *       carrying the Publication's current data.
  * </ul>
@@ -65,8 +65,8 @@ final class ContributorMapper {
     return NviContributor.builder()
         .withId(creator.id())
         .withName(extractName(creator, enrichment))
-        .withOrcid(extractOrcid(enrichment))
-        .withRole(extractRole(enrichment))
+        .withOrcid(extractOrcid(creator, enrichment))
+        .withRole(creator.role().value())
         .withAffiliations(buildNviCreatorAffiliations(creator))
         .build();
   }
@@ -86,8 +86,8 @@ final class ContributorMapper {
     return Contributor.builder()
         .withId(contributorDto.id())
         .withName(contributorDto.name())
-        .withOrcid(extractOrcid(contributorDto))
-        .withRole(extractRole(contributorDto))
+        .withOrcid(orcidFromPublication(contributorDto).orElse(null))
+        .withRole(roleFromPublication(contributorDto).orElse(null))
         .withAffiliations(buildSimpleAffiliations(contributorDto))
         .build();
   }
@@ -110,22 +110,25 @@ final class ContributorMapper {
   }
 
   // TODO: NP-51468 - Remove fallback when ORCID is migrated
-  private static String extractOrcid(ContributorDto contributorDto) {
-    return Optional.ofNullable(contributorDto)
-        .map(ContributorDto::orcid)
-        .map(Object::toString)
-        .orElse(null);
+  private static String extractOrcid(NviCreator creator, ContributorDto contributorDto) {
+    return orcidFromCandidate(creator).or(() -> orcidFromPublication(contributorDto)).orElse(null);
   }
 
-  // TODO: NP-51468 - Remove fallback when role is migrated
-  private static String extractRole(ContributorDto contributorDto) {
+  private static Optional<String> orcidFromCandidate(NviCreator creator) {
+    return Optional.ofNullable(creator).map(NviCreator::orcid).map(Object::toString);
+  }
+
+  private static Optional<String> orcidFromPublication(ContributorDto contributorDto) {
+    return Optional.ofNullable(contributorDto).map(ContributorDto::orcid).map(Object::toString);
+  }
+
+  private static Optional<String> roleFromPublication(ContributorDto contributorDto) {
     return Optional.ofNullable(contributorDto)
         .map(ContributorDto::roles)
         .orElse(emptyList())
         .stream()
         .findAny()
-        .map(ContributorRole::value)
-        .orElse(null);
+        .map(ContributorRole::value);
   }
 
   /**

--- a/libs/migration-service/src/main/java/no/sikt/nva/nvi/migration/CandidateMigrationService.java
+++ b/libs/migration-service/src/main/java/no/sikt/nva/nvi/migration/CandidateMigrationService.java
@@ -1,5 +1,7 @@
 package no.sikt.nva.nvi.migration;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 import static java.util.function.Predicate.not;
 import static no.sikt.nva.nvi.common.service.CandidateService.defaultCandidateService;
 import static nva.commons.core.StringUtils.isBlank;
@@ -27,7 +29,8 @@ import org.slf4j.LoggerFactory;
 /**
  * Service intended for updating persisted candidates with data from external sources, such as
  * expanded publications stored in S3. This can be used in batch migrations to add missing fields to
- * reported candidates. Currently, backfills missing verified creator names (NP-51445).
+ * reported candidates. Currently, backfills missing verified creator names (NP-51445) and missing
+ * creator ORCID (NP-51468).
  */
 public final class CandidateMigrationService implements MigrationService {
 
@@ -68,13 +71,14 @@ public final class CandidateMigrationService implements MigrationService {
 
   private static boolean shouldMigrate(Candidate candidate) {
     var details = candidate.publicationDetails();
-    return hasCreatorsWithMissingNames(details.nviCreators());
+    return details.nviCreators().stream()
+        .anyMatch(CandidateMigrationService::hasMissingCreatorData);
   }
 
   private static Candidate addMissingPublicationDetails(
       Candidate candidate, PublicationDto publication) {
     var currentDetails = candidate.publicationDetails();
-    var updatedCreators = addMissingCreatorNames(currentDetails.nviCreators(), publication);
+    var updatedCreators = addMissingCreatorData(currentDetails.nviCreators(), publication);
     var updatedDetails = currentDetails.copy().withNviCreators(updatedCreators).build();
 
     return candidate
@@ -84,20 +88,25 @@ public final class CandidateMigrationService implements MigrationService {
         .build();
   }
 
-  private static boolean hasCreatorsWithMissingNames(Collection<NviCreator> creators) {
-    return creators.stream().anyMatch(CandidateMigrationService::shouldUpdateCreatorName);
+  private static boolean hasMissingCreatorData(NviCreator creator) {
+    return shouldUpdateCreatorName(creator) || shouldUpdateCreatorOrcid(creator);
   }
 
   private static boolean shouldUpdateCreatorName(NviCreator creator) {
     return creator.isVerified() && isBlank(creator.name());
   }
 
-  private static List<NviCreator> addMissingCreatorNames(
+  private static boolean shouldUpdateCreatorOrcid(NviCreator creator) {
+    return creator.isVerified() && isNull(creator.orcid());
+  }
+
+  private static List<NviCreator> addMissingCreatorData(
       Collection<NviCreator> currentCreators, PublicationDto publication) {
     var creatorNames = buildCreatorNameMap(publication);
+    var creatorOrcids = buildCreatorOrcidMap(publication);
 
     return currentCreators.stream()
-        .map(creator -> addNameToCreatorIfMissing(creator, creatorNames))
+        .map(creator -> addMissingCreatorData(creator, creatorNames, creatorOrcids))
         .toList();
   }
 
@@ -109,11 +118,23 @@ public final class CandidateMigrationService implements MigrationService {
         .collect(Collectors.toMap(ContributorDto::id, ContributorDto::name));
   }
 
-  private static NviCreator addNameToCreatorIfMissing(
-      NviCreator creator, Map<URI, String> creatorNamesFromPublication) {
-    var nameFromPublication = creatorNamesFromPublication.get(creator.id());
-    return shouldUpdateCreatorName(creator)
-        ? creator.copy().withName(nameFromPublication).build()
-        : creator;
+  private static Map<URI, URI> buildCreatorOrcidMap(PublicationDto publication) {
+    return publication.contributors().stream()
+        .filter(ContributorDto::isCreator)
+        .filter(ContributorDto::isVerified)
+        .filter(contributor -> nonNull(contributor.orcid()))
+        .collect(Collectors.toMap(ContributorDto::id, ContributorDto::orcid));
+  }
+
+  private static NviCreator addMissingCreatorData(
+      NviCreator creator, Map<URI, String> creatorNames, Map<URI, URI> creatorOrcids) {
+    var updatedCreator = creator.copy();
+    if (shouldUpdateCreatorName(creator)) {
+      updatedCreator.withName(creatorNames.get(creator.id()));
+    }
+    if (shouldUpdateCreatorOrcid(creator)) {
+      updatedCreator.withOrcid(creatorOrcids.get(creator.id()));
+    }
+    return updatedCreator.build();
   }
 }

--- a/libs/migration-service/src/test/java/no/sikt/nva/nvi/migration/CandidateMigrationServiceTest.java
+++ b/libs/migration-service/src/test/java/no/sikt/nva/nvi/migration/CandidateMigrationServiceTest.java
@@ -5,6 +5,7 @@ import static no.sikt.nva.nvi.common.db.DbCandidateFixtures.randomCandidateBuild
 import static no.sikt.nva.nvi.common.db.DbPublicationDetailsFixtures.randomPublicationBuilder;
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.model.ContributorFixtures.mapToContributorDto;
+import static no.sikt.nva.nvi.common.model.ContributorFixtures.randomContributorDtoBuilder;
 import static no.sikt.nva.nvi.common.model.NviCreatorFixtures.verifiedNviCreatorFrom;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationId;
 import static no.sikt.nva.nvi.test.TestConstants.COUNTRY_CODE_NORWAY;
@@ -12,6 +13,7 @@ import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.net.URI;
 import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
@@ -55,7 +57,7 @@ class CandidateMigrationServiceTest {
         publicationFactory.withContributor(mapToContributorDto(creator)).getExpandedPublication();
 
     var affiliations = List.copyOf(creator.getAffiliationIds());
-    var creatorWithoutName = new DbCreator(creator.id(), null, affiliations);
+    var creatorWithoutName = new DbCreator(creator.id(), null, null, affiliations);
     var candidateId =
         createLegacyCandidate(
             publication, builder -> builder.creators(List.of(creatorWithoutName)));
@@ -69,9 +71,48 @@ class CandidateMigrationServiceTest {
   }
 
   @Test
+  void shouldMigrateCreatorOrcid() {
+    var nviOrg = publicationFactory.setupTopLevelOrganization(COUNTRY_CODE_NORWAY, true);
+    var creator = verifiedNviCreatorFrom(nviOrg, nviOrg.id());
+    var publication =
+        publicationFactory.withContributor(mapToContributorDto(creator)).getExpandedPublication();
+
+    var creatorWithoutOrcid =
+        new DbCreator(creator.id(), creator.name(), null, List.copyOf(creator.getAffiliationIds()));
+    var candidateId =
+        createLegacyCandidate(
+            publication, builder -> builder.creators(List.of(creatorWithoutOrcid)));
+
+    migrationService.migrateCandidate(candidateId);
+
+    var updatedCreator = getCreatorById(candidateId, creator.id());
+    assertThat(updatedCreator.orcid()).isEqualTo(creator.orcid());
+  }
+
+  @Test
+  void shouldNotOverwriteExistingCreatorData() {
+    var nviOrg = publicationFactory.setupTopLevelOrganization(COUNTRY_CODE_NORWAY, true);
+    var creator = verifiedNviCreatorFrom(nviOrg, nviOrg.id());
+    var contributorWithDifferentData =
+        randomContributorDtoBuilder(nviOrg).withId(creator.id()).build();
+    var publication =
+        publicationFactory.withContributor(contributorWithDifferentData).getExpandedPublication();
+
+    var candidateId =
+        createLegacyCandidate(
+            publication, builder -> builder.creators(List.of(creator.toDbCreatorType())));
+
+    migrationService.migrateCandidate(candidateId);
+
+    var updatedCreator = getCreatorById(candidateId, creator.id());
+    assertThat(updatedCreator.name()).isEqualTo(creator.name());
+    assertThat(updatedCreator.orcid()).isEqualTo(creator.orcid());
+  }
+
+  @Test
   void shouldPreserveCreatorNotFoundInPublication() {
     var orphanCreatorId = randomUri();
-    var orphanCreator = new DbCreator(orphanCreatorId, null, List.of(randomUri()));
+    var orphanCreator = new DbCreator(orphanCreatorId, null, null, List.of(randomUri()));
 
     var candidateId =
         createLegacyCandidate(
@@ -83,6 +124,14 @@ class CandidateMigrationServiceTest {
     var updatedCandidate = candidateService.getCandidateByIdentifier(candidateId);
     assertThat(updatedCandidate.publicationDetails().nviCreators())
         .anyMatch(creator -> orphanCreatorId.equals(creator.id()));
+  }
+
+  private NviCreator getCreatorById(UUID candidateIdentifier, URI creatorId) {
+    var updatedCandidate = candidateService.getCandidateByIdentifier(candidateIdentifier);
+    return updatedCandidate.publicationDetails().nviCreators().stream()
+        .filter(creator -> creatorId.equals(creator.id()))
+        .findFirst()
+        .orElseThrow();
   }
 
   private UUID createLegacyCandidate(

--- a/libs/publication-service/src/main/resources/nva_normalization.rq
+++ b/libs/publication-service/src/main/resources/nva_normalization.rq
@@ -139,7 +139,11 @@ WHERE {
         FILTER(?otherName > ?contributorName)
       }
     }
-    OPTIONAL { ?personId :orcId ?orcid }
+    # The ORCID is currently stored with the key "orcId" in expanded publications, but we
+    # accept both casing variants in case this is normalized to "orcid" upstream.
+    OPTIONAL { ?personId :orcId ?mixedCaseOrcid }
+    OPTIONAL { ?personId :orcid ?lowerCaseOrcid }
+    BIND(COALESCE(?mixedCaseOrcid, ?lowerCaseOrcid) AS ?orcid)
 
     # Find all valid affiliations for the contributor
     OPTIONAL {

--- a/libs/publication-service/src/main/resources/nva_normalization.rq
+++ b/libs/publication-service/src/main/resources/nva_normalization.rq
@@ -139,7 +139,7 @@ WHERE {
         FILTER(?otherName > ?contributorName)
       }
     }
-    OPTIONAL { ?personId :orcid ?orcid }
+    OPTIONAL { ?personId :orcId ?orcid }
 
     # Find all valid affiliations for the contributor
     OPTIONAL {

--- a/libs/publication-service/src/main/resources/publication_frame.json
+++ b/libs/publication-service/src/main/resources/publication_frame.json
@@ -49,8 +49,7 @@
       "@type": "xsd:dateTime"
     },
     "orcid": {
-      "@id": "orcid",
-      "@type": "@id"
+      "@id": "orcid"
     },
     "organization": {
       "@id": "organization",

--- a/libs/publication-service/src/test/java/no/sikt/nva/nvi/publication/PublicationLoaderServiceTest.java
+++ b/libs/publication-service/src/test/java/no/sikt/nva/nvi/publication/PublicationLoaderServiceTest.java
@@ -13,6 +13,7 @@ import static no.sikt.nva.nvi.common.examples.ExamplePublications.EXAMPLE_PUBLIC
 import static no.sikt.nva.nvi.common.examples.ExamplePublications.EXAMPLE_WITH_DUPLICATE_DATE;
 import static no.sikt.nva.nvi.common.examples.ExamplePublications.EXAMPLE_WITH_NO_TITLE;
 import static no.sikt.nva.nvi.common.examples.ExamplePublications.EXAMPLE_WITH_TWO_TITLES;
+import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static nva.commons.core.ioutils.IoUtils.stringFromResources;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
@@ -21,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
@@ -192,6 +194,30 @@ class PublicationLoaderServiceTest {
 
     assertThat(logRecorder.asString())
         .doesNotContain("Should contain at least one verified or unverified contributor");
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"orcId", "orcid"})
+  void shouldParseContributorOrcidRegardlessOfKeyCasing(String orcidKey) throws IOException {
+    var expectedOrcid = URI.create("https://orcid.org/0000-0001-2345-6789");
+    var document = withOrcidOnAllContributors(orcidKey, expectedOrcid);
+
+    var publication = parseExampleDocument(EXAMPLE_PUBLICATION_1_PATH, document);
+
+    assertThat(publication.contributors())
+        .isNotEmpty()
+        .allSatisfy(contributor -> assertThat(contributor.orcid()).isEqualTo(expectedOrcid));
+  }
+
+  private static String withOrcidOnAllContributors(String orcidKey, URI orcid) throws IOException {
+    var rawDocument = stringFromResources(Path.of(EXAMPLE_PUBLICATION_1_PATH));
+    var document = (ObjectNode) dtoObjectMapper.readTree(rawDocument);
+    var contributors = document.at("/body/entityDescription/contributors");
+    for (var contributor : contributors) {
+      var identity = (ObjectNode) contributor.get("identity");
+      identity.put(orcidKey, orcid.toString());
+    }
+    return dtoObjectMapper.writeValueAsString(document);
   }
 
   @Test

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -541,7 +541,7 @@ public final class CandidateDao extends Dao {
 
   @JsonSerialize
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
-  @DynamoDbImmutable(builder = DbCreator.Builder.class)
+  @DynamoDbImmutable(builder = DbUnverifiedCreator.Builder.class)
   public record DbUnverifiedCreator(String creatorName, List<URI> affiliations)
       implements DbCreatorType {
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateDao.java
@@ -485,6 +485,8 @@ public final class CandidateDao extends Dao {
   public sealed interface DbCreatorType permits DbCreator, DbUnverifiedCreator {
     String creatorName();
 
+    URI orcid();
+
     List<URI> affiliations();
 
     DbCreatorType copy();
@@ -493,7 +495,7 @@ public final class CandidateDao extends Dao {
   @JsonSerialize
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
   @DynamoDbImmutable(builder = DbCreator.Builder.class)
-  public record DbCreator(URI creatorId, String creatorName, List<URI> affiliations)
+  public record DbCreator(URI creatorId, String creatorName, URI orcid, List<URI> affiliations)
       implements DbCreatorType {
 
     public static Builder builder() {
@@ -506,6 +508,7 @@ public final class CandidateDao extends Dao {
       return builder()
           .creatorId(creatorId)
           .creatorName(creatorName)
+          .orcid(orcid)
           .affiliations(new ArrayList<>(affiliations))
           .build();
     }
@@ -514,6 +517,7 @@ public final class CandidateDao extends Dao {
 
       private URI creatorId;
       private String creatorName;
+      private URI orcid;
       private List<URI> affiliations;
 
       private Builder() {}
@@ -528,13 +532,18 @@ public final class CandidateDao extends Dao {
         return this;
       }
 
+      public Builder orcid(URI orcid) {
+        this.orcid = orcid;
+        return this;
+      }
+
       public Builder affiliations(List<URI> affiliations) {
         this.affiliations = affiliations;
         return this;
       }
 
       public DbCreator build() {
-        return new DbCreator(creatorId, creatorName, affiliations);
+        return new DbCreator(creatorId, creatorName, orcid, affiliations);
       }
     }
   }
@@ -542,7 +551,7 @@ public final class CandidateDao extends Dao {
   @JsonSerialize
   @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type")
   @DynamoDbImmutable(builder = DbUnverifiedCreator.Builder.class)
-  public record DbUnverifiedCreator(String creatorName, List<URI> affiliations)
+  public record DbUnverifiedCreator(String creatorName, URI orcid, List<URI> affiliations)
       implements DbCreatorType {
 
     public static Builder builder() {
@@ -552,12 +561,17 @@ public final class CandidateDao extends Dao {
     @Override
     @DynamoDbIgnore
     public DbUnverifiedCreator copy() {
-      return builder().creatorName(creatorName).affiliations(new ArrayList<>(affiliations)).build();
+      return builder()
+          .creatorName(creatorName)
+          .orcid(orcid)
+          .affiliations(new ArrayList<>(affiliations))
+          .build();
     }
 
     public static final class Builder {
 
       private String creatorName;
+      private URI builderOrcid;
       private List<URI> builderAffiliations;
 
       private Builder() {}
@@ -567,13 +581,18 @@ public final class CandidateDao extends Dao {
         return this;
       }
 
+      public Builder orcid(URI orcid) {
+        this.builderOrcid = orcid;
+        return this;
+      }
+
       public Builder affiliations(List<URI> affiliations) {
         this.builderAffiliations = affiliations;
         return this;
       }
 
       public DbUnverifiedCreator build() {
-        return new DbUnverifiedCreator(creatorName, builderAffiliations);
+        return new DbUnverifiedCreator(creatorName, builderOrcid, builderAffiliations);
       }
     }
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/NviCreator.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/model/NviCreator.java
@@ -17,6 +17,7 @@ import no.sikt.nva.nvi.common.client.model.Organization;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCreator;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbCreatorType;
 import no.sikt.nva.nvi.common.db.CandidateDao.DbUnverifiedCreator;
+import no.sikt.nva.nvi.common.dto.ContributorRole;
 import no.sikt.nva.nvi.common.dto.VerificationStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -32,6 +33,7 @@ import org.slf4j.LoggerFactory;
  *
  * @param id Unique ID as a URI, which can be dereferenced for more information.
  * @param name The name of the person, which is used for display purposes.
+ * @param orcid The ORCID of the person, if known.
  * @param verificationStatus The verification status of the person, which indicates whether their
  *     identity is confirmed.
  * @param nviAffiliations A collection of organizations that the person is directly affiliated with.
@@ -42,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public record NviCreator(
     URI id,
     String name,
+    URI orcid,
     VerificationStatus verificationStatus,
     Collection<URI> nviAffiliations,
     Collection<Organization> topLevelNviOrganizations) {
@@ -65,6 +68,7 @@ public record NviCreator(
     return builder()
         .withId(id)
         .withName(name)
+        .withOrcid(orcid)
         .withVerificationStatus(verificationStatus)
         .withNviAffiliations(nviAffiliations)
         .withTopLevelNviOrganizations(topLevelNviOrganizations);
@@ -93,9 +97,18 @@ public record NviCreator(
     return new NviCreator(
         creatorId,
         creator.creatorName(),
+        creator.orcid(),
         verificationStatus,
         creator.affiliations(),
         affiliatedTopLevelOrganizations);
+  }
+
+  /**
+   * The role of the person on the publication. An NviCreator is by definition a 'Creator' (i.e.
+   * author or equivalent), so this is a constant value.
+   */
+  public ContributorRole role() {
+    return ContributorRole.CREATOR;
   }
 
   public Set<URI> getAffiliationIds() {
@@ -162,14 +175,15 @@ public record NviCreator(
 
   public DbCreatorType toDbCreatorType() {
     if (isVerified()) {
-      return new DbCreator(id, name, List.copyOf(nviAffiliations));
+      return new DbCreator(id, name, orcid, List.copyOf(nviAffiliations));
     }
-    return new DbUnverifiedCreator(name, List.copyOf(nviAffiliations));
+    return new DbUnverifiedCreator(name, orcid, List.copyOf(nviAffiliations));
   }
 
   public static final class Builder {
     private URI id;
     private String name;
+    private URI orcid;
     private VerificationStatus verificationStatus;
     private Collection<URI> nviAffiliations;
     private Collection<Organization> topLevelNviOrganizations;
@@ -183,6 +197,11 @@ public record NviCreator(
 
     public Builder withName(String name) {
       this.name = name;
+      return this;
+    }
+
+    public Builder withOrcid(URI orcid) {
+      this.orcid = orcid;
       return this;
     }
 
@@ -203,7 +222,7 @@ public record NviCreator(
 
     public NviCreator build() {
       return new NviCreator(
-          id, name, verificationStatus, nviAffiliations, topLevelNviOrganizations);
+          id, name, orcid, verificationStatus, nviAffiliations, topLevelNviOrganizations);
     }
   }
 }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/SampleExpandedPublicationFactory.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/SampleExpandedPublicationFactory.java
@@ -183,14 +183,13 @@ public class SampleExpandedPublicationFactory {
     if (nonNull(additionalNames)) {
       names.addAll(List.of(additionalNames));
     }
-    var orcId = randomUri();
     for (var role : contributor.roles()) {
       var expandedContributor =
           SampleExpandedContributor.builder()
               .withId(contributor.id())
               .withNames(names)
               .withRole(role.getValue())
-              .withOrcId(orcId)
+              .withOrcId(contributor.orcid())
               .withVerificationStatus(contributor.verificationStatus().getValue())
               .withAffiliations(expandedAffiliations)
               .build();

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbCandidateFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbCandidateFixtures.java
@@ -7,6 +7,7 @@ import static no.sikt.nva.nvi.common.db.DbPublicationDetailsFixtures.getExpected
 import static no.sikt.nva.nvi.common.db.DbPublicationDetailsFixtures.randomPublicationBuilder;
 import static no.sikt.nva.nvi.common.model.NviCreatorFixtures.mapToDbCreators;
 import static no.sikt.nva.nvi.test.TestUtils.randomName;
+import static no.sikt.nva.nvi.test.TestUtils.randomOrcid;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 
@@ -76,6 +77,7 @@ public final class DbCandidateFixtures {
   private static CandidateDao.DbCreator randomDbCreator(URI organizationId) {
     return CandidateDao.DbCreator.builder()
         .creatorId(randomUri())
+        .orcid(randomOrcid())
         .affiliations(List.of(organizationId))
         .build();
   }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPublicationDetailsFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/db/DbPublicationDetailsFixtures.java
@@ -7,6 +7,7 @@ import static no.sikt.nva.nvi.common.model.NviCreatorFixtures.mapToDbCreators;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.mapToDbPublicationDate;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDateInCurrentYear;
 import static no.sikt.nva.nvi.test.TestUtils.generatePublicationId;
+import static no.sikt.nva.nvi.test.TestUtils.randomOrcid;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 
 import java.net.URI;
@@ -41,6 +42,7 @@ public final class DbPublicationDetailsFixtures {
             List.of(
                 DbCreator.builder()
                     .creatorId(creatorId)
+                    .orcid(randomOrcid())
                     .affiliations(List.of(organizationId))
                     .build()));
   }

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/examples/ExampleContributors.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/examples/ExampleContributors.java
@@ -44,6 +44,7 @@ public class ExampleContributors {
       ContributorDto.builder()
           .withId(URI.create("https://api.sandbox.nva.aws.unit.no/cristin/person/1685065"))
           .withName("Donald Duck")
+          .withOrcid(URI.create("https://fake.orcid.org/1234-5678-1234-5678"))
           .withRole(ROLE_CREATOR)
           .withVerificationStatus(STATUS_VERIFIED)
           .withAffiliations(List.of(TOP_LEVEL_ORGANIZATION_SIKT))

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/ContributorFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/ContributorFixtures.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.common.model;
 
 import static no.sikt.nva.nvi.test.TestUtils.randomContributorId;
 import static no.sikt.nva.nvi.test.TestUtils.randomName;
+import static no.sikt.nva.nvi.test.TestUtils.randomOrcid;
 
 import java.util.List;
 import no.sikt.nva.nvi.common.client.model.Organization;
@@ -21,6 +22,7 @@ public final class ContributorFixtures {
     return ContributorDto.builder()
         .withId(randomContributorId())
         .withName(randomName())
+        .withOrcid(randomOrcid())
         .withRole(ROLE_CREATOR)
         .withVerificationStatus(STATUS_VERIFIED)
         .withAffiliations(List.of(affiliations));
@@ -45,6 +47,7 @@ public final class ContributorFixtures {
     return ContributorDto.builder()
         .withId(nviCreator.id())
         .withName(nviCreator.name())
+        .withOrcid(nviCreator.orcid())
         .withVerificationStatus(nviCreator.verificationStatus())
         .withRole(ROLE_CREATOR)
         .withAffiliations(affiliations)

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/NviCreatorFixtures.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/model/NviCreatorFixtures.java
@@ -6,6 +6,7 @@ import static no.sikt.nva.nvi.common.model.ContributorFixtures.STATUS_VERIFIED;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomTopLevelOrganization;
 import static no.sikt.nva.nvi.test.TestUtils.randomContributorId;
 import static no.sikt.nva.nvi.test.TestUtils.randomName;
+import static no.sikt.nva.nvi.test.TestUtils.randomOrcid;
 
 import java.net.URI;
 import java.util.Collection;
@@ -27,6 +28,7 @@ public final class NviCreatorFixtures {
     return NviCreator.builder()
         .withId(randomContributorId())
         .withName(randomName())
+        .withOrcid(randomOrcid())
         .withVerificationStatus(STATUS_VERIFIED)
         .withNviAffiliations(List.of(affiliationId))
         .withTopLevelNviOrganizations(List.of(institution));
@@ -45,6 +47,7 @@ public final class NviCreatorFixtures {
     return new NviCreator(
         randomContributorId(),
         randomName(),
+        randomOrcid(),
         STATUS_VERIFIED,
         List.of(affiliations),
         List.of(topLevelOrganization));
@@ -59,6 +62,7 @@ public final class NviCreatorFixtures {
     return new NviCreator(
         null,
         randomName(),
+        null,
         STATUS_UNVERIFIED,
         List.of(affiliations),
         List.of(topLevelOrganization));

--- a/nvi-commons/src/testFixtures/resources/expandedPublications/validNviCandidate2.json
+++ b/nvi-commons/src/testFixtures/resources/expandedPublications/validNviCandidate2.json
@@ -89,6 +89,7 @@
           "id" : "https://api.sandbox.nva.aws.unit.no/cristin/person/1685065",
           "type" : "Identity",
           "name" : "Donald Duck",
+          "orcId" : "https://fake.orcid.org/1234-5678-1234-5678",
           "verificationStatus" : "Verified"
         },
         "role" : {
@@ -296,6 +297,7 @@
           "id" : "https://api.sandbox.nva.aws.unit.no/cristin/person/1685065",
           "type" : "Identity",
           "name" : "Donald Duck",
+          "orcId" : "https://fake.orcid.org/1234-5678-1234-5678",
           "verificationStatus" : "Verified"
         },
         "role" : {

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestConstants.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestConstants.java
@@ -45,7 +45,7 @@ public final class TestConstants {
 
   public static final int ONE = 1;
   public static final String AFFILIATIONS_FIELD = "affiliations";
-  public static final String ORCID_FIELD = "orcid";
+  public static final String ORCID_FIELD = "orcId";
   public static final String VERIFICATION_STATUS_FIELD = "verificationStatus";
   public static final String MAIN_TITLE_FIELD = "mainTitle";
   public static final String PUBLICATION_DATE_FIELD = "publicationDate";

--- a/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
+++ b/nvi-test/src/main/java/no/sikt/nva/nvi/test/TestUtils.java
@@ -107,6 +107,12 @@ public final class TestUtils {
         .getUri();
   }
 
+  public static URI randomOrcid() {
+    return UriWrapper.fromHost("https://fake.orcid.org")
+        .addChild(FAKER.numerify("####-####-####-####"))
+        .getUri();
+  }
+
   public static BigDecimal randomBigDecimal() {
     return randomBigDecimal(SCALE);
   }


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51491

Adds ORCID to the data we persist about NVI creators and sets the `role` as a static field (since it's the same for all persisted contributors). Expands the existing migration code so that we can backfill the `orcid` field based on the current publication state. Note that this adds data to the record that may not have existed at the time the candidate was reported.


Changes:

- [fix: Use correct field name when parsing ORCID](https://github.com/BIBSYSDEV/nva-nvi/pull/791/commits/a3d2ddf36a9101a7a6c8ea00410e75ad27d3b2c2)
- [fix: Use correct builder for DbUnverifiedCreator](https://github.com/BIBSYSDEV/nva-nvi/pull/791/commits/ff89212dd32955a62c9450107da3fb1b015321be)
- [feat: Persist ORCID for NVI creators](https://github.com/BIBSYSDEV/nva-nvi/pull/791/commits/87116fa9c69b1075715ad7be3e0836c0aacef833)
