### PR TITLE
refactor: Support publication identifier as query parameter

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -787,6 +787,8 @@ paths:
                     },
                   "period": "2023",
                 }
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "500":
           $ref: "#/components/responses/InternalServerError"
   /reports:

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -458,7 +458,7 @@ paths:
       summary: Get candidate by publication identifier
       operationId: getNviCandidateByPublicationIdentifier
       parameters:
-        - $ref: "#/components/parameters/PublicationIdPathParameter"
+        - $ref: "#/components/parameters/PublicationIdentifierPathParameter"
       security: *authenticated
       x-amazon-apigateway-integration:
         uri:
@@ -753,14 +753,14 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /publication/{publicationId}/report-status:
+  /publication/{identifier}/report-status:
     get:
       tags:
         - Report
       description: >
         Get the NVI report status for a publication, indicating whether the publication
         is reported, under review, or not a candidate.
-      summary: Get report status by publication id
+      summary: Get report status for a publication
       operationId: getReportStatusByPublicationId
       parameters:
         - $ref: "#/components/parameters/PublicationIdentifierPathParameter"

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -473,6 +473,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/NviCandidateResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "404":

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -450,7 +450,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /candidate/publication/{publicationId}:
+  /candidate/publication/{identifier}:
     get:
       tags:
         - Candidate
@@ -763,7 +763,7 @@ paths:
       summary: Get report status by publication id
       operationId: getReportStatusByPublicationId
       parameters:
-        - $ref: "#/components/parameters/PublicationIdPathParameter"
+        - $ref: "#/components/parameters/PublicationIdentifierPathParameter"
       x-amazon-apigateway-integration:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchReportStatusByPublicationIdHandler.Arn}:live/invocations
@@ -1056,9 +1056,9 @@ paths:
 
 components:
   parameters:
-    PublicationIdPathParameter:
+    PublicationIdentifierPathParameter:
       in: path
-      name: publicationId
+      name: identifier
       description: >
         The publication identifier.
         A full UTF-8 encoded publication URI is also accepted, but this format is deprecated.

--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -450,7 +450,7 @@ paths:
           $ref: "#/components/responses/NotFound"
         "500":
           $ref: "#/components/responses/InternalServerError"
-  /candidate/publication/{candidatePublicationId}:
+  /candidate/publication/{publicationId}:
     get:
       tags:
         - Candidate
@@ -458,12 +458,7 @@ paths:
       summary: Get candidate by publication identifier
       operationId: getNviCandidateByPublicationIdentifier
       parameters:
-        - in: path
-          name: candidatePublicationId
-          description: The publication identifier the candidate, this must be URI UTF-8 encoded
-          required: true
-          schema:
-            type: string
+        - $ref: "#/components/parameters/PublicationIdPathParameter"
       security: *authenticated
       x-amazon-apigateway-integration:
         uri:
@@ -768,12 +763,7 @@ paths:
       summary: Get report status by publication id
       operationId: getReportStatusByPublicationId
       parameters:
-        - in: path
-          name: publicationId
-          description: A UTF-8 encoded URI (publicationId)
-          required: true
-          schema:
-            type: string
+        - $ref: "#/components/parameters/PublicationIdPathParameter"
       x-amazon-apigateway-integration:
         uri:
           Fn::Sub: arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${FetchReportStatusByPublicationIdHandler.Arn}:live/invocations
@@ -1065,6 +1055,23 @@ paths:
           $ref: "#/components/responses/InternalServerError"
 
 components:
