### PR TITLE
refactor: Extract fetching of environment variables

### DIFF
--- a/.run/Template Cucumber Java.run.xml
+++ b/.run/Template Cucumber Java.run.xml
@@ -7,7 +7,6 @@
       <env name="COGNITO_AUTHORIZER_URLS" value="api.fake.nva.aws.unit.no/auth" />
       <env name="CUSTOM_DOMAIN_BASE_PATH" value="scientific-index" />
       <env name="EXPANDED_RESOURCES_BUCKET" value="testBucket" />
-      <env name="NVI_TABLE_NAME" value="some-table" />
       <env name="SEARCH_INFRASTRUCTURE_AUTH_URI" value="localhost" />
       <env name="SEARCH_INFRASTRUCTURE_API_HOST" value="localhost" />
       <env name="UPSERT_CANDIDATE_DLQ_QUEUE_URL" value="http://localhost:3000/upsert-candidate-DLQ" />

--- a/build-logic/src/main/groovy/nva.nvi.java-conventions.gradle
+++ b/build-logic/src/main/groovy/nva.nvi.java-conventions.gradle
@@ -30,7 +30,6 @@ test {
     environment("COGNITO_AUTHORIZER_URLS", "http://localhost:3000")
     environment("CUSTOM_DOMAIN_BASE_PATH", "scientific-index")
     environment("LOG_LEVEL", "info")
-    environment("NVI_TABLE_NAME", "some-table")
     environment("SEARCH_INFRASTRUCTURE_API_HOST", "localhost")
     environment("SEARCH_INFRASTRUCTURE_AUTH_URI", "localhost")
 }

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/batch/ReEvaluateNviCandidatesHandler.java
@@ -1,7 +1,7 @@
 package no.sikt.nva.nvi.events.batch;
 
 import static java.util.Objects.isNull;
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.db.CandidateRepository.defaultCandidateRepository;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
@@ -54,7 +54,7 @@ public class ReEvaluateNviCandidatesHandler extends EventHandler<ReEvaluateReque
   @JacocoGenerated
   public ReEvaluateNviCandidatesHandler() {
     this(
-        new CandidateRepository(defaultDynamoClient()),
+        defaultCandidateRepository(),
         new NviQueueClient(),
         new Environment(),
         defaultEventBridgeClient());

--- a/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
+++ b/event-handlers/src/main/java/no/sikt/nva/nvi/events/cristin/CristinNviReportEventConsumer.java
@@ -1,7 +1,7 @@
 package no.sikt.nva.nvi.events.cristin;
 
 import static java.util.Collections.emptyList;
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.db.CandidateRepository.defaultCandidateRepository;
 import static no.sikt.nva.nvi.common.utils.Validator.isMissing;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static nva.commons.core.StringUtils.isNotBlank;
@@ -52,10 +52,7 @@ public class CristinNviReportEventConsumer implements RequestHandler<SQSEvent, V
 
   @JacocoGenerated
   public CristinNviReportEventConsumer() {
-    this(
-        new CandidateRepository(defaultDynamoClient()),
-        S3Driver.defaultS3Client().build(),
-        new Environment());
+    this(defaultCandidateRepository(), S3Driver.defaultS3Client().build(), new Environment());
   }
 
   public CristinNviReportEventConsumer(

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/CandidateRepository.java
@@ -10,7 +10,7 @@ import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_PUBLICATI
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SECONDARY_INDEX_YEAR_HASH_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SORT_KEY;
-import static no.sikt.nva.nvi.common.utils.ApplicationConstants.NVI_TABLE_NAME;
+import static no.sikt.nva.nvi.common.utils.ApplicationConstants.getTableName;
 import static no.sikt.nva.nvi.common.utils.Validator.hasElements;
 import static software.amazon.awssdk.enhanced.dynamodb.TableSchema.fromImmutableClass;
 import static software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional.keyEqualTo;
@@ -28,6 +28,8 @@ import no.sikt.nva.nvi.common.db.CandidateDao.DbCandidate;
 import no.sikt.nva.nvi.common.db.model.TableScanRequest;
 import no.sikt.nva.nvi.common.db.model.YearQueryRequest;
 import no.sikt.nva.nvi.common.model.ListingResult;
+import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
@@ -56,18 +58,25 @@ public class CandidateRepository extends DynamoRepository {
   protected final DynamoDbTable<NviPeriodDao> periodTable;
   private final DynamoDbIndex<CandidateDao> publicationIdIndex;
   private final DynamoDbIndex<CandidateDao> yearIndex;
+  private final String tableName;
 
-  public CandidateRepository(DynamoDbClient client) {
+  public CandidateRepository(DynamoDbClient client, Environment environment) {
     super(client);
-    this.candidateTable = this.client.table(NVI_TABLE_NAME, fromImmutableClass(CandidateDao.class));
+    this.tableName = getTableName(environment);
+    this.candidateTable = this.client.table(tableName, fromImmutableClass(CandidateDao.class));
     this.uniquenessTable =
-        this.client.table(NVI_TABLE_NAME, fromImmutableClass(CandidateUniquenessEntryDao.class));
+        this.client.table(tableName, fromImmutableClass(CandidateUniquenessEntryDao.class));
     this.publicationIdIndex = this.candidateTable.index(SECONDARY_INDEX_PUBLICATION_ID);
     this.yearIndex = this.candidateTable.index(SECONDARY_INDEX_YEAR);
     this.approvalStatusTable =
-        this.client.table(NVI_TABLE_NAME, fromImmutableClass(ApprovalStatusDao.class));
-    this.noteTable = this.client.table(NVI_TABLE_NAME, fromImmutableClass(NoteDao.class));
-    this.periodTable = this.client.table(NVI_TABLE_NAME, fromImmutableClass(NviPeriodDao.class));
+        this.client.table(tableName, fromImmutableClass(ApprovalStatusDao.class));
+    this.noteTable = this.client.table(tableName, fromImmutableClass(NoteDao.class));
+    this.periodTable = this.client.table(tableName, fromImmutableClass(NviPeriodDao.class));
+  }
+
+  @JacocoGenerated
+  public static CandidateRepository defaultCandidateRepository() {
+    return new CandidateRepository(defaultDynamoClient(), new Environment());
   }
 
   public ListingResult<UUID> weaklyConsistentCandidateScan(TableScanRequest requestParameters) {
@@ -76,9 +85,9 @@ public class CandidateRepository extends DynamoRepository {
     return mapToListingResult(scanResponse.lastEvaluatedKey(), scanResponse.items());
   }
 
-  private static ScanRequest createCandidateScanRequest(TableScanRequest request) {
+  private ScanRequest createCandidateScanRequest(TableScanRequest request) {
     return ScanRequest.builder()
-        .tableName(NVI_TABLE_NAME)
+        .tableName(tableName)
         .filterExpression("begins_with(#pk, :prefix) AND begins_with(#sk, :prefix)")
         .expressionAttributeNames(Map.of("#pk", HASH_KEY, "#sk", SORT_KEY))
         .expressionAttributeValues(Map.of(":prefix", AttributeValue.fromS(CandidateDao.TYPE)))
@@ -96,9 +105,9 @@ public class CandidateRepository extends DynamoRepository {
     return mapToListingResult(queryResponse.lastEvaluatedKey(), queryResponse.items());
   }
 
-  private static QueryRequest createYearQueryRequest(YearQueryRequest request) {
+  private QueryRequest createYearQueryRequest(YearQueryRequest request) {
     return QueryRequest.builder()
-        .tableName(NVI_TABLE_NAME)
+        .tableName(tableName)
         .indexName(SECONDARY_INDEX_YEAR)
         .keyConditionExpression("#year = :year")
         .expressionAttributeNames(Map.of("#year", SECONDARY_INDEX_YEAR_HASH_KEY))
@@ -313,7 +322,7 @@ public class CandidateRepository extends DynamoRepository {
   private QueryRequest getCandidateAggregateRequest(UUID candidateId) {
     var candidateKey = CandidateDao.createPartitionKey(candidateId.toString());
     return QueryRequest.builder()
-        .tableName(NVI_TABLE_NAME)
+        .tableName(tableName)
         .keyConditionExpression("#pk = :pk")
         .expressionAttributeNames(Map.of("#pk", HASH_KEY))
         .expressionAttributeValues(Map.of(":pk", AttributeValue.builder().s(candidateKey).build()))

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/DynamoRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/DynamoRepository.java
@@ -3,11 +3,12 @@ package no.sikt.nva.nvi.common.db;
 import static java.util.Objects.isNull;
 import static no.sikt.nva.nvi.common.DatabaseConstants.HASH_KEY;
 import static no.sikt.nva.nvi.common.DatabaseConstants.SORT_KEY;
-import static no.sikt.nva.nvi.common.utils.ApplicationConstants.REGION;
+import static no.sikt.nva.nvi.common.utils.ApplicationConstants.getRegion;
 
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import no.sikt.nva.nvi.common.exceptions.TransactionException;
+import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,10 +94,11 @@ public class DynamoRepository {
 
   @JacocoGenerated
   public static DynamoDbClient defaultDynamoClient() {
+    var environment = new Environment();
     return DynamoDbClient.builder()
         .httpClient(UrlConnectionHttpClient.create())
         .credentialsProvider(DefaultCredentialsProvider.builder().build())
-        .region(REGION)
+        .region(getRegion(environment))
         .build();
   }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/PeriodRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/PeriodRepository.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import nva.commons.core.Environment;
-import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -25,11 +24,6 @@ public class PeriodRepository extends DynamoRepository {
   public PeriodRepository(DynamoDbClient client, Environment environment) {
     super(client);
     this.nviPeriodTable = this.client.table(getTableName(environment), NviPeriodDao.TABLE_SCHEMA);
-  }
-
-  @JacocoGenerated
-  public static PeriodRepository defaultPeriodRepository() {
-    return new PeriodRepository(defaultDynamoClient(), new Environment());
   }
 
   public void create(NviPeriodDao period) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/PeriodRepository.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/db/PeriodRepository.java
@@ -1,10 +1,12 @@
 package no.sikt.nva.nvi.common.db;
 
-import static no.sikt.nva.nvi.common.utils.ApplicationConstants.NVI_TABLE_NAME;
+import static no.sikt.nva.nvi.common.utils.ApplicationConstants.getTableName;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import nva.commons.core.Environment;
+import nva.commons.core.JacocoGenerated;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
@@ -20,9 +22,14 @@ public class PeriodRepository extends DynamoRepository {
   private static final Logger LOGGER = LoggerFactory.getLogger(PeriodRepository.class);
   protected final DynamoDbTable<NviPeriodDao> nviPeriodTable;
 
-  public PeriodRepository(DynamoDbClient client) {
+  public PeriodRepository(DynamoDbClient client, Environment environment) {
     super(client);
-    this.nviPeriodTable = this.client.table(NVI_TABLE_NAME, NviPeriodDao.TABLE_SCHEMA);
+    this.nviPeriodTable = this.client.table(getTableName(environment), NviPeriodDao.TABLE_SCHEMA);
+  }
+
+  @JacocoGenerated
+  public static PeriodRepository defaultPeriodRepository() {
+    return new PeriodRepository(defaultDynamoClient(), new Environment());
   }
 
   public void create(NviPeriodDao period) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NviNotificationClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/notification/NviNotificationClient.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.common.notification;
 
 import java.time.Duration;
 import no.sikt.nva.nvi.common.utils.ApplicationConstants;
+import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -38,7 +39,7 @@ public class NviNotificationClient implements NotificationClient<NviPublishMessa
   @JacocoGenerated
   private static SnsClient defaultSnsClient() {
     return SnsClient.builder()
-        .region(ApplicationConstants.REGION)
+        .region(ApplicationConstants.getRegion(new Environment()))
         .httpClient(httpClientForConcurrentQueries())
         .build();
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/queue/NviQueueClient.java
@@ -8,6 +8,7 @@ import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import no.sikt.nva.nvi.common.utils.ApplicationConstants;
+import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
@@ -84,7 +85,7 @@ public class NviQueueClient implements QueueClient {
   @JacocoGenerated
   protected static SqsClient defaultSqsClient() {
     return SqsClient.builder()
-        .region(ApplicationConstants.REGION)
+        .region(ApplicationConstants.getRegion(new Environment()))
         .httpClient(httpClientForConcurrentQueries())
         .build();
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/ApprovalService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/ApprovalService.java
@@ -1,7 +1,7 @@
 package no.sikt.nva.nvi.common.service;
 
 import static java.util.Collections.emptyList;
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.db.CandidateRepository.defaultCandidateRepository;
 
 import java.util.List;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -27,8 +27,7 @@ public class ApprovalService {
 
   @JacocoGenerated
   public static ApprovalService defaultApprovalService() {
-    var dynamoClient = defaultDynamoClient();
-    return new ApprovalService(new CandidateRepository(dynamoClient));
+    return new ApprovalService(defaultCandidateRepository());
   }
 
   public void updateApproval(

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
@@ -2,7 +2,8 @@ package no.sikt.nva.nvi.common.service;
 
 import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.db.CandidateRepository.defaultCandidateRepository;
+import static no.sikt.nva.nvi.common.db.PeriodRepository.defaultPeriodRepository;
 import static no.sikt.nva.nvi.common.service.NviPeriodService.findByPublishingYear;
 import static no.sikt.nva.nvi.common.service.model.Candidate.getApprovalsToDelete;
 import static no.sikt.nva.nvi.common.service.model.Candidate.getUpdatedInstitutionPoints;
@@ -49,11 +50,8 @@ public class CandidateService {
 
   @JacocoGenerated
   public static CandidateService defaultCandidateService() {
-    var dynamoClient = defaultDynamoClient();
     return new CandidateService(
-        new Environment(),
-        new PeriodRepository(dynamoClient),
-        new CandidateRepository(dynamoClient));
+        new Environment(), defaultPeriodRepository(), defaultCandidateRepository());
   }
 
   public void upsertCandidate(UpsertNviCandidateRequest request) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
@@ -2,8 +2,7 @@ package no.sikt.nva.nvi.common.service;
 
 import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
-import static no.sikt.nva.nvi.common.db.CandidateRepository.defaultCandidateRepository;
-import static no.sikt.nva.nvi.common.db.PeriodRepository.defaultPeriodRepository;
+import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
 import static no.sikt.nva.nvi.common.service.NviPeriodService.findByPublishingYear;
 import static no.sikt.nva.nvi.common.service.model.Candidate.getApprovalsToDelete;
 import static no.sikt.nva.nvi.common.service.model.Candidate.getUpdatedInstitutionPoints;
@@ -50,8 +49,12 @@ public class CandidateService {
 
   @JacocoGenerated
   public static CandidateService defaultCandidateService() {
+    var environment = new Environment();
+    var dynamoClient = defaultDynamoClient();
     return new CandidateService(
-        new Environment(), defaultPeriodRepository(), defaultCandidateRepository());
+        new Environment(),
+        new PeriodRepository(dynamoClient, environment),
+        new CandidateRepository(dynamoClient, environment));
   }
 
   public void upsertCandidate(UpsertNviCandidateRequest request) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NoteService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NoteService.java
@@ -1,7 +1,7 @@
 package no.sikt.nva.nvi.common.service;
 
 import static java.util.Collections.emptyList;
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.db.CandidateRepository.defaultCandidateRepository;
 
 import java.util.List;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
@@ -23,8 +23,7 @@ public class NoteService {
 
   @JacocoGenerated
   public static NoteService defaultNoteService() {
-    var dynamoClient = defaultDynamoClient();
-    return new NoteService(new CandidateRepository(dynamoClient));
+    return new NoteService(defaultCandidateRepository());
   }
 
   public void createNote(Candidate candidate, CreateNoteRequest request) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviPeriodService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviPeriodService.java
@@ -1,6 +1,6 @@
 package no.sikt.nva.nvi.common.service;
 
-import static no.sikt.nva.nvi.common.db.PeriodRepository.defaultPeriodRepository;
+import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
 
 import java.net.URI;
 import java.util.Collection;
@@ -35,7 +35,9 @@ public class NviPeriodService {
 
   @JacocoGenerated
   public static NviPeriodService defaultNviPeriodService() {
-    return new NviPeriodService(new Environment(), defaultPeriodRepository());
+    var environment = new Environment();
+    return new NviPeriodService(
+        environment, new PeriodRepository(defaultDynamoClient(), environment));
   }
 
   public void create(CreatePeriodRequest request) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviPeriodService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/NviPeriodService.java
@@ -1,6 +1,6 @@
 package no.sikt.nva.nvi.common.service;
 
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.db.PeriodRepository.defaultPeriodRepository;
 
 import java.net.URI;
 import java.util.Collection;
@@ -35,8 +35,7 @@ public class NviPeriodService {
 
   @JacocoGenerated
   public static NviPeriodService defaultNviPeriodService() {
-    var dynamoClient = defaultDynamoClient();
-    return new NviPeriodService(new Environment(), new PeriodRepository(dynamoClient));
+    return new NviPeriodService(new Environment(), defaultPeriodRepository());
   }
 
   public void create(CreatePeriodRequest request) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/ApplicationConstants.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/ApplicationConstants.java
@@ -11,9 +11,6 @@ import software.amazon.awssdk.regions.Region;
 @JacocoGenerated
 public final class ApplicationConstants {
 
-  public static final Environment ENVIRONMENT = new Environment();
-  public static final String NVI_TABLE_NAME = readNviTableName();
-  public static final Region REGION = acquireAwsRegion();
   public static final ZoneId DEFAULT_TIME_ZONE = ZoneId.of("Europe/Oslo");
 
   private ApplicationConstants() {}
@@ -22,11 +19,11 @@ public final class ApplicationConstants {
     return Year.now(DEFAULT_TIME_ZONE);
   }
 
-  private static String readNviTableName() {
-    return ENVIRONMENT.readEnv("NVI_TABLE_NAME");
+  public static String getTableName(Environment environment) {
+    return environment.readEnv("NVI_TABLE_NAME");
   }
 
-  private static Region acquireAwsRegion() {
-    return ENVIRONMENT.readEnvOpt(AWS_REGION_ENV_VARIABLE).map(Region::of).orElse(Region.EU_WEST_1);
+  public static Region getRegion(Environment environment) {
+    return environment.readEnvOpt(AWS_REGION_ENV_VARIABLE).map(Region::of).orElse(Region.EU_WEST_1);
   }
 }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/ApplicationConstants.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/ApplicationConstants.java
@@ -8,7 +8,6 @@ import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
 import software.amazon.awssdk.regions.Region;
 
-@JacocoGenerated
 public final class ApplicationConstants {
 
   public static final ZoneId DEFAULT_TIME_ZONE = ZoneId.of("Europe/Oslo");
@@ -23,6 +22,7 @@ public final class ApplicationConstants {
     return environment.readEnv("NVI_TABLE_NAME");
   }
 
+  @JacocoGenerated
   public static Region getRegion(Environment environment) {
     return environment.readEnvOpt(AWS_REGION_ENV_VARIABLE).map(Region::of).orElse(Region.EU_WEST_1);
   }

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/CandidateRepositoryTest.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.common.db;
 
 import static java.util.Collections.emptyList;
 import static java.util.UUID.randomUUID;
+import static no.sikt.nva.nvi.common.EnvironmentFixtures.getGlobalEnvironment;
 import static no.sikt.nva.nvi.common.UpsertRequestFixtures.createUpsertCandidateRequest;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.createCandidateDao;
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.randomApplicableCandidateDao;
@@ -91,7 +92,7 @@ class CandidateRepositoryTest {
   @Test
   void shouldThrowTransactionExceptionWhenFailingOnSendingTransaction() {
     var client = mock(DynamoDbClient.class);
-    var failingRepository = new CandidateRepository(client);
+    var failingRepository = new CandidateRepository(client, getGlobalEnvironment());
 
     when(client.transactWriteItems((TransactWriteItemsRequest) any()))
         .thenThrow(getTransactionCanceledException());

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/ConcurrencyHandlingTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/ConcurrencyHandlingTests.java
@@ -12,6 +12,7 @@ import static no.sikt.nva.nvi.common.model.InstanceType.ACADEMIC_MONOGRAPH;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationId;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDate;
 import static no.sikt.nva.nvi.common.model.UserInstanceFixtures.createCuratorUserInstance;
+import static no.sikt.nva.nvi.common.utils.ApplicationConstants.getTableName;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -42,6 +43,7 @@ import no.sikt.nva.nvi.common.service.CandidateService;
 import no.sikt.nva.nvi.common.service.NviPeriodService;
 import no.sikt.nva.nvi.common.service.model.ApprovalStatus;
 import no.sikt.nva.nvi.common.service.model.Candidate;
+import nva.commons.core.Environment;
 import org.assertj.core.api.ThrowableAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -62,6 +64,7 @@ import software.amazon.awssdk.services.dynamodb.model.UpdateItemRequest;
  * business/domain objects.
  */
 class ConcurrencyHandlingTests {
+  private static final Environment ENVIRONMENT = getGlobalEnvironment();
   private static final URI ORGANIZATION_1 = randomOrganizationId();
   private static final URI ORGANIZATION_2 = randomOrganizationId();
   private static final PublicationDate PUBLICATION_DATE = randomPublicationDate();
@@ -474,8 +477,8 @@ class ConcurrencyHandlingTests {
       var testService =
           new CandidateService(
               getGlobalEnvironment(),
-              new PeriodRepository(mockClient),
-              new CandidateRepository(mockClient));
+              new PeriodRepository(mockClient, ENVIRONMENT),
+              new CandidateRepository(mockClient, ENVIRONMENT));
 
       testService.getCandidateByIdentifier(candidateIdentifier);
 
@@ -489,8 +492,8 @@ class ConcurrencyHandlingTests {
       var testService =
           new CandidateService(
               getGlobalEnvironment(),
-              new PeriodRepository(mockClient),
-              new CandidateRepository(mockClient));
+              new PeriodRepository(mockClient, ENVIRONMENT),
+              new CandidateRepository(mockClient, ENVIRONMENT));
 
       testService.findCandidateAndPeriodsByPublicationId(publicationId);
 
@@ -619,7 +622,7 @@ class ConcurrencyHandlingTests {
   private void updateDirectlyWithLowLevelClient(CandidateDao current, String updateExpression) {
     candidateRepository.defaultClient.updateItem(
         UpdateItemRequest.builder()
-            .tableName(System.getenv("NVI_TABLE_NAME"))
+            .tableName(getTableName(getGlobalEnvironment()))
             .key(
                 Map.of(
                     "PrimaryKeyHashKey",

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/ConcurrencyHandlingTests.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/ConcurrencyHandlingTests.java
@@ -476,7 +476,7 @@ class ConcurrencyHandlingTests {
       var mockClient = spy(scenario.getLocalDynamo());
       var testService =
           new CandidateService(
-              getGlobalEnvironment(),
+              ENVIRONMENT,
               new PeriodRepository(mockClient, ENVIRONMENT),
               new CandidateRepository(mockClient, ENVIRONMENT));
 
@@ -491,7 +491,7 @@ class ConcurrencyHandlingTests {
       var mockClient = spy(scenario.getLocalDynamo());
       var testService =
           new CandidateService(
-              getGlobalEnvironment(),
+              ENVIRONMENT,
               new PeriodRepository(mockClient, ENVIRONMENT),
               new CandidateRepository(mockClient, ENVIRONMENT));
 
@@ -622,7 +622,7 @@ class ConcurrencyHandlingTests {
   private void updateDirectlyWithLowLevelClient(CandidateDao current, String updateExpression) {
     candidateRepository.defaultClient.updateItem(
         UpdateItemRequest.builder()
-            .tableName(getTableName(getGlobalEnvironment()))
+            .tableName(getTableName(ENVIRONMENT))
             .key(
                 Map.of(
                     "PrimaryKeyHashKey",

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/DynamoDbRetryWrapperTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/db/DynamoDbRetryWrapperTest.java
@@ -1,7 +1,6 @@
 package no.sikt.nva.nvi.common.db;
 
 import static no.sikt.nva.nvi.common.db.CandidateDaoFixtures.randomApplicableCandidateDao;
-import static no.sikt.nva.nvi.common.utils.ApplicationConstants.NVI_TABLE_NAME;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -43,7 +42,7 @@ class DynamoDbRetryWrapperTest {
             .dynamoDbClient(dynamodb)
             .initialRetryWaitTimeMs(INITIAL_RETRY_WAIT_TIME_MS)
             .writeRetriesMaxCount(WRITE_RETRIES_MAX_COUNT)
-            .tableName(NVI_TABLE_NAME)
+            .tableName(TABLE_NAME)
             .build();
   }
 
@@ -94,7 +93,7 @@ class DynamoDbRetryWrapperTest {
             .dynamoDbClient(dynamodb)
             .initialRetryWaitTimeMs(veryLongInitialRetryWaitTimeMs)
             .writeRetriesMaxCount(WRITE_RETRIES_MAX_COUNT)
-            .tableName(NVI_TABLE_NAME)
+            .tableName(TABLE_NAME)
             .build();
 
     when(dynamodb.batchWriteItem(any(BatchWriteItemRequest.class)))

--- a/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
+++ b/nvi-commons/src/testFixtures/java/no/sikt/nva/nvi/common/TestScenario.java
@@ -9,7 +9,7 @@ import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomOrganizationId;
 import static no.sikt.nva.nvi.common.model.PublicationDateFixtures.randomPublicationDateDtoInYear;
 import static no.sikt.nva.nvi.common.model.UserInstanceFixtures.createCuratorUserInstance;
-import static no.sikt.nva.nvi.common.utils.ApplicationConstants.NVI_TABLE_NAME;
+import static no.sikt.nva.nvi.common.utils.ApplicationConstants.getTableName;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 
 import java.io.IOException;
@@ -48,12 +48,12 @@ public class TestScenario {
   private final CandidateService candidateService;
 
   public TestScenario() {
-    localDynamo = initializeTestDatabase(NVI_TABLE_NAME);
-    candidateRepository = new CandidateRepository(localDynamo);
-    periodRepository = new PeriodRepository(localDynamo);
-    periodService = new NviPeriodService(getGlobalEnvironment(), periodRepository);
-    candidateService =
-        new CandidateService(getGlobalEnvironment(), periodRepository, candidateRepository);
+    var environment = getGlobalEnvironment();
+    localDynamo = initializeTestDatabase(getTableName(environment));
+    candidateRepository = new CandidateRepository(localDynamo, environment);
+    periodRepository = new PeriodRepository(localDynamo, environment);
+    periodService = new NviPeriodService(environment, periodRepository);
+    candidateService = new CandidateService(environment, periodRepository, candidateRepository);
 
     s3Client = new FakeS3Client();
     s3Driver = new S3Driver(s3Client, EnvironmentFixtures.EXPANDED_RESOURCES_BUCKET.getValue());

--- a/nvi-rest/build.gradle
+++ b/nvi-rest/build.gradle
@@ -12,7 +12,6 @@ dependencies {
     api(nvaLibs.json)
     api(project(':nvi-commons'))
     api(project(':viewing-scope'))
-    implementation(nvaCatalog.aws.sdk2.dynamo)
     implementation(nvaCatalog.slf4j.api)
     implementation(nvaLibs.auth)
     testFixturesApi(testFixtures(project(":nvi-commons")))

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandler.java
@@ -1,7 +1,7 @@
 package no.sikt.nva.nvi.rest.fetch;
 
 import static java.net.HttpURLConnection.HTTP_OK;
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.service.CandidateService.defaultCandidateService;
 import static no.sikt.nva.nvi.common.utils.RequestUtil.isNviAdmin;
 import static no.sikt.nva.nvi.common.utils.RequestUtil.isNviCurator;
 import static nva.commons.core.attempt.Try.attempt;
@@ -10,8 +10,6 @@ import com.amazonaws.services.lambda.runtime.Context;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import no.sikt.nva.nvi.common.db.CandidateRepository;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.model.UserInstance;
 import no.sikt.nva.nvi.common.service.CandidateResponseFactory;
 import no.sikt.nva.nvi.common.service.CandidateService;
@@ -35,19 +33,13 @@ public class FetchNviCandidateByPublicationIdHandler extends ApiGatewayHandler<V
 
   @JacocoGenerated
   public FetchNviCandidateByPublicationIdHandler() {
-    this(
-        new CandidateRepository(defaultDynamoClient()),
-        new PeriodRepository(defaultDynamoClient()),
-        new Environment());
+    this(defaultCandidateService(), new Environment());
   }
 
   public FetchNviCandidateByPublicationIdHandler(
-      CandidateRepository candidateRepository,
-      PeriodRepository periodRepository,
-      Environment environment) {
+      CandidateService candidateService, Environment environment) {
     super(Void.class, environment);
-    this.candidateService =
-        new CandidateService(environment, periodRepository, candidateRepository);
+    this.candidateService = candidateService;
   }
 
   @Override

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodHandler.java
@@ -1,11 +1,10 @@
 package no.sikt.nva.nvi.rest.fetch;
 
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.service.NviPeriodService.defaultNviPeriodService;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.NviPeriodService;
 import no.sikt.nva.nvi.common.service.dto.NviPeriodDto;
 import no.sikt.nva.nvi.common.service.exception.PeriodNotFoundException;
@@ -31,9 +30,7 @@ public class FetchNviPeriodHandler extends ApiGatewayHandler<Void, NviPeriodDto>
 
   @JacocoGenerated
   public FetchNviPeriodHandler() {
-    this(
-        new NviPeriodService(new Environment(), new PeriodRepository(defaultDynamoClient())),
-        new Environment());
+    this(defaultNviPeriodService(), new Environment());
   }
 
   public FetchNviPeriodHandler(NviPeriodService nviPeriodService, Environment environment) {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviPeriodsHandler.java
@@ -1,12 +1,11 @@
 package no.sikt.nva.nvi.rest.fetch;
 
-import static no.sikt.nva.nvi.common.db.DynamoRepository.defaultDynamoClient;
+import static no.sikt.nva.nvi.common.service.NviPeriodService.defaultNviPeriodService;
 import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.HttpURLConnection;
 import java.util.List;
-import no.sikt.nva.nvi.common.db.PeriodRepository;
 import no.sikt.nva.nvi.common.service.NviPeriodService;
 import no.sikt.nva.nvi.common.service.model.NviPeriod;
 import no.sikt.nva.nvi.common.utils.RequestUtil;
@@ -24,9 +23,7 @@ public class FetchNviPeriodsHandler extends ApiGatewayHandler<Void, NviPeriodsRe
 
   @JacocoGenerated
   public FetchNviPeriodsHandler() {
-    this(
-        new NviPeriodService(new Environment(), new PeriodRepository(defaultDynamoClient())),
-        new Environment());
+    this(defaultNviPeriodService(), new Environment());
   }
 
   public FetchNviPeriodsHandler(NviPeriodService nviPeriodService, Environment environment) {

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
@@ -29,8 +29,7 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
 
   @Override
   protected ApiGatewayHandler<Void, CandidateDto> createHandler() {
-    return new FetchNviCandidateByPublicationIdHandler(
-        scenario.getCandidateRepository(), scenario.getPeriodRepository(), environment);
+    return new FetchNviCandidateByPublicationIdHandler(scenario.getCandidateService(), environment);
   }
 
   @Override


### PR DESCRIPTION
Refactors how we read the DynamoDB table name from environment variables, so that it doesn't need to be in sync across all test cases.