+  parameters:
+    PublicationIdPathParameter:
+      in: path
+      name: publicationId
+      description: >
+        The publication identifier.
+        A full UTF-8 encoded publication URI is also accepted, but this format is deprecated.
+      required: true
+      schema:
+        type: string
+      examples:
+        publicationIdentifier:
+          summary: Publication identifier (preferred)
+          value: "019facbbf461-5f709279-f824-42bc-a471-61362965632b"
+        publicationUri:
+          summary: URL-encoded publication URI (deprecated)
+          value: "https%3A%2F%2Fapi.dev.nva.aws.unit.no%2Fpublication%2F019facbbf461-5f709279-f824-42bc-a471-61362965632b"
   schemas:
     NviPeriod:
       type: object

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
@@ -11,6 +11,7 @@ import static no.sikt.nva.nvi.common.service.model.Candidate.shouldResetCandidat
 import java.net.URI;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.UUID;
 import no.sikt.nva.nvi.common.db.CandidateRepository;
 import no.sikt.nva.nvi.common.db.Dao;
@@ -164,6 +165,12 @@ public class CandidateService {
     LOGGER.info("Fetching candidate by publication id {}", publicationId);
     var responseContext = findCandidateAndPeriodsByPublicationId(publicationId);
     return responseContext.getCandidate().orElseThrow(CandidateNotFoundException::new);
+  }
+
+  public Optional<Candidate> findCandidateByPublicationId(URI publicationId) {
+    LOGGER.info("Fetching candidate by publication id {}", publicationId);
+    var responseContext = findCandidateAndPeriodsByPublicationId(publicationId);
+    return responseContext.getCandidate();
   }
 
   public CandidateAndPeriods findCandidateAndPeriodsByPublicationId(URI publicationId) {

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/service/CandidateService.java
@@ -162,13 +162,10 @@ public class CandidateService {
   }
 
   public Candidate getCandidateByPublicationId(URI publicationId) {
-    LOGGER.info("Fetching candidate by publication id {}", publicationId);
-    var responseContext = findCandidateAndPeriodsByPublicationId(publicationId);
-    return responseContext.getCandidate().orElseThrow(CandidateNotFoundException::new);
+    return findCandidateByPublicationId(publicationId).orElseThrow(CandidateNotFoundException::new);
   }
 
   public Optional<Candidate> findCandidateByPublicationId(URI publicationId) {
-    LOGGER.info("Fetching candidate by publication id {}", publicationId);
     var responseContext = findCandidateAndPeriodsByPublicationId(publicationId);
     return responseContext.getCandidate();
   }

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/EnvironmentUriFactory.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/EnvironmentUriFactory.java
@@ -2,6 +2,7 @@ package no.sikt.nva.nvi.common.utils;
 
 import java.net.URI;
 import java.util.UUID;
+import no.unit.nva.identifiers.SortableIdentifier;
 import nva.commons.core.Environment;
 import nva.commons.core.paths.UriWrapper;
 
@@ -11,6 +12,7 @@ public final class EnvironmentUriFactory {
   private static final String CUSTOM_DOMAIN_BASE_PATH = "CUSTOM_DOMAIN_BASE_PATH";
   private static final String CANDIDATE_PATH = "candidate";
   private static final String CONTEXT_PATH = "context";
+  private static final String PUBLICATION_PATH = "publication";
 
   private EnvironmentUriFactory() {}
 
@@ -18,6 +20,14 @@ public final class EnvironmentUriFactory {
     return baseUrl(environment)
         .addChild(CANDIDATE_PATH)
         .addChild(candidateIdentifier.toString())
+        .getUri();
+  }
+
+  public static URI publicationId(
+      Environment environment, SortableIdentifier publicationIdentifier) {
+    return UriWrapper.fromHost(environment.readEnv(API_HOST))
+        .addChild(PUBLICATION_PATH)
+        .addChild(publicationIdentifier.toString())
         .getUri();
   }
 

--- a/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/RequestUtil.java
+++ b/nvi-commons/src/main/java/no/sikt/nva/nvi/common/utils/RequestUtil.java
@@ -1,17 +1,51 @@
 package no.sikt.nva.nvi.common.utils;
 
 import static nva.commons.apigateway.RestRequestHandler.COMMA;
+import static nva.commons.core.attempt.Try.attempt;
 
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.List;
 import no.sikt.nva.nvi.common.service.model.Username;
+import no.unit.nva.identifiers.SortableIdentifier;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
+import nva.commons.core.Environment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class RequestUtil {
 
+  private static final Logger LOGGER = LoggerFactory.getLogger(RequestUtil.class);
+
   private RequestUtil() {}
+
+  /**
+   * Resolves a publication ID from a path parameter that contains either a publication identifier
+   * or a full, URL-encoded publication URI. The URI format is deprecated and only supported until
+   * all consumers send the identifier. Throws IllegalArgumentException when the parameter is
+   * neither an absolute URI nor a valid SortableIdentifier.
+   */
+  public static URI getPublicationId(
+      RequestInfo requestInfo, String pathParameterName, Environment environment) {
+    var decodedParameter =
+        URLDecoder.decode(
+            requestInfo.getPathParameters().get(pathParameterName), StandardCharsets.UTF_8);
+    if (isAbsoluteUri(decodedParameter)) {
+      LOGGER.warn("Publication ID parameter is in deprecated URI format: {}", decodedParameter);
+      return URI.create(decodedParameter);
+    } else {
+      var publicationIdentifier = new SortableIdentifier(decodedParameter);
+      return EnvironmentUriFactory.publicationId(environment, publicationIdentifier);
+    }
+  }
+
+  private static boolean isAbsoluteUri(String value) {
+    return attempt(() -> URI.create(value).isAbsolute()).orElse(_ -> false);
+  }
 
   public static Username getUsername(RequestInfo requestInfo) throws UnauthorizedException {
     return Username.fromString(requestInfo.getUserName());

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/RequestUtilTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/RequestUtilTest.java
@@ -1,8 +1,10 @@
 package no.sikt.nva.nvi.common.utils;
 
+import static no.sikt.nva.nvi.common.EnvironmentFixtures.API_HOST;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomString;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.params.provider.Arguments.argumentSet;
@@ -10,19 +12,28 @@ import static org.junit.jupiter.params.provider.Arguments.argumentSet;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.InputStream;
 import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import java.util.stream.Stream;
+import no.sikt.nva.nvi.common.EnvironmentFixtures;
 import no.sikt.nva.nvi.common.service.model.Username;
+import no.unit.nva.identifiers.SortableIdentifier;
 import no.unit.nva.testutils.HandlerRequestBuilder;
 import nva.commons.apigateway.AccessRight;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiIoException;
 import nva.commons.apigateway.exceptions.UnauthorizedException;
+import nva.commons.logutils.LogRecorder;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class RequestUtilTest {
+
+  private static final String PATH_PARAM_PUBLICATION_ID = "publicationId";
 
   @Test
   void shouldGetUsername() throws UnauthorizedException, JsonProcessingException, ApiIoException {
@@ -53,6 +64,54 @@ class RequestUtilTest {
     assertThrows(
         UnauthorizedException.class,
         () -> RequestUtil.hasAccessRight(requestInfo, AccessRight.MANAGE_NVI));
+  }
+
+  @Test
+  void shouldConstructPublicationIdWhenPathParameterIsPublicationIdentifier()
+      throws JsonProcessingException, ApiIoException {
+    var publicationIdentifier = SortableIdentifier.next().toString();
+    var requestInfo = createRequestWithPublicationIdPathParameter(publicationIdentifier);
+    var actualPublicationId =
+        RequestUtil.getPublicationId(
+            requestInfo, PATH_PARAM_PUBLICATION_ID, EnvironmentFixtures.getGlobalEnvironment());
+    var expectedPublicationId =
+        URI.create(
+            "https://%s/publication/%s".formatted(API_HOST.getValue(), publicationIdentifier));
+    assertEquals(expectedPublicationId, actualPublicationId);
+  }
+
+  @Test
+  void shouldAcceptEncodedPublicationUriAsPathParameterAndLogWarning()
+      throws JsonProcessingException, ApiIoException {
+    var logRecorder = LogRecorder.forClass(RequestUtil.class);
+    var publicationId = randomUri();
+    var encodedPublicationId = URLEncoder.encode(publicationId.toString(), StandardCharsets.UTF_8);
+    var requestInfo = createRequestWithPublicationIdPathParameter(encodedPublicationId);
+    var actualPublicationId =
+        RequestUtil.getPublicationId(
+            requestInfo, PATH_PARAM_PUBLICATION_ID, EnvironmentFixtures.getGlobalEnvironment());
+    assertEquals(publicationId, actualPublicationId);
+    assertThat(logRecorder.asString()).contains("deprecated", publicationId.toString());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"not-a-valid-identifier", "not a parseable uri"})
+  void shouldThrowIllegalArgumentExceptionWhenPathParameterIsNeitherIdentifierNorUri(
+      String pathParameterValue) throws JsonProcessingException, ApiIoException {
+    var requestInfo = createRequestWithPublicationIdPathParameter(pathParameterValue);
+    var environment = EnvironmentFixtures.getGlobalEnvironment();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> RequestUtil.getPublicationId(requestInfo, PATH_PARAM_PUBLICATION_ID, environment));
+  }
+
+  private static RequestInfo createRequestWithPublicationIdPathParameter(String pathParameterValue)
+      throws JsonProcessingException, ApiIoException {
+    var request =
+        new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
+            .withPathParameters(Map.of(PATH_PARAM_PUBLICATION_ID, pathParameterValue))
+            .build();
+    return RequestInfo.fromRequest(request);
   }
 
   private static InputStream createRequest(

--- a/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/RequestUtilTest.java
+++ b/nvi-commons/src/test/java/no/sikt/nva/nvi/common/utils/RequestUtilTest.java
@@ -95,7 +95,14 @@ class RequestUtilTest {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = {"not-a-valid-identifier", "not a parseable uri"})
+  @ValueSource(
+      strings = {
+        "not-a-valid-identifier",
+        "not a parseable uri",
+        "gopher://",
+        "file://",
+        "/relative/foo.html"
+      })
   void shouldThrowIllegalArgumentExceptionWhenPathParameterIsNeitherIdentifierNorUri(
       String pathParameterValue) throws JsonProcessingException, ApiIoException {
     var requestInfo = createRequestWithPublicationIdPathParameter(pathParameterValue);

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandler.java
@@ -8,8 +8,6 @@ import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import no.sikt.nva.nvi.common.model.UserInstance;
 import no.sikt.nva.nvi.common.service.CandidateResponseFactory;
 import no.sikt.nva.nvi.common.service.CandidateService;
@@ -17,6 +15,7 @@ import no.sikt.nva.nvi.common.service.dto.CandidateDto;
 import no.sikt.nva.nvi.common.service.exception.CandidateNotFoundException;
 import no.sikt.nva.nvi.common.service.model.Candidate;
 import no.sikt.nva.nvi.common.utils.ExceptionMapper;
+import no.sikt.nva.nvi.common.utils.RequestUtil;
 import no.sikt.nva.nvi.rest.ViewingScopeHandler;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
@@ -28,7 +27,7 @@ import nva.commons.core.JacocoGenerated;
 public class FetchNviCandidateByPublicationIdHandler extends ApiGatewayHandler<Void, CandidateDto>
     implements ViewingScopeHandler {
 
-  public static final String CANDIDATE_PUBLICATION_ID = "candidatePublicationId";
+  public static final String PATH_PARAM_PUBLICATION_ID = "publicationId";
   private final CandidateService candidateService;
 
   @JacocoGenerated
@@ -65,9 +64,7 @@ public class FetchNviCandidateByPublicationIdHandler extends ApiGatewayHandler<V
   }
 
   private URI getPublicationId(RequestInfo requestInfo) {
-    return URI.create(
-        URLDecoder.decode(
-            requestInfo.getPathParameters().get(CANDIDATE_PUBLICATION_ID), StandardCharsets.UTF_8));
+    return RequestUtil.getPublicationId(requestInfo, PATH_PARAM_PUBLICATION_ID, environment);
   }
 
   private Candidate checkIfApplicable(Candidate candidate) {

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandler.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandler.java
@@ -5,17 +5,14 @@ import static nva.commons.core.attempt.Try.attempt;
 
 import com.amazonaws.services.lambda.runtime.Context;
 import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import no.sikt.nva.nvi.common.service.CandidateService;
-import no.sikt.nva.nvi.common.service.exception.CandidateNotFoundException;
 import no.sikt.nva.nvi.common.utils.ExceptionMapper;
+import no.sikt.nva.nvi.common.utils.RequestUtil;
 import nva.commons.apigateway.ApiGatewayHandler;
 import nva.commons.apigateway.RequestInfo;
 import nva.commons.apigateway.exceptions.ApiGatewayException;
 import nva.commons.core.Environment;
 import nva.commons.core.JacocoGenerated;
-import nva.commons.core.attempt.Failure;
 
 public class FetchReportStatusByPublicationIdHandler
     extends ApiGatewayHandler<Void, ReportStatusDto> {
@@ -41,10 +38,7 @@ public class FetchReportStatusByPublicationIdHandler
   @Override
   protected ReportStatusDto processInput(Void unused, RequestInfo requestInfo, Context context)
       throws ApiGatewayException {
-    var publicationId = getPublicationId(requestInfo);
-    return attempt(() -> candidateService.getCandidateByPublicationId(publicationId))
-        .map(ReportStatusDto::fromCandidate)
-        .orElse(failure -> handleNotFoundOrFailure(failure, publicationId));
+    return attempt(() -> getCandidateStatus(requestInfo)).orElseThrow(ExceptionMapper::map);
   }
 
   @Override
@@ -52,22 +46,15 @@ public class FetchReportStatusByPublicationIdHandler
     return HTTP_OK;
   }
 
-  private static ReportStatusDto handleNotFoundOrFailure(
-      Failure<ReportStatusDto> failure, URI publicationId) throws ApiGatewayException {
-    if (failure.getException() instanceof CandidateNotFoundException) {
-      return ReportStatusDto.builder()
-          .withPublicationId(publicationId)
-          .withStatus(StatusDto.NOT_CANDIDATE)
-          .build();
-    } else {
-      throw ExceptionMapper.map(failure);
-    }
+  private ReportStatusDto getCandidateStatus(RequestInfo requestInfo) {
+    var publicationId = getPublicationId(requestInfo);
+    var candidate = candidateService.findCandidateByPublicationId(publicationId);
+    return candidate
+        .map(ReportStatusDto::fromCandidate)
+        .orElseGet(() -> ReportStatusDto.forNonCandidate(publicationId));
   }
 
   private URI getPublicationId(RequestInfo requestInfo) {
-    return URI.create(
-        URLDecoder.decode(
-            requestInfo.getPathParameters().get(PATH_PARAM_PUBLICATION_ID),
-            StandardCharsets.UTF_8));
+    return RequestUtil.getPublicationId(requestInfo, PATH_PARAM_PUBLICATION_ID, environment);
   }
 }

--- a/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/ReportStatusDto.java
+++ b/nvi-rest/src/main/java/no/sikt/nva/nvi/rest/fetch/ReportStatusDto.java
@@ -18,6 +18,10 @@ public record ReportStatusDto(
         publishingYear);
   }
 
+  public static ReportStatusDto forNonCandidate(URI publicationId) {
+    return builder().withPublicationId(publicationId).withStatus(StatusDto.NOT_CANDIDATE).build();
+  }
+
   public static Builder builder() {
     return new Builder();
   }

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchNviCandidateByPublicationIdHandlerTest.java
@@ -1,7 +1,8 @@
 package no.sikt.nva.nvi.rest.fetch;
 
 import static no.sikt.nva.nvi.common.dto.AllowedOperationFixtures.CURATOR_CAN_FINALIZE_APPROVAL;
-import static no.sikt.nva.nvi.rest.fetch.FetchNviCandidateByPublicationIdHandler.CANDIDATE_PUBLICATION_ID;
+import static no.sikt.nva.nvi.rest.fetch.FetchNviCandidateByPublicationIdHandler.PATH_PARAM_PUBLICATION_ID;
+import static no.sikt.nva.nvi.test.TestUtils.generatePublicationId;
 import static no.sikt.nva.nvi.test.TestUtils.randomYear;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.net.HttpURLConnection;
+import java.util.UUID;
 import no.sikt.nva.nvi.common.FakeEnvironment;
 import no.sikt.nva.nvi.common.db.ReportStatus;
 import no.sikt.nva.nvi.common.service.dto.ApprovalStatusDto;
@@ -39,7 +41,7 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
 
   @BeforeEach
   void setUp() {
-    resourcePathParameter = CANDIDATE_PUBLICATION_ID;
+    resourcePathParameter = PATH_PARAM_PUBLICATION_ID;
   }
 
   @Test
@@ -105,6 +107,22 @@ class FetchNviCandidateByPublicationIdHandlerTest extends BaseCandidateRestHandl
     assertThat(responseDto)
         .extracting(CandidateDto::id, CandidateDto::publicationId)
         .containsExactly(expectedCandidateUri(candidate), candidate.getPublicationId());
+  }
+
+  @Test
+  void shouldReturnValidCandidateWhenRequestUsesPublicationIdentifier() throws IOException {
+    var publicationIdentifier = UUID.randomUUID();
+    var publicationId = generatePublicationId(publicationIdentifier);
+    var upsertRequest =
+        upsertRequestWithOneVerifiedCreator().withPublicationId(publicationId).build();
+    var candidate = scenario.upsertCandidate(upsertRequest);
+    var request = createRequestWithCuratorAccess(publicationIdentifier.toString());
+
+    var responseDto = handleRequest(request);
+
+    assertThat(responseDto)
+        .extracting(CandidateDto::id, CandidateDto::publicationId)
+        .containsExactly(expectedCandidateUri(candidate), publicationId);
   }
 
   @Test

--- a/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
+++ b/nvi-rest/src/test/java/no/sikt/nva/nvi/rest/fetch/FetchReportStatusByPublicationIdHandlerTest.java
@@ -6,6 +6,7 @@ import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupClosedPeri
 import static no.sikt.nva.nvi.common.db.PeriodRepositoryFixtures.setupOpenPeriod;
 import static no.sikt.nva.nvi.common.model.OrganizationFixtures.randomTopLevelOrganization;
 import static no.sikt.nva.nvi.test.TestUtils.CURRENT_YEAR;
+import static no.sikt.nva.nvi.test.TestUtils.generatePublicationId;
 import static no.unit.nva.commons.json.JsonUtils.dtoObjectMapper;
 import static no.unit.nva.testutils.RandomDataGenerator.randomUri;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -15,8 +16,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.HttpURLConnection;
 import java.net.URI;
 import java.util.Map;
+import java.util.UUID;
 import no.sikt.nva.nvi.common.TestScenario;
 import no.sikt.nva.nvi.common.UpsertRequestBuilder;
 import no.sikt.nva.nvi.common.dto.PublicationDateDto;
@@ -33,6 +36,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.zalando.problem.Problem;
 
 class FetchReportStatusByPublicationIdHandlerTest {
   private static final String PATH_PARAM_PUBLICATION_ID = "publicationId";
@@ -86,6 +90,31 @@ class FetchReportStatusByPublicationIdHandlerTest {
     var expected =
         ReportStatusDto.builder()
             .withPublicationId(pendingCandidate.getPublicationId())
+            .withStatus(StatusDto.PENDING_REVIEW)
+            .withYear(String.valueOf(CURRENT_YEAR))
+            .build();
+    assertEquals(expected, actualResponseBody);
+  }
+
+  @Test
+  void shouldReturnReportStatusWhenRequestUsesPublicationIdentifier() throws IOException {
+    var publicationIdentifier = UUID.randomUUID();
+    var publicationId = generatePublicationId(publicationIdentifier);
+    var upsertRequest =
+        UpsertRequestBuilder.randomUpsertRequestBuilder()
+            .withPublicationId(publicationId)
+            .withPublicationDate(new PublicationDateDto(String.valueOf(CURRENT_YEAR), null, null))
+            .build();
+    scenario.upsertCandidate(upsertRequest);
+
+    handler.handleRequest(createRequest(publicationIdentifier.toString()), output, context);
+
+    var actualResponseBody =
+        GatewayResponse.fromOutputStream(output, ReportStatusDto.class)
+            .getBodyObject(ReportStatusDto.class);
+    var expected =
+        ReportStatusDto.builder()
+            .withPublicationId(publicationId)
             .withStatus(StatusDto.PENDING_REVIEW)
             .withYear(String.valueOf(CURRENT_YEAR))
             .build();
@@ -210,6 +239,14 @@ class FetchReportStatusByPublicationIdHandlerTest {
   }
 
   @Test
+  void shouldReturnBadRequestWhenPathParameterIsNeitherIdentifierNorUri() throws IOException {
+    handler.handleRequest(createRequest("not-a-valid-identifier"), output, context);
+
+    var response = GatewayResponse.fromOutputStream(output, Problem.class);
+    assertEquals(HttpURLConnection.HTTP_BAD_REQUEST, response.getStatusCode());
+  }
+
+  @Test
   void shouldReturnNotCandidateWhenPublicationIsNotFound() throws IOException {
     var notFoundPublicationId = randomUri();
 
@@ -227,9 +264,14 @@ class FetchReportStatusByPublicationIdHandlerTest {
   }
 
   private static InputStream createRequest(URI publicationId) throws JsonProcessingException {
+    return createRequest(publicationId.toString());
+  }
+
+  private static InputStream createRequest(String pathParameterValue)
+      throws JsonProcessingException {
     return new HandlerRequestBuilder<InputStream>(dtoObjectMapper)
         .withHeaders(Map.of(HttpHeaders.ACCEPT, ContentType.APPLICATION_JSON.getMimeType()))
-        .withPathParameters(Map.of(PATH_PARAM_PUBLICATION_ID, publicationId.toString()))
+        .withPathParameters(Map.of(PATH_PARAM_PUBLICATION_ID, pathParameterValue))
         .build();
   }
 

--- a/template.yaml
+++ b/template.yaml
@@ -1129,7 +1129,7 @@ Resources:
         GetEvent:
           Type: Api
           Properties:
-            Path: /candidate/publication/{candidatePublicationId+}
+            Path: /candidate/publication/{publicationId+}
             Method: get
             RestApiId: !Ref ScientificIndexApi
 

--- a/template.yaml
+++ b/template.yaml
@@ -1129,7 +1129,7 @@ Resources:
         GetEvent:
           Type: Api
           Properties:
-            Path: /candidate/publication/{publicationId+}
+            Path: /candidate/publication/{identifier+}
             Method: get
             RestApiId: !Ref ScientificIndexApi
 


### PR DESCRIPTION
Ticket: https://sikt.atlassian.net/browse/NP-51503

The two endpoints  `/publication/{publicationId}/report-status` and `/candidate/publication/{candidatePublicationId}` currently accept only the full URI form of publication ID, e.g. `scientific-index/candidate/publication/https%3A%2F%2Fapi.sandbox.nva.aws.unit.no%2Fpublication%2F018d16a8f8da-fe63c816-2646-49bb-afbc-64fa8d9fed51`.

This expands both endpoints to also accept the bare identifier, e.g. `scientific-index/candidate/publication/018d16a8f8da-fe63c816-2646-49bb-afbc-64fa8d9fed51`. The frontend relies on the old behavior, so we still need to support the URI format until frontend switches to using the bare identifier.